### PR TITLE
Enable in-place Gather for compatible inputs on CPU

### DIFF
--- a/src/ops/gather.cc
+++ b/src/ops/gather.cc
@@ -1,9 +1,41 @@
 #include "ctranslate2/ops/gather.h"
 
+#include <algorithm>
+
 #include "../device_dispatch.h"
 
 namespace ctranslate2 {
   namespace ops {
+
+    static Shape compute_output_shape(const StorageView& data, const StorageView& input) {
+      Shape output_shape(input.shape());
+      for (size_t i = 1; i < data.rank(); ++i)
+        output_shape.push_back(data.dim(i));
+      return output_shape;
+    }
+
+    static bool support_gather_batch_inplace(const StorageView& data, const StorageView& input) {
+      // We can gather in place if the output is not larger than data and indices are in
+      // increasing order (i.e. we never need to gather from a previous index).
+      return (input.device() == Device::CPU
+              && input.size() <= data.dim(0)
+              && std::is_sorted(input.data<int32_t>(), input.data<int32_t>() + input.size()));
+    }
+
+    template <typename T>
+    void gather_batch_inplace(StorageView& data, const StorageView& input) {
+      const auto* indices = input.data<int32_t>();
+      auto* dst = data.data<T>();
+      const auto copy_dim = data.stride(0);
+      for (size_t i = 0; i < input.size(); ++i) {
+        if (static_cast<size_t>(indices[i]) != i) {
+          const auto* src = data.data<T>() + indices[i] * copy_dim;
+          primitives<Device::CPU>::copy(src, dst, copy_dim);
+        }
+        dst += copy_dim;
+      }
+    }
+
 
     Gather::Gather(int axis) {
       if (axis != 0)
@@ -11,18 +43,21 @@ namespace ctranslate2 {
     }
 
     void Gather::operator()(StorageView& data, const StorageView& input) const {
-      StorageView clone(std::move(data));
-      operator()(clone, input, data);
+      if (support_gather_batch_inplace(data, input)) {
+        PROFILE_FUN;
+        TYPE_DISPATCH(data.dtype(), (gather_batch_inplace<T>(data, input)));
+        data.resize(compute_output_shape(data, input));
+      } else {
+        StorageView clone(std::move(data));
+        operator()(clone, input, data);
+      }
     }
 
     void Gather::operator()(const StorageView& data,
                             const StorageView& input,
                             StorageView& output) const {
       PROFILE_FUN;
-      Shape output_shape(input.shape());
-      for (size_t i = 1; i < data.rank(); ++i)
-        output_shape.push_back(data.dim(i));
-      output.resize(output_shape);
+      output.resize(compute_output_shape(data, input));
       DEVICE_DISPATCH(data.device(),
                       TYPE_DISPATCH(data.dtype(), (compute<D, T>(data, input, output))));
     }

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -52,6 +52,46 @@ TEST(OpDeviceTest, SplitInvalidNumOutputs) {
   ASSERT_RAISES(ops::Split(0)(x, a, b, c), std::invalid_argument);
 }
 
+TEST(OpDeviceTest, GatherInPlaceStrictlyIncreasing) {
+  StorageView data({4, 2}, std::vector<float>{1, 1, 2, 2, 3, 3, 4, 4});
+  void* data_ptr = data.buffer();
+  StorageView ids({2}, std::vector<int32_t>{1, 2});
+  StorageView expected({2, 2}, std::vector<float>{2, 2, 3, 3});
+  ops::Gather(0)(data, ids);
+  expect_storage_eq(data, expected);
+  EXPECT_EQ(data.buffer(), data_ptr);
+}
+
+TEST(OpDeviceTest, GatherInPlaceIncreasing) {
+  StorageView data({4, 2}, std::vector<float>{1, 1, 2, 2, 3, 3, 4, 4});
+  void* data_ptr = data.buffer();
+  StorageView ids({3}, std::vector<int32_t>{1, 1, 3});
+  StorageView expected({3, 2}, std::vector<float>{2, 2, 2, 2, 4, 4});
+  ops::Gather(0)(data, ids);
+  expect_storage_eq(data, expected);
+  EXPECT_EQ(data.buffer(), data_ptr);
+}
+
+TEST(OpDeviceTest, GatherInPlaceDecreasing) {
+  StorageView data({4, 2}, std::vector<float>{1, 1, 2, 2, 3, 3, 4, 4});
+  void* data_ptr = data.buffer();
+  StorageView ids({2}, std::vector<int32_t>{1, 0});
+  StorageView expected({2, 2}, std::vector<float>{2, 2, 1, 1});
+  ops::Gather(0)(data, ids);
+  expect_storage_eq(data, expected);
+  EXPECT_NE(data.buffer(), data_ptr);
+}
+
+TEST(OpDeviceTest, GatherInPlaceLarger) {
+  StorageView data({4, 2}, std::vector<float>{1, 1, 2, 2, 3, 3, 4, 4});
+  void* data_ptr = data.buffer();
+  StorageView ids({5}, std::vector<int32_t>{0, 1, 2, 3, 3});
+  StorageView expected({5, 2}, std::vector<float>{1, 1, 2, 2, 3, 3, 4, 4, 4, 4});
+  ops::Gather(0)(data, ids);
+  expect_storage_eq(data, expected);
+  EXPECT_NE(data.buffer(), data_ptr);
+}
+
 TEST(OpTest, GemmInt16) {
   StorageView a({64, 64}, static_cast<int16_t>(1));
   StorageView b(a);

--- a/tests/translator_test.cc
+++ b/tests/translator_test.cc
@@ -147,6 +147,21 @@ TEST_P(SearchVariantTest, TranslateWithPrefix) {
   EXPECT_EQ(result.output(), expected);
 }
 
+TEST_P(SearchVariantTest, TranslateBatch) {
+  Translator translator = default_translator();
+  TranslationOptions options;
+  options.beam_size = GetParam();
+  std::vector<std::vector<std::string>> inputs = {
+    {"آ", "ز", "ا"},
+    {"آ", "ت", "ز", "م", "و", "ن"}};
+  std::vector<std::vector<std::string>> expected = {
+    {"a", "z", "z", "a"},
+    {"a", "t", "z", "m", "o", "n"}};
+  auto result = translator.translate_batch(inputs, options);
+  EXPECT_EQ(result[0].output(), expected[0]);
+  EXPECT_EQ(result[1].output(), expected[1]);
+}
+
 INSTANTIATE_TEST_CASE_P(
   TranslatorTest,
   SearchVariantTest,


### PR DESCRIPTION
In parallel, we sort sentences within a batch from longest to shortest so that finished translations are more likely to occur at the end of the batch. This makes updating the decoder state more efficient as it is faster to remove elements at the end of arrays.