### PR TITLE
Revert parallel_for integration in low level transformation

### DIFF
--- a/src/primitives/cpu.cc
+++ b/src/primitives/cpu.cc
@@ -27,10 +27,8 @@ namespace ctranslate2 {
                        dim_t size,
                        const Function& func,
                        dim_t work_size = 1) {
-    parallel_for(0, size, GRAIN_SIZE / work_size,
-                 [&](dim_t begin, dim_t end) {
-                   std::transform(x + begin, x + end, y + begin, func);
-                 });
+    (void)work_size;
+    std::transform(x, x + size, y, func);
   }
 
   template <typename T1, typename T2, typename T3, typename Function>
@@ -40,10 +38,8 @@ namespace ctranslate2 {
                         dim_t size,
                         const Function& func,
                         dim_t work_size = 1) {
-    parallel_for(0, size, GRAIN_SIZE / work_size,
-                 [&](dim_t begin, dim_t end) {
-                   std::transform(a + begin, a + end, b + begin, c + begin, func);
-                 });
+    (void)work_size;
+    std::transform(a, a + size, b, c, func);
   }
 
   template<>

--- a/src/primitives/parallel.h
+++ b/src/primitives/parallel.h
@@ -29,13 +29,9 @@ namespace ctranslate2 {
       return;
     }
 #ifdef _OPENMP
-    const dim_t omp_num_threads = omp_get_num_threads();
-    if (omp_num_threads == 1) {
-      return f(begin, end);
-    }
     #pragma omp parallel if (!omp_in_parallel() && ((end - begin) > grain_size))
     {
-      dim_t num_threads = omp_num_threads;
+      dim_t num_threads = omp_get_num_threads();
       if (grain_size > 0) {
         num_threads = std::min(num_threads, ceil_divide((end - begin), grain_size));
       }


### PR DESCRIPTION
In dcbe5a507cd6eedce08f27087d6e3d33f1310485, we tried to address a memory leak issue when using intra_threads = 1 (possibly related to nested parallel regions). However, the fix is incorrect as `omp_get_num_threads` returns a different value in the parallel region.

As a quick and safe fix, we revert the parallel_for integration for now.