### PR TITLE
Ensure vocabulary map produces weights with a size divisble by 16

### DIFF
--- a/include/ctranslate2/vocabulary_map.h
+++ b/include/ctranslate2/vocabulary_map.h
@@ -22,9 +22,11 @@ namespace ctranslate2 {
     bool empty() const;
 
     std::vector<size_t>
-    get_candidates(const std::vector<std::vector<std::string>>& batch_tokens) const;
+    get_candidates(const std::vector<std::vector<std::string>>& batch_tokens,
+                   const size_t multiple_of = 16) const;
 
   private:
+    const size_t _vocabulary_size;
     std::set<size_t> _fixed_candidates;
     std::vector<std::unordered_map<std::string, std::vector<size_t>>> _map_rules;
   };

--- a/src/vocabulary_map.cc
+++ b/src/vocabulary_map.cc
@@ -4,7 +4,8 @@
 
 namespace ctranslate2 {
 
-  VocabularyMap::VocabularyMap(const std::string& map_path, const Vocabulary& vocabulary) {
+  VocabularyMap::VocabularyMap(const std::string& map_path, const Vocabulary& vocabulary)
+    : _vocabulary_size(vocabulary.size()) {
     std::ifstream map_file(map_path);
     if (!map_file.is_open())
       return;
@@ -58,7 +59,8 @@ namespace ctranslate2 {
   }
 
   std::vector<size_t>
-  VocabularyMap::get_candidates(const std::vector<std::vector<std::string>>& batch_tokens) const {
+  VocabularyMap::get_candidates(const std::vector<std::vector<std::string>>& batch_tokens,
+                                const size_t multiple_of) const {
     std::set<size_t> candidates = _fixed_candidates;
     std::string accu;
     for (const auto& tokens : batch_tokens) {
@@ -74,7 +76,16 @@ namespace ctranslate2 {
         }
       }
     }
-    return std::vector<size_t>(candidates.begin(), candidates.end());
+
+    std::vector<size_t> ids(candidates.begin(), candidates.end());
+    const size_t num_candidates = ids.size();
+    const size_t padding_size = multiple_of - (num_candidates % multiple_of);
+    if (padding_size != multiple_of && num_candidates + padding_size <= _vocabulary_size) {
+      std::vector<size_t> padding(padding_size, 0);
+      ids.insert(ids.begin(), padding.begin(), padding.end());
+    }
+
+    return ids;
   }
 
 }


### PR DESCRIPTION
This is to ensure memory alignment for subsequent operations.