### PR TITLE
Load model on CPU by default in Model::load

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ echo "▁H ello ▁world !" | nvidia-docker run -i --rm -v $PWD:/data \
 
 ```python
 >>> import ctranslate2
->>> translator = ctranslate2.Translator("ende_ctranslate2/", device="cpu")
+>>> translator = ctranslate2.Translator("ende_ctranslate2/")
 >>> translator.translate_batch([["▁H", "ello", "▁world", "!"]])
 ```
 
@@ -182,7 +182,7 @@ echo "▁H ello ▁world !" | nvidia-docker run -i --rm -v $PWD:/data \
 #include <ctranslate2/translator.h>
 
 int main() {
-  ctranslate2::Translator translator("ende_ctranslate2/", ctranslate2::Device::CPU);
+  ctranslate2::Translator translator("ende_ctranslate2/");
   ctranslate2::TranslationResult result = translator.translate({"▁H", "ello", "▁world", "!"});
 
   for (const auto& token : result.output())

--- a/include/ctranslate2/models/model.h
+++ b/include/ctranslate2/models/model.h
@@ -20,11 +20,11 @@ namespace ctranslate2 {
     class Model {
     public:
       static std::shared_ptr<const Model> load(const std::string& path,
-                                               const std::string& device,
+                                               const std::string& device = "cpu",
                                                int device_index = 0,
                                                const std::string& compute_type = "default");
       static std::shared_ptr<const Model> load(const std::string& path,
-                                               Device device,
+                                               Device device = Device::CPU,
                                                int device_index = 0,
                                                ComputeType compute_type = ComputeType::DEFAULT);
 

--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -25,7 +25,7 @@ namespace ctranslate2 {
   // be safely executed in parallel.
   class Translator {
   public:
-    Translator(const std::string& model_dir, Device device, int device_index = 0);
+    Translator(const std::string& model_dir, Device device = Device::CPU, int device_index = 0);
     Translator(const std::shared_ptr<const models::Model>& model);
     Translator(const Translator& other);
 


### PR DESCRIPTION
This aligns the behavior with the Python API.