### PR TITLE
Remove translation client from CentOS 7 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ docker pull opennmt/ctranslate2:latest-ubuntu18-gpu
 
 The images include:
 
-* a translation client to directly translate files (default entrypoint)
+* a translation client to directly translate files (only in Ubuntu images)
 * Python 2 and 3 packages (with GPU support)
 * `libctranslate2.so` library development files
 

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -1,9 +1,8 @@
 FROM centos:7 as builder
 
-RUN yum install -y centos-release-scl-rh && \
-    yum install -y \
-        devtoolset-3-gcc \
-        devtoolset-3-gcc-c++ \
+RUN yum install -y \
+        gcc \
+        gcc-c++ \
         make \
         python-devel \
         wget && \
@@ -38,8 +37,8 @@ ENV CTRANSLATE2_ROOT=/root/ctranslate2
 
 RUN mkdir build && \
     cd build && \
-    source scl_source enable devtoolset-3 && \
     cmake -DCMAKE_INSTALL_PREFIX=${CTRANSLATE2_ROOT} \
+          -DLIB_ONLY=ON \
           -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" .. && \
     VERBOSE=1 make -j4 && \
     make install
@@ -52,7 +51,6 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     rm get-pip.py && \
     pip --no-cache-dir install pybind11==2.4.3 && \
     pip freeze | grep pybind11 > /root/ctranslate2/install_requirements.txt && \
-    source scl_source enable devtoolset-3 && \
     python setup.py bdist_wheel && \
     python setup.py sdist && \
     mv dist/* /root/ctranslate2 && \
@@ -71,5 +69,3 @@ WORKDIR /opt
 
 ENV CTRANSLATE2_ROOT=/opt/ctranslate2
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CTRANSLATE2_ROOT/lib64
-
-ENTRYPOINT ["/opt/ctranslate2/bin/translate"]

--- a/docker/Dockerfile.centos7-gpu
+++ b/docker/Dockerfile.centos7-gpu
@@ -1,9 +1,8 @@
 FROM nvidia/cuda:10.0-cudnn7-devel-centos7 as builder
 
-RUN yum install -y centos-release-scl-rh && \
-    yum install -y \
-        devtoolset-3-gcc \
-        devtoolset-3-gcc-c++ \
+RUN yum install -y \
+        gcc \
+        gcc-c++ \
         make \
         python-devel \
         wget && \
@@ -49,8 +48,8 @@ ENV CTRANSLATE2_ROOT=/root/ctranslate2
 
 RUN mkdir build && \
     cd build && \
-    source scl_source enable devtoolset-3 && \
     cmake -DCMAKE_INSTALL_PREFIX=${CTRANSLATE2_ROOT} \
+          -DLIB_ONLY=ON \
           -DWITH_CUDA=ON \
           -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" \
           -DCUDA_NVCC_FLAGS="${CUDA_NVCC_FLAGS}" -DCUDA_ARCH_LIST="${CUDA_ARCH_LIST}" .. && \
@@ -65,7 +64,6 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     rm get-pip.py && \
     pip --no-cache-dir install pybind11==2.4.3 && \
     pip freeze | grep pybind11 > /root/ctranslate2/install_requirements.txt && \
-    source scl_source enable devtoolset-3 && \
     python setup.py bdist_wheel && \
     python setup.py sdist && \
     mv dist/* /root/ctranslate2 && \
@@ -90,5 +88,3 @@ WORKDIR /opt
 
 ENV CTRANSLATE2_ROOT=/opt/ctranslate2
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CTRANSLATE2_ROOT/lib64
-
-ENTRYPOINT ["/opt/ctranslate2/bin/translate"]


### PR DESCRIPTION
The new cxxopts dependency of the translation client requires GCC 4.9+. This is causing issues in downstream images that use the default glibc version.