### PR TITLE
Move DEVICE_DISPATCH macro out of public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(LINK_DIRECTORIES
   )
 set(INCLUDE_DIRECTORIES
   ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/src
   )
 set(SOURCES
   src/decoding.cc

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -63,8 +63,7 @@ COPY python python
 WORKDIR /root/ctranslate2-dev/python
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py
 RUN pip --no-cache-dir install setuptools wheel
-RUN CTRANSLATE2_ROOT=/root/ctranslate2 \
-    python setup.py bdist_wheel
+RUN CTRANSLATE2_ROOT=/root/ctranslate2 python setup.py bdist_wheel
 
 WORKDIR /root
 RUN cp /opt/intel/lib/intel64/libiomp5.so /root/ctranslate2/lib64 && \

--- a/docker/Dockerfile.centos7-gpu
+++ b/docker/Dockerfile.centos7-gpu
@@ -89,8 +89,7 @@ COPY python python
 WORKDIR /root/ctranslate2-dev/python
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py
 RUN pip --no-cache-dir install setuptools wheel
-RUN CFLAGS="-DWITH_CUDA=ON" CTRANSLATE2_ROOT=/root/ctranslate2 \
-    python setup.py bdist_wheel
+RUN CTRANSLATE2_ROOT=/root/ctranslate2 python setup.py bdist_wheel
 
 WORKDIR /root
 RUN cp /opt/intel/lib/intel64/libiomp5.so /root/ctranslate2/lib64 && \

--- a/docker/Dockerfile.ubuntu16
+++ b/docker/Dockerfile.ubuntu16
@@ -69,8 +69,7 @@ COPY python python
 
 WORKDIR /root/ctranslate2-dev/python
 RUN pip --no-cache-dir install setuptools wheel
-RUN CTRANSLATE2_ROOT=/root/ctranslate2 \
-    python setup.py bdist_wheel
+RUN CTRANSLATE2_ROOT=/root/ctranslate2 python setup.py bdist_wheel
 
 WORKDIR /root
 RUN cp /opt/intel/lib/intel64/libiomp5.so /root/ctranslate2/lib && \

--- a/include/ctranslate2/devices.h
+++ b/include/ctranslate2/devices.h
@@ -32,34 +32,4 @@ namespace ctranslate2 {
     int _prev_index;
   };
 
-#define UNSUPPORTED_DEVICE_CASE(DEVICE)                       \
-  case DEVICE: {                                              \
-    throw std::runtime_error("unsupported device " #DEVICE);  \
-    break;                                                    \
-  }
-
-#define DEVICE_CASE(DEVICE, STMT)               \
-  case DEVICE: {                                \
-    const Device D = DEVICE;                    \
-    STMT;                                       \
-    break;                                      \
-  }
-
-#define SINGLE_ARG(...) __VA_ARGS__
-
-// TODO: Move this macro out of public headers.
-#ifndef WITH_CUDA
-#  define DEVICE_DISPATCH(DEVICE, STMTS)                \
-  switch (DEVICE) {                                     \
-    UNSUPPORTED_DEVICE_CASE(Device::CUDA)               \
-    DEVICE_CASE(Device::CPU, SINGLE_ARG(STMTS))         \
-  }
-#else
-#  define DEVICE_DISPATCH(DEVICE, STMTS)                \
-  switch (DEVICE) {                                     \
-    DEVICE_CASE(Device::CUDA, SINGLE_ARG(STMTS))        \
-    DEVICE_CASE(Device::CPU, SINGLE_ARG(STMTS))         \
-  }
-#endif
-
 }

--- a/src/decoding.cc
+++ b/src/decoding.cc
@@ -4,6 +4,7 @@
 #include <limits>
 
 #include "ctranslate2/ops/ops.h"
+#include "device_dispatch.h"
 
 namespace ctranslate2 {
 

--- a/src/device_dispatch.h
+++ b/src/device_dispatch.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <stdexcept>
+
+#include "ctranslate2/devices.h"
+
+#define UNSUPPORTED_DEVICE_CASE(DEVICE)                       \
+  case DEVICE: {                                              \
+    throw std::runtime_error("unsupported device " #DEVICE);  \
+    break;                                                    \
+  }
+
+#define DEVICE_CASE(DEVICE, STMT)               \
+  case DEVICE: {                                \
+    const Device D = DEVICE;                    \
+    STMT;                                       \
+    break;                                      \
+  }
+
+#define SINGLE_ARG(...) __VA_ARGS__
+#ifndef WITH_CUDA
+#  define DEVICE_DISPATCH(DEVICE, STMTS)                \
+  switch (DEVICE) {                                     \
+    UNSUPPORTED_DEVICE_CASE(Device::CUDA)               \
+    DEVICE_CASE(Device::CPU, SINGLE_ARG(STMTS))         \
+  }
+#else
+#  define DEVICE_DISPATCH(DEVICE, STMTS)                \
+  switch (DEVICE) {                                     \
+    DEVICE_CASE(Device::CUDA, SINGLE_ARG(STMTS))        \
+    DEVICE_CASE(Device::CPU, SINGLE_ARG(STMTS))         \
+  }
+#endif

--- a/src/devices.cc
+++ b/src/devices.cc
@@ -5,6 +5,7 @@
 #endif
 
 #include "ctranslate2/primitives/primitives.h"
+#include "device_dispatch.h"
 
 namespace ctranslate2 {
 

--- a/src/layers/common.cc
+++ b/src/layers/common.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/layers/common.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace layers {
 

--- a/src/models/transformer.cc
+++ b/src/models/transformer.cc
@@ -2,6 +2,8 @@
 
 #include <cmath>
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace models {
 

--- a/src/ops/add.cc
+++ b/src/ops/add.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/add.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/ops/concat.cc
+++ b/src/ops/concat.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/concat.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/ops/dequantize.cc
+++ b/src/ops/dequantize.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/dequantize.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/ops/gather.cc
+++ b/src/ops/gather.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/gather.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/ops/gemm.cc
+++ b/src/ops/gemm.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/gemm.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/ops/layer_norm.cc
+++ b/src/ops/layer_norm.cc
@@ -2,6 +2,8 @@
 
 #include <cmath>
 
+#include "device_dispatch.h"
+
 #define EPSILON 0.000001f
 
 namespace ctranslate2 {

--- a/src/ops/matmul.cc
+++ b/src/ops/matmul.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/matmul.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/ops/mul.cc
+++ b/src/ops/mul.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/mul.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/ops/quantize.cc
+++ b/src/ops/quantize.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/quantize.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/ops/relu.cc
+++ b/src/ops/relu.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/relu.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/ops/softmax.cc
+++ b/src/ops/softmax.cc
@@ -2,6 +2,8 @@
 
 #include <cmath>
 
+#include "device_dispatch.h"
+
 #define EPSILON 0.000001f
 
 namespace ctranslate2 {

--- a/src/ops/split.cc
+++ b/src/ops/split.cc
@@ -1,7 +1,8 @@
 #include "ctranslate2/ops/split.h"
 
 #include <numeric>
-#include <stdexcept>
+
+#include "device_dispatch.h"
 
 namespace ctranslate2 {
   namespace ops {

--- a/src/ops/sub.cc
+++ b/src/ops/sub.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/sub.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/ops/tile.cc
+++ b/src/ops/tile.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/tile.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/ops/topk.cc
+++ b/src/ops/topk.cc
@@ -4,6 +4,8 @@
 #include <numeric>
 #include <vector>
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/ops/transpose.cc
+++ b/src/ops/transpose.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/transpose.h"
 
+#include "device_dispatch.h"
+
 namespace ctranslate2 {
   namespace ops {
 

--- a/src/storage_view.cc
+++ b/src/storage_view.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/storage_view.h"
 
+#include "device_dispatch.h"
+
 #define PRINT_MAX_VALUES 6
 
 namespace ctranslate2 {


### PR DESCRIPTION
The macro depended on the WITH_CUDA compilation flag but client libraries should not know about this flag.