### PR TITLE
Directly query device properties to determine int8 support

### DIFF
--- a/include/ctranslate2/utils.h
+++ b/include/ctranslate2/utils.h
@@ -9,8 +9,8 @@
 namespace ctranslate2 {
 
   // Check feature support.
-  bool mayiuse_int16(Device device);
-  bool mayiuse_int8(Device device);
+  bool mayiuse_int16(Device device, int device_index = 0);
+  bool mayiuse_int8(Device device, int device_index = 0);
 
   void set_num_threads(size_t num_threads);
 

--- a/src/cuda/utils.h
+++ b/src/cuda/utils.h
@@ -62,7 +62,7 @@ namespace ctranslate2 {
 
     int get_gpu_count();
     bool has_gpu();
-    bool has_fast_int8();
+    bool has_fast_int8(int device = -1);
 
     // Custom allocator for Thrust.
     class ThrustAllocator {

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -241,8 +241,8 @@ namespace ctranslate2 {
     void Model::finalize() {
       auto scoped_device_setter = get_scoped_device_setter();
 
-      const bool support_int8 = mayiuse_int8(_device);
-      const bool support_int16 = mayiuse_int16(_device);
+      const bool support_int8 = mayiuse_int8(_device, _device_index);
+      const bool support_int16 = mayiuse_int16(_device, _device_index);
 
       std::vector<std::string> variables_to_remove;
       std::vector<std::pair<std::string, StorageView>> variables_to_add;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -34,7 +34,7 @@ namespace ctranslate2 {
   }
 #endif
 
-  bool mayiuse_int16(Device device) {
+  bool mayiuse_int16(Device device, int) {
     switch (device) {
 #ifdef WITH_MKL
     case Device::CPU:
@@ -45,11 +45,11 @@ namespace ctranslate2 {
     }
   }
 
-  bool mayiuse_int8(Device device) {
+  bool mayiuse_int8(Device device, int device_index) {
     switch (device) {
 #ifdef WITH_CUDA
     case Device::CUDA:
-      return cuda::has_fast_int8();
+      return cuda::has_fast_int8(device_index);
 #endif
 #ifdef WITH_MKL
     case Device::CPU:


### PR DESCRIPTION
INT8 support actually comes down to the GPU compute capability. We can easily query this value with `cudaGetDeviceProperties` which is way faster than initializing a TensorRT builder.