### PR TITLE
Fix conversion of models with shared embeddings

### DIFF
--- a/python/ctranslate2/converters/converter.py
+++ b/python/ctranslate2/converters/converter.py
@@ -59,8 +59,7 @@ class Converter(object):
         model_spec.validate()
         self._check_vocabulary_size("source", src_vocab, model_spec.source_vocabulary_size)
         self._check_vocabulary_size("target", tgt_vocab, model_spec.target_vocabulary_size)
-        if quantization is not None:
-            model_spec.quantize(quantization)
+        model_spec.optimize(quantization=quantization)
         model_spec.serialize(os.path.join(output_dir, "model.bin"))
         if vmap is not None:
             shutil.copy(vmap, os.path.join(output_dir, "vmap.txt"))

--- a/python/ctranslate2/specs/model_spec.py
+++ b/python/ctranslate2/specs/model_spec.py
@@ -64,7 +64,6 @@ class LayerSpec(object):
                 # Convert bool to an integer type.
                 setattr(spec, attr_name, np.dtype("int8").type(value))
         self.visit(_check)
-        self._alias_variables()
 
     def variables(self, prefix="", ordered=False):
         """Returns a dict mapping variables name to value. If ordered is True,
@@ -98,7 +97,7 @@ class LayerSpec(object):
                     setattr(spec, attr_name, other_name)
                     break
 
-    def quantize(self, quantization):
+    def _quantize(self, quantization):
         """Possibly quantizes the variable of the layer."""
         def _quantize(spec, name, value):
             if "weight" in name and isinstance(value, np.ndarray):
@@ -116,6 +115,12 @@ class LayerSpec(object):
                 setattr(spec, "weight_scale", scale)
                 setattr(spec, "weight", value)
         self.visit(_quantize)
+
+    def optimize(self, quantization=None):
+        """Applies some optimizations on this layer."""
+        self._alias_variables()
+        if quantization is not None:
+            self._quantize(quantization)
 
     def visit(self, fn):
         """Recursively visits this layer and its children."""


### PR DESCRIPTION
Variables should be aliased after checking the vocabulary sizes.

Fixes #118.