### PR TITLE
Include a Python source distribution in the final Docker images

### DIFF
--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -47,10 +47,11 @@ COPY CMakeLists.txt .
 
 ARG CXX_FLAGS
 ENV CXX_FLAGS=${CXX_FLAGS}
+ENV CTRANSLATE2_ROOT=/root/ctranslate2
 
 RUN mkdir build && \
     cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=/root/ctranslate2 \
+    cmake -DCMAKE_INSTALL_PREFIX=${CTRANSLATE2_ROOT} \
           -DCMAKE_PREFIX_PATH=${MKLDNN_ROOT} -DWITH_MKLDNN=ON \
           -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" .. && \
     VERBOSE=1 make -j4 && \
@@ -59,14 +60,18 @@ RUN mkdir build && \
 COPY python python
 
 WORKDIR /root/ctranslate2-dev/python
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py
-RUN pip --no-cache-dir install pybind11==2.4.3
-RUN CTRANSLATE2_ROOT=/root/ctranslate2 python setup.py bdist_wheel
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py && \
+    rm get-pip.py && \
+    pip --no-cache-dir install pybind11==2.4.3 && \
+    python setup.py bdist_wheel && \
+    python setup.py sdist && \
+    mv dist/* /root/ctranslate2 && \
+    rmdir dist
 
 WORKDIR /root
 RUN cp /opt/intel/lib/intel64/libiomp5.so /root/ctranslate2/lib64 && \
-    cp -P /root/mkl-dnn/lib64/libmkldnn.so* /root/ctranslate2/lib64 && \
-    cp /root/ctranslate2-dev/python/dist/*whl /root/ctranslate2
+    cp -P /root/mkl-dnn/lib64/libmkldnn.so* /root/ctranslate2/lib64
 
 FROM centos:7
 
@@ -76,6 +81,7 @@ RUN pip --no-cache-dir install /opt/ctranslate2/*.whl
 
 WORKDIR /opt
 
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/ctranslate2/lib64
+ENV CTRANSLATE2_ROOT=/opt/ctranslate2
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CTRANSLATE2_ROOT/lib64
 
 ENTRYPOINT ["/opt/ctranslate2/bin/translate"]

--- a/docker/Dockerfile.centos7-gpu
+++ b/docker/Dockerfile.centos7-gpu
@@ -65,10 +65,11 @@ ARG CUDA_NVCC_FLAGS
 ENV CUDA_NVCC_FLAGS=${CUDA_NVCC_FLAGS:-"-Xfatbin -compress-all"}
 ARG CUDA_ARCH_LIST
 ENV CUDA_ARCH_LIST=${CUDA_ARCH_LIST:-"Common"}
+ENV CTRANSLATE2_ROOT=/root/ctranslate2
 
 RUN mkdir build && \
     cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=/root/ctranslate2 \
+    cmake -DCMAKE_INSTALL_PREFIX=${CTRANSLATE2_ROOT} \
           -DCMAKE_PREFIX_PATH="${CUB_ROOT};${MKLDNN_ROOT}" \
           -DWITH_CUDA=ON -DWITH_MKLDNN=ON \
           -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" \
@@ -79,16 +80,20 @@ RUN mkdir build && \
 COPY python python
 
 WORKDIR /root/ctranslate2-dev/python
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py
-RUN pip --no-cache-dir install pybind11==2.4.3
-RUN CTRANSLATE2_ROOT=/root/ctranslate2 python setup.py bdist_wheel
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py && \
+    rm get-pip.py && \
+    pip --no-cache-dir install pybind11==2.4.3 && \
+    python setup.py bdist_wheel && \
+    python setup.py sdist && \
+    mv dist/* /root/ctranslate2 && \
+    rmdir dist
 
 WORKDIR /root
 RUN cp /opt/intel/lib/intel64/libiomp5.so /root/ctranslate2/lib64 && \
     cp -P /root/mkl-dnn/lib64/libmkldnn.so* /root/ctranslate2/lib64 && \
     cp -P /usr/local/cuda/lib64/libcudnn.so* /root/ctranslate2/lib64 && \
-    cp -P /lib64/libnvinfer.so* /root/ctranslate2/lib64 && \
-    cp /root/ctranslate2-dev/python/dist/*whl /root/ctranslate2
+    cp -P /lib64/libnvinfer.so* /root/ctranslate2/lib64
 
 FROM nvidia/cuda:10.0-base-centos7
 
@@ -102,6 +107,7 @@ RUN pip --no-cache-dir install /opt/ctranslate2/*.whl
 
 WORKDIR /opt
 
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/ctranslate2/lib64
+ENV CTRANSLATE2_ROOT=/opt/ctranslate2
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CTRANSLATE2_ROOT/lib64
 
 ENTRYPOINT ["/opt/ctranslate2/bin/translate"]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -76,12 +76,14 @@ RUN wget -nv https://bootstrap.pypa.io/get-pip.py && \
       ${PYTHON} setup.py bdist_wheel && \
       rm -r build \
     ; done && \
-    rm get-pip.py
+    rm get-pip.py && \
+    python setup.py sdist && \
+    mv dist/* /root/ctranslate2 && \
+    rmdir dist
 
 WORKDIR /root
 RUN cp /opt/intel/lib/intel64/libiomp5.so /root/ctranslate2/lib && \
-    cp -P /root/mkl-dnn/lib/libmkldnn.so* /root/ctranslate2/lib && \
-    cp /root/ctranslate2-dev/python/dist/*whl /root/ctranslate2
+    cp -P /root/mkl-dnn/lib/libmkldnn.so* /root/ctranslate2/lib
 
 FROM ubuntu:${UBUNTU_VERSION}
 
@@ -102,6 +104,7 @@ RUN wget -nv https://bootstrap.pypa.io/get-pip.py && \
 
 WORKDIR /opt
 
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/ctranslate2/lib
+ENV CTRANSLATE2_ROOT=/opt/ctranslate2
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CTRANSLATE2_ROOT/lib
 
 ENTRYPOINT ["/opt/ctranslate2/bin/translate"]

--- a/docker/Dockerfile.ubuntu-gpu
+++ b/docker/Dockerfile.ubuntu-gpu
@@ -94,14 +94,16 @@ RUN wget -nv https://bootstrap.pypa.io/get-pip.py && \
       ${PYTHON} setup.py bdist_wheel && \
       rm -r build \
     ; done && \
-    rm get-pip.py
+    rm get-pip.py && \
+    python setup.py sdist && \
+    mv dist/* /root/ctranslate2 && \
+    rmdir dist
 
 WORKDIR /root
 RUN cp /opt/intel/lib/intel64/libiomp5.so /root/ctranslate2/lib && \
     cp -P /root/mkl-dnn/lib/libmkldnn.so* /root/ctranslate2/lib && \
     cp -P /usr/lib/x86_64-linux-gnu/libcudnn.so* /root/ctranslate2/lib && \
-    cp -P /usr/lib/x86_64-linux-gnu/libnvinfer.so* /root/ctranslate2/lib && \
-    cp /root/ctranslate2-dev/python/dist/*whl /root/ctranslate2
+    cp -P /usr/lib/x86_64-linux-gnu/libnvinfer.so* /root/ctranslate2/lib
 
 FROM nvidia/cuda:10.0-base-ubuntu${UBUNTU_VERSION}
 
@@ -122,6 +124,7 @@ RUN wget -nv https://bootstrap.pypa.io/get-pip.py && \
 
 WORKDIR /opt
 
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/ctranslate2/lib
+ENV CTRANSLATE2_ROOT=/opt/ctranslate2
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CTRANSLATE2_ROOT/lib
 
 ENTRYPOINT ["/opt/ctranslate2/bin/translate"]

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,6 +30,26 @@ ctranslate2_module = Extension(
 setup(
     name="ctranslate2",
     version="1.2.1",
+    license="MIT",
+    description="Custom C++ inference engine for OpenNMT models",
+    author="OpenNMT",
+    author_email="guillaume.klein@systrangroup.com",
+    url="https://github.com/OpenNMT/CTranslate2",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence"
+    ],
+    project_urls={
+        "Forum": "http://forum.opennmt.net/",
+        "Gitter": "https://gitter.im/OpenNMT/CTranslate2",
+        "Source": "https://github.com/OpenNMT/CTranslate2/"
+    },
+    keywords="opennmt nmt neural machine translation cuda mkl inference quantization",
     packages=find_packages(exclude=["bin"]),
     ext_modules=[ctranslate2_module],
     install_requires=[


### PR DESCRIPTION
This allows downstream Docker images to compile Python wheels for other Python versions.