### PR TITLE
Add <algorithm> include in layer_norm_cpu.cc

### DIFF
--- a/src/ops/layer_norm_cpu.cc
+++ b/src/ops/layer_norm_cpu.cc
@@ -1,5 +1,6 @@
 #include "ctranslate2/ops/layer_norm.h"
 
+#include <algorithm>
 #include <cmath>
 
 #define EPSILON 1e-5


### PR DESCRIPTION
The <algorithm> header is required when building with MSVC because `min` and `max` are defined as macros in Windows headers.