### PR TITLE
enable building on Windows/MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 3.7)
+
+# Set policy for setting the MSVC runtime library for static MSVC builds
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
 project(ctranslate2)
 
 option(WITH_MKL "Compile with Intel MKL backend" ON)
@@ -7,7 +13,17 @@ option(WITH_CUDA "Compile with CUDA backend" OFF)
 option(LIB_ONLY "Do not compile clients" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
-set(INTEL_ROOT /opt/intel CACHE FILEPATH "Path to Intel root directory")
+if(DEFINED ENV{INTELROOT})
+  set(INTEL_ROOT_DEFAULT $ENV{INTELROOT})
+elseif(DEFINED ENV{MKLROOT})
+  set(INTEL_ROOT_DEFAULT $ENV{MKLROOT}/..)
+elseif(WIN32)
+  set(ProgramFilesx86 "ProgramFiles(x86)")
+  set(INTEL_ROOT_DEFAULT $ENV{${ProgramFilesx86}}/IntelSWTools/compilers_and_libraries/windows)
+else()
+  set(INTEL_ROOT_DEFAULT "/opt/intel")
+endif()
+set(INTEL_ROOT ${INTEL_ROOT_DEFAULT} CACHE FILEPATH "Path to Intel root directory")
 set(OPENMP_RUNTIME "INTEL" CACHE STRING "OpenMP runtime (INTEL, COMP)")
 
 # Set Release build type by default to get sane performance.
@@ -17,7 +33,20 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 # Set CXX flags.
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -ffast-math")
+
+if(MSVC)
+  if(BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  else()
+    if(CMAKE_VERSION VERSION_LESS "3.15.0")
+      message(FATAL_ERROR "Use CMake 3.15 or later when setting BUILD_SHARED_LIBS to OFF")
+    endif()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -ffast-math")
+endif()
 
 find_package(Threads)
 find_package(OpenMP)
@@ -74,7 +103,7 @@ set(LIBRARIES
 
 if(OPENMP_RUNTIME STREQUAL "INTEL")
   # Find Intel libraries.
-  find_library(IOMP5_LIBRARY iomp5 ${INTEL_ROOT}/lib/intel64)
+  find_library(IOMP5_LIBRARY iomp5 libiomp5md HINTS ${INTEL_ROOT}/lib/intel64 ${INTEL_ROOT}/compiler/lib/intel64)
   if(IOMP5_LIBRARY)
     list(APPEND LIBRARIES ${IOMP5_LIBRARY})
     message(STATUS "Using OpenMP: ${IOMP5_LIBRARY}")
@@ -93,10 +122,11 @@ else()
 endif()
 
 if(WITH_MKL)
-  set(MKL_ROOT ${INTEL_ROOT}/mkl)
+  find_path(MKL_ROOT include/mkl.h PATHS $ENV{MKLROOT} ${INTEL_ROOT}/mkl
+                                   DOC "Path to MKL root directory")
 
   # Find MKL includes.
-  find_path(MKL_INCLUDE_DIR mkl.h ${MKL_ROOT}/include/)
+  find_path(MKL_INCLUDE_DIR NAMES mkl.h HINTS ${MKL_ROOT}/include/)
   if(MKL_INCLUDE_DIR)
     message(STATUS "Found MKL include directory: ${MKL_INCLUDE_DIR}")
   else()
@@ -104,7 +134,7 @@ if(WITH_MKL)
   endif()
 
   # Find MKL libraries.
-  find_library(MKL_CORE_LIBRARY mkl_core ${MKL_ROOT}/lib/intel64)
+  find_library(MKL_CORE_LIBRARY NAMES mkl_core PATHS ${MKL_ROOT}/lib/intel64)
   if(MKL_CORE_LIBRARY)
     get_filename_component(MKL_LIBRARY_DIR ${MKL_CORE_LIBRARY} DIRECTORY)
     message(STATUS "Found MKL library directory: ${MKL_LIBRARY_DIR}")
@@ -112,19 +142,39 @@ if(WITH_MKL)
     message(FATAL_ERROR "MKL library directory not found")
   endif()
 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
   add_definitions(-DWITH_MKL -DMKL_ILP64)
-  set(MKL_LIBRARIES
-    ${MKL_LIBRARY_DIR}/libmkl_core.a
-    ${MKL_LIBRARY_DIR}/libmkl_intel_ilp64.a
-    )
+  if(WIN32)
+    set(MKL_LIBRARIES
+      ${MKL_LIBRARY_DIR}/mkl_core.lib
+      ${MKL_LIBRARY_DIR}/mkl_intel_ilp64.lib
+      )
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
+    set(MKL_LIBRARIES
+      ${MKL_LIBRARY_DIR}/libmkl_core.a
+      ${MKL_LIBRARY_DIR}/libmkl_intel_ilp64.a
+      )
+  endif()
+  
   if(OPENMP_RUNTIME STREQUAL "INTEL")
-    list(APPEND MKL_LIBRARIES ${MKL_LIBRARY_DIR}/libmkl_intel_thread.a)
+    if(WIN32)
+      list(APPEND MKL_LIBRARIES ${MKL_LIBRARY_DIR}/mkl_intel_thread.lib)
+    else()
+      list(APPEND MKL_LIBRARIES ${MKL_LIBRARY_DIR}/libmkl_intel_thread.a)
+    endif()
   elseif(OPENMP_RUNTIME STREQUAL "COMP")
-    list(APPEND MKL_LIBRARIES ${MKL_LIBRARY_DIR}/libmkl_gnu_thread.a)
+    if(WIN32)
+      message(FATAL_ERROR "Building with MKL requires Intel OpenMP")
+    else()
+      list(APPEND MKL_LIBRARIES ${MKL_LIBRARY_DIR}/libmkl_gnu_thread.a)
+    endif()
   endif()
   list(APPEND INCLUDE_DIRECTORIES ${MKL_INCLUDE_DIR})
-  list(APPEND LIBRARIES -Wl,--start-group ${MKL_LIBRARIES} -Wl,--end-group)
+  if(WIN32)
+    list(APPEND LIBRARIES ${MKL_LIBRARIES})
+  else()
+    list(APPEND LIBRARIES -Wl,--start-group ${MKL_LIBRARIES} -Wl,--end-group)
+  endif()
 
   if(WITH_MKLDNN)
     find_path(MKLDNN_INCLUDE_DIR mkldnn.hpp)
@@ -152,7 +202,15 @@ endif()
 if (WITH_CUDA)
   find_package(CUDA 10.0 REQUIRED)
   add_definitions(-DWITH_CUDA)
-  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11")
+  if(MSVC)
+    if(BUILD_SHARED_LIBS)
+      set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler=/MD$<$<CONFIG:Debug>:d>")
+    else()
+      set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler=/MT$<$<CONFIG:Debug>:d>")
+    endif()
+  else()
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11")
+  endif()
   if(OpenMP_CXX_FOUND)
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler=${OpenMP_CXX_FLAGS}")
   endif()
@@ -164,10 +222,9 @@ if (WITH_CUDA)
   cuda_select_nvcc_arch_flags(ARCH_FLAGS ${CUDA_ARCH_LIST})
   list(APPEND CUDA_NVCC_FLAGS ${ARCH_FLAGS})
 
-  message(STATUS "NVCC compilation flags: ${CUDA_NVCC_FLAGS}")
-
   find_library(CUDNN_LIBRARY cudnn
     ${CUDA_TOOLKIT_ROOT_DIR}/lib64
+    ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64
     /usr/lib/x86_64-linux-gnu
     )
   if(CUDNN_LIBRARY)
@@ -185,9 +242,13 @@ if (WITH_CUDA)
     message(STATUS "Found TensorRT include directory: ${TENSORRT_INCLUDE_DIR}")
   endif()
 
-  # TensorRT 6 header generates a lot of deprecating warnings. Ignore them.
-  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -isystem ${TENSORRT_INCLUDE_DIR}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -isystem ${TENSORRT_INCLUDE_DIR}")
+  if(NOT MSVC)
+    # TensorRT 6 header generates a lot of deprecating warnings. Ignore them.
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -isystem ${TENSORRT_INCLUDE_DIR}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -isystem ${TENSORRT_INCLUDE_DIR}")
+  endif()
+  
+  message(STATUS "NVCC compilation flags: ${CUDA_NVCC_FLAGS}")
 
   find_path(CUB_INCLUDE_DIR NAMES cub/cub.cuh)
   if(NOT CUB_INCLUDE_DIR)
@@ -205,8 +266,13 @@ if (WITH_CUDA)
     message(STATUS "Found Thrust include directory: ${THRUST_INCLUDE_DIR}")
   endif()
 
+  include_directories(
+    ${TENSORRT_INCLUDE_DIR}
+  )
+
   cuda_include_directories(
     ${CUB_INCLUDE_DIR}
+    ${THRUST_INCLUDE_DIR}
     )
   cuda_add_library(${PROJECT_NAME}
     ${SOURCES}

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost COMPONENTS program_options)
 
+include_directories(
+  ${Boost_INCLUDE_DIRS}
+  )
+
 add_executable(translate
   translate.cc
   )

--- a/include/ctranslate2/ops/tile.h
+++ b/include/ctranslate2/ops/tile.h
@@ -31,7 +31,8 @@ namespace ctranslate2 {
         output.resize(output_shape);
 
         size_t copied = 0;
-        for (ssize_t i = last_repeated_dim; i >= 0; --i) {
+        size_t i = last_repeated_dim;
+        do {
           const size_t axis = i;
           const size_t repeat_dim = repeats.at<int32_t>(axis);
           size_t iter_dim = 1;
@@ -55,7 +56,7 @@ namespace ctranslate2 {
             }
             copied *= repeat_dim;
           }
-        }
+        } while (i-- > 0);
       }
     };
 

--- a/include/ctranslate2/primitives/primitives.h
+++ b/include/ctranslate2/primitives/primitives.h
@@ -197,6 +197,12 @@ namespace ctranslate2 {
                            Out* c);
   };
 
