### PR TITLE
Cache result of platformHasFastInt8 call

### DIFF
--- a/src/cuda/utils.h
+++ b/src/cuda/utils.h
@@ -62,7 +62,6 @@ namespace ctranslate2 {
 
     int get_gpu_count();
     bool has_gpu();
-    bool has_fast_fp16();
     bool has_fast_int8();
 
     // Custom allocator for Thrust.


### PR DESCRIPTION
This involves creating and destroying a TensorRT builder object, but the result of this call will not change for the lifetime of the program so we can cache it.

Closes #132.