### PR TITLE
Remove fill operation in StorageView(Shape) constructor

### DIFF
--- a/include/ctranslate2/storage_view.h
+++ b/include/ctranslate2/storage_view.h
@@ -43,6 +43,8 @@ namespace ctranslate2 {
   public:
     StorageView(DataType type = DataType::FLOAT, Device device = Device::CPU);
     StorageView(Device device, DataType type = DataType::FLOAT);
+
+    // The reserved memory is uninitialized.
     StorageView(const Shape& shape, DataType type = DataType::FLOAT, Device device = Device::CPU);
 
     template <typename T>
@@ -97,7 +99,10 @@ namespace ctranslate2 {
     StorageView& clear();
     // Releases the memory.
     StorageView& release();
-    // Reserves this size (data are discarded).
+    // Reserves the memory.
+    // If size is larger than the currently allocated size, a reallocation occurs and
+    // the data is replaced by uninitialized memory.
+    // If size is smaller than the currently allocated size, this a no-op.
     StorageView& reserve(dim_t size);
 
     dim_t rank() const;
@@ -113,6 +118,7 @@ namespace ctranslate2 {
 
     StorageView& reshape(const Shape& new_shape);
 
+    // Resize methods (see also reserve() for information about reallocation policy).
     StorageView& resize_as(const StorageView& other);
     StorageView& resize(const Shape& new_shape);
     StorageView& resize(dim_t dim, dim_t new_size);

--- a/src/storage_view.cc
+++ b/src/storage_view.cc
@@ -31,7 +31,6 @@ namespace ctranslate2 {
     , _device(device) {
     DEVICE_DISPATCH(device, _device_index = primitives<D>::get_device());
     resize(shape);
-    TYPE_DISPATCH(type, fill(T()));
   }
 
   StorageView::StorageView(const StorageView& other)

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -63,7 +63,7 @@ namespace ctranslate2 {
     }
 
     // Make 2D input.
-    StorageView input({batch_size, max_length}, DataType::INT32);
+    StorageView input({batch_size, max_length}, int32_t(0));
     for (dim_t i = 0; i < batch_size; ++i) {
       const dim_t length = ids[i].size();
       for (dim_t t = 0; t < length; ++t)

--- a/tests/primitives_test.cc
+++ b/tests/primitives_test.cc
@@ -2,7 +2,7 @@
 #include "ctranslate2/primitives/primitives.h"
 
 TEST(PrimitiveTest, StridedFillCPU) {
-  StorageView x({3, 2});
+  StorageView x({3, 2}, float(0));
   StorageView expected({3, 2}, std::vector<float>{1, 0, 1, 0, 1, 0});
   primitives<Device::CPU>::strided_fill(x.data<float>(), 1.f, 2, 3);
   expect_storage_eq(x, expected);


### PR DESCRIPTION
2 reasons:

* initialized memory is not always needed so this is a small optimization for these cases
* this matches the semantic of resize(Shape) which does not initialize memory