+#ifdef WITH_MKL
+  template<>
+  template<>
+  void primitives<Device::CPU>::mul(float a, float* y, size_t size);
+#endif
+
   template <Device D1, Device D2>
   struct cross_device_primitives {
     template <typename T>

--- a/include/ctranslate2/primitives/primitives.h
+++ b/include/ctranslate2/primitives/primitives.h
@@ -197,12 +197,6 @@ namespace ctranslate2 {
                            Out* c);
   };
 
-#ifdef WITH_MKL
-  template<>
-  template<>
-  void primitives<Device::CPU>::mul(float a, float* y, size_t size);
-#endif
-
   template <Device D1, Device D2>
   struct cross_device_primitives {
     template <typename T>

--- a/include/ctranslate2/storage_view.h
+++ b/include/ctranslate2/storage_view.h
@@ -3,6 +3,11 @@
 #include <ostream>
 #include <vector>
 
+#ifdef _MSC_VER
+#  include <BaseTsd.h>
+   typedef SSIZE_T ssize_t;
+#endif
+
 #include "types.h"
 #include "primitives/primitives.h"
 

--- a/src/ops/layer_norm_cpu.cc
+++ b/src/ops/layer_norm_cpu.cc
@@ -16,7 +16,7 @@ namespace ctranslate2 {
       size_t batch_size = input.size() / depth;
       StorageView tmp({batch_size, depth}, input.dtype(), input.device());
       #pragma omp parallel for
-      for (long long i = 0; i < batch_size; ++i) {
+      for (long long i = 0; i < static_cast<long long>(batch_size); ++i) {
         const auto* x = input.data<T>() + i * depth;
         auto* y = output.data<T>() + i * depth;
         auto* t = tmp.data<T>() + i * depth;

--- a/src/ops/layer_norm_cpu.cc
+++ b/src/ops/layer_norm_cpu.cc
@@ -16,7 +16,7 @@ namespace ctranslate2 {
       size_t batch_size = input.size() / depth;
       StorageView tmp({batch_size, depth}, input.dtype(), input.device());
       #pragma omp parallel for
-      for (size_t i = 0; i < batch_size; ++i) {
+      for (long long i = 0; i < batch_size; ++i) {
         const auto* x = input.data<T>() + i * depth;
         auto* y = output.data<T>() + i * depth;
         auto* t = tmp.data<T>() + i * depth;

--- a/src/ops/softmax_cpu.cc
+++ b/src/ops/softmax_cpu.cc
@@ -14,7 +14,7 @@ namespace ctranslate2 {
       size_t total_depth = input.dim(-1);
       size_t batch_size = input.size() / total_depth;
       #pragma omp parallel for
-      for (long long i = 0; i < batch_size; ++i) {
+      for (long long i = 0; i < static_cast<long long>(batch_size); ++i) {
         const auto* x = input.data<T>() + (i * total_depth);
         auto* y = output.data<T>() + (i * total_depth);
         size_t depth = total_depth;

--- a/src/ops/softmax_cpu.cc
+++ b/src/ops/softmax_cpu.cc
@@ -14,7 +14,7 @@ namespace ctranslate2 {
       size_t total_depth = input.dim(-1);
       size_t batch_size = input.size() / total_depth;
       #pragma omp parallel for
-      for (size_t i = 0; i < batch_size; ++i) {
+      for (long long i = 0; i < batch_size; ++i) {
         const auto* x = input.data<T>() + (i * total_depth);
         auto* y = output.data<T>() + (i * total_depth);
         size_t depth = total_depth;

--- a/src/ops/topk_cpu.cc
+++ b/src/ops/topk_cpu.cc
@@ -15,7 +15,7 @@ namespace ctranslate2 {
       StorageView full_indices({batch_size, depth}, indices.dtype());
 
       #pragma omp parallel for
-      for (size_t i = 0; i < batch_size; ++i) {
+      for (long long i = 0; i < batch_size; ++i) {
         const auto* input = x.data<DataType>() + (i * depth);
         auto* ids = full_indices.data<IndexType>() + (i * depth);
         auto* val = values.data<DataType>() + (i * _k);

--- a/src/ops/topk_cpu.cc
+++ b/src/ops/topk_cpu.cc
@@ -15,7 +15,7 @@ namespace ctranslate2 {
       StorageView full_indices({batch_size, depth}, indices.dtype());
 
       #pragma omp parallel for
-      for (long long i = 0; i < batch_size; ++i) {
+      for (long long i = 0; i < static_cast<long long>(batch_size); ++i) {
         const auto* input = x.data<DataType>() + (i * depth);
         auto* ids = full_indices.data<IndexType>() + (i * depth);
         auto* val = values.data<DataType>() + (i * _k);

--- a/src/primitives/cpu.cc
+++ b/src/primitives/cpu.cc
@@ -269,7 +269,7 @@ namespace ctranslate2 {
                                                  size_t x_size, size_t scale_size) {
     size_t depth = x_size / scale_size;
     #pragma omp parallel for
-    for (size_t i = 0; i < scale_size; ++i) {
+    for (long long i = 0; i < scale_size; ++i) {
       const auto offset = i * depth;
       unquantize(x + offset, y + offset, depth, scale[i]);
     }
@@ -279,7 +279,7 @@ namespace ctranslate2 {
   void primitives<Device::CPU>::quantize_batch(const float* x, float* scales, int8_t* qx,
                                                size_t batch_size, size_t depth) {
     #pragma omp parallel for
-    for (size_t i = 0; i < batch_size; ++i) {
+    for (long long i = 0; i < batch_size; ++i) {
       const float* row = x + i * depth;
       int8_t* qrow = qx + i * depth;
       auto scale = static_cast<float>(std::numeric_limits<int8_t>::max()) / amax(row, depth);
@@ -296,7 +296,7 @@ namespace ctranslate2 {
                                                size_t batch_size,
                                                size_t depth) {
     #pragma omp parallel for
-    for (size_t i = 0; i < batch_size; ++i) {
+    for (long long i = 0; i < batch_size; ++i) {
       for (size_t j = 0; j < depth; ++j) {
         const auto index = j + i * depth;
         y[index] = static_cast<float>(x[index]) / (input_scales[i] * weight_scales[j]);
@@ -386,7 +386,7 @@ namespace ctranslate2 {
   template <typename DataType, typename IndexType>
   void primitives<Device::CPU>::transpose_2d(const DataType* a, const IndexType* dims, DataType* b) {
     #pragma omp parallel for
-    for (size_t i0 = 0; i0 < dims[0]; ++i0) {
+    for (long long i0 = 0; i0 < dims[0]; ++i0) {
       for (size_t i1 = 0; i1 < dims[1]; ++i1) {
         b[i1 * dims[0] + i0] = a[i0 * dims[1] + i1];
       }
@@ -418,7 +418,7 @@ namespace ctranslate2 {
                                b_stride[perm_ind[2]]};
 
     #pragma omp parallel for
-    for (size_t i0 = 0; i0 < dims[0]; ++i0) {
+    for (long long i0 = 0; i0 < dims[0]; ++i0) {
       for (size_t i1 = 0; i1 < dims[1]; ++i1) {
         for (size_t i2 = 0; i2 < dims[2]; ++i2) {
           const size_t b_i = (i0 * perm_b_stride[0] + i1 * perm_b_stride[1] +
@@ -447,7 +447,7 @@ namespace ctranslate2 {
                                b_stride[perm_ind[2]], b_stride[perm_ind[3]]};
 
     #pragma omp parallel for
-    for (size_t i0 = 0; i0 < dims[0]; ++i0) {
+    for (long long i0 = 0; i0 < dims[0]; ++i0) {
       for (size_t i1 = 0; i1 < dims[1]; ++i1) {
         for (size_t i2 = 0; i2 < dims[2]; ++i2) {
           for (size_t i3 = 0; i3 < dims[3]; ++i3) {

--- a/src/primitives/cpu.cc
+++ b/src/primitives/cpu.cc
@@ -200,8 +200,8 @@ namespace ctranslate2 {
 #ifdef WITH_MKL
   template<>
   template<>
-  void primitives<Device::CPU>::mul(float a, float* y, size_t size) {
-    cblas_sscal(size, a, y, 1 /* incx */);
+  void primitives<Device::CPU>::mul(float a, const float* x, float* y, size_t size) {
+    cblas_saxpby(size, a, x, 1 /* incx */, 0 /* b */, y, 1 /* incy */);
   }
 #endif
 
@@ -269,7 +269,7 @@ namespace ctranslate2 {
                                                  size_t x_size, size_t scale_size) {
     size_t depth = x_size / scale_size;
     #pragma omp parallel for
-    for (long long i = 0; i < scale_size; ++i) {
+    for (long long i = 0; i < static_cast<long long>(scale_size); ++i) {
       const auto offset = i * depth;
       unquantize(x + offset, y + offset, depth, scale[i]);
     }
@@ -279,7 +279,7 @@ namespace ctranslate2 {
   void primitives<Device::CPU>::quantize_batch(const float* x, float* scales, int8_t* qx,
                                                size_t batch_size, size_t depth) {
     #pragma omp parallel for
-    for (long long i = 0; i < batch_size; ++i) {
+    for (long long i = 0; i < static_cast<long long>(batch_size); ++i) {
       const float* row = x + i * depth;
       int8_t* qrow = qx + i * depth;
       auto scale = static_cast<float>(std::numeric_limits<int8_t>::max()) / amax(row, depth);
@@ -296,7 +296,7 @@ namespace ctranslate2 {
                                                size_t batch_size,
                                                size_t depth) {
     #pragma omp parallel for
-    for (long long i = 0; i < batch_size; ++i) {
+    for (long long i = 0; i < static_cast<long long>(batch_size); ++i) {
       for (size_t j = 0; j < depth; ++j) {
         const auto index = j + i * depth;
         y[index] = static_cast<float>(x[index]) / (input_scales[i] * weight_scales[j]);
@@ -386,7 +386,7 @@ namespace ctranslate2 {
   template <typename DataType, typename IndexType>
   void primitives<Device::CPU>::transpose_2d(const DataType* a, const IndexType* dims, DataType* b) {
     #pragma omp parallel for
-    for (long long i0 = 0; i0 < dims[0]; ++i0) {
+    for (long long i0 = 0; i0 < static_cast<long long>(dims[0]); ++i0) {
       for (size_t i1 = 0; i1 < dims[1]; ++i1) {
         b[i1 * dims[0] + i0] = a[i0 * dims[1] + i1];
       }
@@ -418,7 +418,7 @@ namespace ctranslate2 {
                                b_stride[perm_ind[2]]};
 
     #pragma omp parallel for
-    for (long long i0 = 0; i0 < dims[0]; ++i0) {
+    for (long long i0 = 0; i0 < static_cast<long long>(dims[0]); ++i0) {
       for (size_t i1 = 0; i1 < dims[1]; ++i1) {
         for (size_t i2 = 0; i2 < dims[2]; ++i2) {
           const size_t b_i = (i0 * perm_b_stride[0] + i1 * perm_b_stride[1] +
@@ -447,7 +447,7 @@ namespace ctranslate2 {
                                b_stride[perm_ind[2]], b_stride[perm_ind[3]]};
 
     #pragma omp parallel for
-    for (long long i0 = 0; i0 < dims[0]; ++i0) {
+    for (long long i0 = 0; i0 < static_cast<long long>(dims[0]); ++i0) {
       for (size_t i1 = 0; i1 < dims[1]; ++i1) {
         for (size_t i2 = 0; i2 < dims[2]; ++i2) {
           for (size_t i3 = 0; i3 < dims[3]; ++i3) {

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/translator.h"
 
+#include <algorithm>
+
 #include "ctranslate2/decoding.h"
 
 namespace ctranslate2 {

--- a/tests/translator_test.cc
+++ b/tests/translator_test.cc
@@ -67,6 +67,12 @@ TEST_P(ModelVariantTest, Transliteration) {
   }
 }
 
+#ifdef WITH_MKLDNN
+DataType i8_test_dtype = DataType::DT_INT8;
+#else
+DataType i8_test_dtype = DataType::DT_INT16;
+#endif
+
 INSTANTIATE_TEST_CASE_P(
   TranslatorTest,
   ModelVariantTest,
@@ -75,11 +81,7 @@ INSTANTIATE_TEST_CASE_P(
     std::make_pair("v1/aren-transliteration-i16", DataType::DT_INT16),
     std::make_pair("v2/aren-transliteration", DataType::DT_FLOAT),
     std::make_pair("v2/aren-transliteration-i16", DataType::DT_INT16),
-#ifdef WITH_MKLDNN
-    std::make_pair("v2/aren-transliteration-i8", DataType::DT_INT8)
-#else
-    std::make_pair("v2/aren-transliteration-i8", DataType::DT_INT16)
-#endif
+    std::make_pair("v2/aren-transliteration-i8", i8_test_dtype)
     ),
   path_to_test_name);
 


### PR DESCRIPTION
This gets a build on Windows with MSVC working.
Changes in the root CMakeLists.txt file to find and set up the MKL and CUDA libraries/paths.
Changes in the cli CMakeLists.txt file to allow non-system Boost.
Use of non-standard `ssize_t` refactored in one case, and a typedef added in the other case. (Perhaps you would be willing that this code also be refactored.)
Inclusion of `<algorithm>` in translator.cc is needed for `std::max`.
The template function delcaration added to primitives.h prevents this error in a MSVC debug build:
```
2>translate.cc
2>ctranslate2.lib(layer_norm_cpu.obj) : error LNK2005: "public: static void __cdecl ctranslate2::primitives<0>::mul<float>(float,float *,unsigned __int64)" (??$mul@M@?$primitives@$0A@@ctranslate2@@SAXMPEAM_K@Z) already defined in ctranslate2.lib(cpu.obj)
2>ctranslate2.lib(softmax_cpu.obj) : error LNK2005: "public: static void __cdecl ctranslate2::primitives<0>::mul<float>(float,float *,unsigned __int64)" (??$mul@M@?$primitives@$0A@@ctranslate2@@SAXMPEAM_K@Z) already defined in ctranslate2.lib(cpu.obj)
```
The change from `size_t` to `long long` in the `omp parallel for` code is for this error:
`error C3016: 'i': index variable in OpenMP 'for' statement must have signed integral type`
Because unfortunately MSVC (even the latest, Visual Studio 2019) support of OpenMP is at version 2.0. Maybe you want to handle this differently (and avoid the sign-compare warnings).

The change to translator_test is for 
`error C2121: '#': invalid character: possibly the result of a macro expansion`
