### PR TITLE
Do not reorder projected memory during beam search

### DIFF
--- a/include/ctranslate2/layers/decoder.h
+++ b/include/ctranslate2/layers/decoder.h
@@ -26,7 +26,15 @@ namespace ctranslate2 {
                               StorageView* logits = nullptr,
                               StorageView* attention = nullptr) = 0;
 
+      // Gathers states based on indices.
+      void gather_state(DecoderState& state, const StorageView& indices) const;
+
     protected:
+      // Returns false if the state does not need to be reordered during beam search.
+      virtual bool should_reorder_state(const std::string& name) const;
+      // Returns the current batch size from the decoder state.
+      virtual size_t batch_size(const DecoderState& state) const;
+
       Device _device;
     };
 

--- a/include/ctranslate2/models/transformer.h
+++ b/include/ctranslate2/models/transformer.h
@@ -113,6 +113,8 @@ namespace ctranslate2 {
                       layers::DecoderState& state,
                       StorageView* logits = nullptr,
                       StorageView* attention = nullptr) override;
+    protected:
+      bool should_reorder_state(const std::string& name) const override;
     private:
       layers::Embeddings _embeddings;
       PositionEncoder _position_encoder;

--- a/include/ctranslate2/ops/gather.h
+++ b/include/ctranslate2/ops/gather.h
@@ -9,6 +9,8 @@ namespace ctranslate2 {
     public:
       Gather(int axis = 0);
       using BinaryOp::operator();
+
+      void operator()(StorageView& data, const StorageView& input) const;
       void operator()(const StorageView& data,
                       const StorageView& input,
                       StorageView& output) const override;

--- a/include/ctranslate2/utils.h
+++ b/include/ctranslate2/utils.h
@@ -10,8 +10,8 @@ namespace ctranslate2 {
 
   void set_num_threads(size_t num_threads);
 
-  bool endswith(const std::string& str, const std::string& suffix);
-  bool startswith(const std::string& str, const std::string& prefix);
+  bool ends_with(const std::string& str, const std::string& suffix);
+  bool starts_with(const std::string& str, const std::string& prefix);
 
 #define THROW_EXCEPTION(EXCEPTION, MESSAGE)                             \
   throw EXCEPTION(std::string(__FILE__) + ":" + std::to_string(__LINE__) + ": " + MESSAGE)

--- a/include/ctranslate2/utils.h
+++ b/include/ctranslate2/utils.h
@@ -10,6 +10,9 @@ namespace ctranslate2 {
 
   void set_num_threads(size_t num_threads);
 
+  bool endswith(const std::string& str, const std::string& suffix);
+  bool startswith(const std::string& str, const std::string& prefix);
+
 #define THROW_EXCEPTION(EXCEPTION, MESSAGE)                             \
   throw EXCEPTION(std::string(__FILE__) + ":" + std::to_string(__LINE__) + ": " + MESSAGE)
 #define THROW_RUNTIME_ERROR(MESSAGE) THROW_EXCEPTION(std::runtime_error, MESSAGE)

--- a/src/layers/decoder.cc
+++ b/src/layers/decoder.cc
@@ -1,10 +1,35 @@
 #include "ctranslate2/layers/decoder.h"
 
+#include "ctranslate2/ops/ops.h"
+
 namespace ctranslate2 {
   namespace layers {
 
     Decoder::Decoder(Device device)
       : _device(device) {
+    }
+
+    void Decoder::gather_state(DecoderState& state, const StorageView& indices) const {
+      static const ops::Gather gather_op;
+
+      // When the batch size is unchanged, assume that we are reordering beams.
+      bool beam_reordering = indices.size() == batch_size(state);
+
+      for (auto& pair : state) {
+        const auto& name = pair.first;
+        auto& value = pair.second;
+        if (beam_reordering && !should_reorder_state(name))
+          continue;
+        gather_op(value, indices);
+      }
+    }
+
+    size_t Decoder::batch_size(const DecoderState& state) const {
+      return state.begin()->second.dim(0);
+    }
+
+    bool Decoder::should_reorder_state(const std::string&) const {
+      return true;
     }
 
   }

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -235,7 +235,7 @@ namespace ctranslate2 {
         auto& variable = variable_pair.second;
 
         // Only process "weight" variables.
-        if (endswith(name, "weight")) {
+        if (ends_with(name, "weight")) {
           convert_data_if_need(support_int8,
                                support_int16,
                                name,

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -34,11 +34,6 @@ namespace ctranslate2 {
       return str;
     }
 
-    static bool endswith(const std::string& str, const std::string& suffix) {
-      return (str.size() >= suffix.size() &&
-              str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0);
-    }
-
 
     Model::Model(const std::string& path, size_t spec_revision)
       : _spec_revision(spec_revision) {

--- a/src/models/transformer.cc
+++ b/src/models/transformer.cc
@@ -261,6 +261,11 @@ namespace ctranslate2 {
       return state;
     }
 
+    bool TransformerDecoder::should_reorder_state(const std::string& name) const {
+      // No need to reorder projected memory keys and values as they are the same for each beam.
+      return !startswith(name, "memory");
+    }
+
     void TransformerDecoder::operator()(size_t step,
                                         const StorageView& ids,
                                         const StorageView& memory,

--- a/src/models/transformer.cc
+++ b/src/models/transformer.cc
@@ -263,7 +263,7 @@ namespace ctranslate2 {
 
     bool TransformerDecoder::should_reorder_state(const std::string& name) const {
       // No need to reorder projected memory keys and values as they are the same for each beam.
-      return !startswith(name, "memory");
+      return !starts_with(name, "memory");
     }
 
     void TransformerDecoder::operator()(size_t step,

--- a/src/ops/gather.cc
+++ b/src/ops/gather.cc
@@ -10,6 +10,11 @@ namespace ctranslate2 {
         throw std::invalid_argument("unsupported gather axis " + std::to_string(axis));
     }
 
+    void Gather::operator()(StorageView& data, const StorageView& input) const {
+      StorageView clone(std::move(data));
+      operator()(clone, input, data);
+    }
+
     void Gather::operator()(const StorageView& data,
                             const StorageView& input,
                             StorageView& output) const {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -60,12 +60,12 @@ namespace ctranslate2 {
 #endif
   }
 
-  bool endswith(const std::string& str, const std::string& suffix) {
+  bool ends_with(const std::string& str, const std::string& suffix) {
     return (str.size() >= suffix.size() &&
             str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0);
   }
 
-  bool startswith(const std::string& str, const std::string& prefix) {
+  bool starts_with(const std::string& str, const std::string& prefix) {
     return (str.size() >= prefix.size() &&
             str.compare(0, prefix.size(), prefix) == 0);
   }

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -60,4 +60,14 @@ namespace ctranslate2 {
 #endif
   }
 
+  bool endswith(const std::string& str, const std::string& suffix) {
+    return (str.size() >= suffix.size() &&
+            str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0);
+  }
+
+  bool startswith(const std::string& str, const std::string& prefix) {
+    return (str.size() >= prefix.size() &&
+            str.compare(0, prefix.size(), prefix) == 0);
+  }
+
 }

--- a/tests/translator_test.cc
+++ b/tests/translator_test.cc
@@ -19,10 +19,6 @@ static std::string beam_to_test_name(::testing::TestParamInfo<size_t> param_info
     return "BeamSearch";
 }
 
-static bool endswith(const std::string& str, const std::string& part) {
-  return str.size() >= part.size() && str.substr(str.size() - part.size()) == part;
-}
-
 static void check_weights_dtype(const std::unordered_map<std::string, StorageView>& variables,
                                 DataType expected_dtype) {
   for (const auto& variable : variables) {

--- a/tests/translator_test.cc
+++ b/tests/translator_test.cc
@@ -24,7 +24,7 @@ static void check_weights_dtype(const std::unordered_map<std::string, StorageVie
   for (const auto& variable : variables) {
     const auto& name = variable.first;
     const auto& value = variable.second;
-    if (endswith(name, "weight")) {
+    if (ends_with(name, "weight")) {
       EXPECT_EQ(value.dtype(), expected_dtype) << "Expected type " << dtype_name(expected_dtype)
                                                << " for weight " << name << ", got "
                                                << dtype_name(value.dtype()) << " instead";


### PR DESCRIPTION
All beams within a batch are the same so we can avoid this operation.