### PR TITLE
Include memory values in the decoder state

### DIFF
--- a/include/ctranslate2/decoding.h
+++ b/include/ctranslate2/decoding.h
@@ -14,8 +14,6 @@ namespace ctranslate2 {
            layers::DecoderState& state,
            const Sampler& sampler,
            const StorageView& start_ids,
-           const StorageView* memory,
-           const StorageView* memory_lengths,
            const dim_t start_step,
            const dim_t end_id,
            const dim_t max_length,
@@ -37,8 +35,6 @@ namespace ctranslate2 {
            layers::DecoderState& state,
            const Sampler& sampler,
            const StorageView& start_ids,
-           const StorageView* memory,
-           const StorageView* memory_lengths,
            const dim_t start_step,
            const dim_t end_id,
            const dim_t max_length,
@@ -61,8 +57,6 @@ namespace ctranslate2 {
            layers::DecoderState& state,
            const Sampler& sampler,
            const StorageView& start_ids,
-           const StorageView* memory,
-           const StorageView* memory_lengths,
            const dim_t start_step,
            const dim_t end_id,
            const dim_t max_length,
@@ -77,19 +71,16 @@ namespace ctranslate2 {
                                       const std::vector<size_t>& prefix_ids,
                                       layers::Decoder& decoder,
                                       layers::DecoderState& state,
-                                      const StorageView* memory,
-                                      const StorageView* memory_lengths,
                                       std::vector<std::vector<float>>* prefix_attention);
 
   std::vector<GenerationResult<size_t>>
   decode(layers::Decoder& decoder,
+         layers::DecoderState& state,
          const SearchStrategy& search_strategy,
          const Sampler& sampler,
          const std::vector<size_t>& start_ids,
          const std::vector<std::vector<size_t>>* prefix_ids,
          const std::vector<size_t>* output_ids_map,
-         StorageView* memory,  // TODO: this should be const.
-         StorageView* memory_lengths,  // TODO: this should be const.
          const dim_t end_id,
          const dim_t max_length,
          const dim_t min_length,

--- a/include/ctranslate2/layers/decoder.h
+++ b/include/ctranslate2/layers/decoder.h
@@ -21,15 +21,9 @@ namespace ctranslate2 {
       virtual DecoderState initial_state() const = 0;
       virtual void operator()(dim_t step,
                               const StorageView& ids,
-                              const StorageView* memory,
-                              const StorageView* memory_lengths,
                               DecoderState& state,
                               StorageView* logits = nullptr,
                               StorageView* attention = nullptr) = 0;
-      void operator()(dim_t step,
-                      const StorageView& ids,
-                      DecoderState& state,
-                      StorageView* logits = nullptr);
 
       // Gathers states based on indices.
       void gather_state(DecoderState& state, const StorageView& indices) const;

--- a/include/ctranslate2/models/transformer.h
+++ b/include/ctranslate2/models/transformer.h
@@ -107,8 +107,6 @@ namespace ctranslate2 {
       layers::DecoderState initial_state() const override;
       void operator()(dim_t step,
                       const StorageView& ids,
-                      const StorageView* memory,
-                      const StorageView* memory_lengths,
                       layers::DecoderState& state,
                       StorageView* logits = nullptr,
                       StorageView* attention = nullptr) override;

--- a/src/layers/decoder.cc
+++ b/src/layers/decoder.cc
@@ -9,13 +9,6 @@ namespace ctranslate2 {
       : _device(device) {
     }
 
-    void Decoder::operator()(dim_t step,
-                             const StorageView& ids,
-                             DecoderState& state,
-                             StorageView* logits) {
-      operator()(step, ids, nullptr, nullptr, state, logits, nullptr);
-    }
-
     void Decoder::gather_state(DecoderState& state, const StorageView& indices) const {
       static const ops::Gather gather_op;
 

--- a/src/models/transformer.cc
+++ b/src/models/transformer.cc
@@ -303,8 +303,6 @@ namespace ctranslate2 {
 
     void TransformerDecoder::operator()(dim_t step,
                                         const StorageView& ids,
-                                        const StorageView* memory,
-                                        const StorageView* memory_lengths,
                                         layers::DecoderState& state,
                                         StorageView* logits,
                                         StorageView* attention) {
@@ -315,6 +313,13 @@ namespace ctranslate2 {
       _embeddings(ids, layer_in);
       if (_position_encoder)
         (*_position_encoder)(layer_in, step);
+
+      const StorageView* memory = nullptr;
+      const StorageView* memory_lengths = nullptr;
+      if (_with_encoder_attention) {
+        memory = &state.at("memory");
+        memory_lengths = &state.at("memory_lengths");
+      }
 
       for (size_t l = 0; l < _layers.size(); ++l) {
         const std::string l_str = std::to_string(l);

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -320,17 +320,19 @@ namespace ctranslate2 {
     }
 
     // Decode.
+    layers::DecoderState state = decoder.initial_state();
+    state.emplace(std::string("memory"), std::move(encoded));
+    state.emplace(std::string("memory_lengths"), std::move(lengths));
     const std::vector<size_t> start_ids(batch_size, target_vocab.to_id(Vocabulary::bos_token));
     const size_t end_id = target_vocab.to_id(Vocabulary::eos_token);
     const std::vector<GenerationResult<size_t>> results = decode(
       decoder,
+      state,
       *make_search_strategy(options),
       *make_sampler(options),
       start_ids,
       target_prefix ? &target_prefix_ids : nullptr,
       !output_ids_map.empty() ? &output_ids_map : nullptr,
-      &encoded,
-      &lengths,
       end_id,
       options.max_decoding_length,
       options.min_decoding_length,


### PR DESCRIPTION
* The memory is now optional so it's better to avoid passing it everywhere.
* The memory requires the same tiling and gathering as the decoder state so the duplication can be removed.