### PR TITLE
Do not share generated encoding between PositionEncoder instances

### DIFF
--- a/include/ctranslate2/models/transformer.h
+++ b/include/ctranslate2/models/transformer.h
@@ -37,11 +37,13 @@ namespace ctranslate2 {
     class PositionEncoder
     {
     public:
+      PositionEncoder();
       PositionEncoder(const TransformerModel& model, const std::string& scope);
       void operator()(StorageView& input, size_t index = 0);
     private:
-      const StorageView& get_position_encoding(size_t max_time, size_t depth, Device device) const;
-      const StorageView* _encoding;
+      const StorageView& get_position_encoding(size_t max_time, size_t depth, Device device);
+      const StorageView* _model_encoding;
+      std::unique_ptr<StorageView> _generated_encoding;
     };
 
     class TransformerFeedForward

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ if (GTEST_FOUND)
   add_executable(ctranslate2_test
     storage_view_test.cc
     ops_test.cc
+    transformer_test.cc
     translator_test.cc
     test.cc)
   target_include_directories(ctranslate2_test PUBLIC

--- a/tests/transformer_test.cc
+++ b/tests/transformer_test.cc
@@ -1,0 +1,29 @@
+#include <ctranslate2/models/transformer.h>
+
+#include "test_utils.h"
+
+extern std::string g_data_dir;
+
+TEST(TransformerTest, PositionEncoderNoSharedState) {
+  // Test case for issue: http://forum.opennmt.net/t/ctranslate2-c-api-returns-strange-results-when-initializing-2-models/3208
+  models::PositionEncoder position_encoder_1;
+  models::PositionEncoder position_encoder_2;
+
+  {
+    StorageView input(
+      {1, 1, 4}, std::vector<float>{0.1, -2.3, 0.5, 1.2});
+    StorageView expected(
+      {1, 1, 4}, std::vector<float>{0.941471, -2.2999, 1.0403, 2.2});
+    position_encoder_1(input);
+    expect_storage_eq(input, expected, 1e-5);
+  }
+
+  {
+    StorageView input(
+      {1, 1, 6}, std::vector<float>{-0.2, -1.3, 0.1, -0.6, 2.0, 1.1});
+    StorageView expected(
+      {1, 1, 6}, std::vector<float>{0.641471, -1.29, 0.1001, -0.0596977, 2.99995, 2.1});
+    position_encoder_2(input);
+    expect_storage_eq(input, expected, 1e-5);
+  }
+}


### PR DESCRIPTION
This caused issues when loading multiple Transformer models with different dimensions. See for example:

http://forum.opennmt.net/t/ctranslate2-c-api-returns-strange-results-when-initializing-2-models/3208