### PR TITLE
Set device that was used for cudnnCreate before cudnnDestroy

### DIFF
--- a/src/cuda/utils.cc
+++ b/src/cuda/utils.cc
@@ -63,16 +63,22 @@ namespace ctranslate2 {
     class CudnnHandle {
     public:
       CudnnHandle() {
+        CUDA_CHECK(cudaGetDevice(&_device));
         CUDNN_CHECK(cudnnCreate(&_handle));
         CUDNN_CHECK(cudnnSetStream(_handle, get_cuda_stream()));
       }
       ~CudnnHandle() {
-        cudnnDestroy(_handle);
+        int current_device;
+        CUDA_CHECK(cudaGetDevice(&current_device));
+        CUDA_CHECK(cudaSetDevice(_device));
+        CUDNN_CHECK(cudnnDestroy(_handle));
+        CUDA_CHECK(cudaSetDevice(current_device));
       }
       cudnnHandle_t get() const {
         return _handle;
       }
     private:
+      int _device;
       cudnnHandle_t _handle;
     };
 


### PR DESCRIPTION
Otherwise, cuDNN will allocate some memory on the active device when `cudnnDestroy` is called.

In practice, when placing a Python translator on GPU N > 0, it briefly allocated memory on GPU 0 upon destruction.