### PR TITLE
Make output scores optional

### DIFF
--- a/cli/translate.cc
+++ b/cli/translate.cc
@@ -87,6 +87,7 @@ int main(int argc, char* argv[]) {
   options.min_decoding_length = args["min_sent_length"].as<size_t>();
   options.num_hypotheses = args["n_best"].as<size_t>();
   options.use_vmap = args["use_vmap"].as<bool>();
+  options.return_scores = args["with_score"].as<bool>();
 
   std::istream* in = &std::cin;
   std::ostream* out = &std::cout;

--- a/docs/python.md
+++ b/docs/python.md
@@ -49,6 +49,7 @@ output = translator.translate_batch(
     max_decoding_length=250,   # Maximum prediction length.
     min_decoding_length=1,     # Minimum prediction length.
     use_vmap=False,            # Use the vocabulary mapping file saved in this model.
+    return_scores=True,        # Include the prediction scores in the output.
     return_attention=False,    # Include the attention vectors in the output.
     return_alternatives=False, # Return alternatives at the first unconstrained decoding position.
     sampling_topk=1,           # Randomly sample predictions from the top K candidates (with beam_size=1).

--- a/include/ctranslate2/decoding.h
+++ b/include/ctranslate2/decoding.h
@@ -20,7 +20,7 @@ namespace ctranslate2 {
            const dim_t min_length,
            const std::vector<size_t>* output_ids_map,
            std::vector<std::vector<std::vector<size_t>>>& sampled_ids,
-           std::vector<std::vector<float>>& scores,
+           std::vector<std::vector<float>>* scores = nullptr,
            std::vector<std::vector<std::vector<std::vector<float>>>>* attention = nullptr,
            const size_t num_hypotheses = 1) const = 0;
   };
@@ -40,7 +40,7 @@ namespace ctranslate2 {
            const dim_t min_length,
            const std::vector<size_t>* output_ids_map,
            std::vector<std::vector<std::vector<size_t>>>& sampled_ids,
-           std::vector<std::vector<float>>& scores,
+           std::vector<std::vector<float>>* scores = nullptr,
            std::vector<std::vector<std::vector<std::vector<float>>>>* attention = nullptr,
            const size_t num_hypotheses = 1) const override;
 
@@ -62,7 +62,7 @@ namespace ctranslate2 {
            const dim_t min_length,
            const std::vector<size_t>* output_ids_map,
            std::vector<std::vector<std::vector<size_t>>>& sampled_ids,
-           std::vector<std::vector<float>>& scores,
+           std::vector<std::vector<float>>* scores = nullptr,
            std::vector<std::vector<std::vector<std::vector<float>>>>* attention = nullptr,
            const size_t num_hypotheses = 1) const override;
   };
@@ -86,6 +86,7 @@ namespace ctranslate2 {
          const dim_t min_length,
          const size_t num_hypotheses,
          const bool return_alternatives,
+         const bool return_scores,
          const bool return_attention);
 
 }

--- a/include/ctranslate2/translation_result.h
+++ b/include/ctranslate2/translation_result.h
@@ -11,20 +11,23 @@ namespace ctranslate2 {
   class GenerationResult {
   public:
     GenerationResult(const size_t num_hypotheses, const bool with_attention);  // Empty result.
-    GenerationResult(std::vector<std::vector<T>> hypotheses,
-                     std::vector<float> scores);
+    GenerationResult(std::vector<std::vector<T>> hypotheses);
     GenerationResult(std::vector<std::vector<T>> hypotheses,
                      std::vector<float> scores,
                      std::vector<std::vector<std::vector<float>>> attention);
 
-    const std::vector<T>& output() const;
-    float score() const;
-
     size_t num_hypotheses() const;
+
+    const std::vector<T>& output() const;
     const std::vector<std::vector<T>>& hypotheses() const;
+
+    float score() const;
     const std::vector<float>& scores() const;
+    void set_scores(std::vector<float> scores);
+    bool has_scores() const;
 
     const std::vector<std::vector<std::vector<float>>>& attention() const;
+    void set_attention(std::vector<std::vector<std::vector<float>>> attention);
     bool has_attention() const;
 
     friend GenerationResult<std::string>

--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -37,6 +37,8 @@ namespace ctranslate2 {
     // beam_size unless return_alternatives is set).
     size_t num_hypotheses = 1;
 
+    // Store scores in the TranslationResult class.
+    bool return_scores = true;
     // Store attention vectors in the TranslationResult class.
     bool return_attention = false;
 

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -113,6 +113,14 @@ def test_return_attention():
     assert len(attention) == 6  # Target length.
     assert len(attention[0]) == 6  # Source length.
 
+def test_ignore_scores():
+    translator = _get_transliterator()
+    output = translator.translate_batch(
+        [["آ" ,"ت" ,"ز" ,"م" ,"و" ,"ن"]],
+        beam_size=1,
+        return_scores=False)
+    assert "scores" not in output[0][0]
+
 def test_return_alternatives():
     translator = _get_transliterator()
     output = translator.translate_batch(

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -106,6 +106,7 @@ public:
       options.min_decoding_length = min_decoding_length;
       options.num_hypotheses = num_hypotheses;
       options.use_vmap = use_vmap;
+      options.return_scores = with_scores;
 
       if (read_batch_size == 0)
         read_batch_size = max_batch_size;
@@ -128,6 +129,7 @@ public:
                            size_t max_decoding_length,
                            size_t min_decoding_length,
                            bool use_vmap,
+                           bool return_scores,
                            bool return_attention,
                            bool return_alternatives,
                            size_t sampling_topk,
@@ -154,6 +156,7 @@ public:
       options.min_decoding_length = min_decoding_length;
       options.num_hypotheses = num_hypotheses;
       options.use_vmap = use_vmap;
+      options.return_scores = return_scores;
       options.return_attention = return_attention;
       options.return_alternatives = return_alternatives;
 
@@ -165,8 +168,10 @@ public:
       py::list batch;
       for (size_t i = 0; i < result.num_hypotheses(); ++i) {
         py::dict hyp;
-        hyp["score"] = result.scores()[i];
         hyp["tokens"] = std_vector_to_py_list(result.hypotheses()[i]);
+        if (result.has_scores()) {
+          hyp["score"] = result.scores()[i];
+        }
         if (result.has_attention()) {
           py::list attn;
           for (const auto& attn_vector : result.attention()[i])
@@ -278,6 +283,7 @@ PYBIND11_MODULE(translator, m)
          py::arg("max_decoding_length")=250,
          py::arg("min_decoding_length")=1,
          py::arg("use_vmap")=false,
+         py::arg("return_scores")=true,
          py::arg("return_attention")=false,
          py::arg("return_alternatives")=false,
          py::arg("sampling_topk")=1,

--- a/src/translation_result.cc
+++ b/src/translation_result.cc
@@ -10,10 +10,8 @@ namespace ctranslate2 {
   }
 
   template <typename T>
-  GenerationResult<T>::GenerationResult(std::vector<std::vector<T>> hypotheses,
-                                        std::vector<float> scores)
-    : _hypotheses(std::move(hypotheses))
-    , _scores(std::move(scores)) {
+  GenerationResult<T>::GenerationResult(std::vector<std::vector<T>> hypotheses)
+    : _hypotheses(std::move(hypotheses)) {
   }
 
   template <typename T>
@@ -51,8 +49,23 @@ namespace ctranslate2 {
   }
 
   template <typename T>
+  void GenerationResult<T>::set_scores(std::vector<float> scores) {
+    _scores = std::move(scores);
+  }
+
+  template <typename T>
+  bool GenerationResult<T>::has_scores() const {
+    return !_scores.empty();
+  }
+
+  template <typename T>
   const std::vector<std::vector<std::vector<float>>>& GenerationResult<T>::attention() const {
     return _attention;
+  }
+
+  template <typename T>
+  void GenerationResult<T>::set_attention(std::vector<std::vector<std::vector<float>>> attention) {
+    _attention = std::move(attention);
   }
 
   template <typename T>

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -329,6 +329,7 @@ namespace ctranslate2 {
       options.min_decoding_length,
       options.num_hypotheses,
       options.return_alternatives,
+      options.return_scores,
       options.return_attention);
 
     // Convert generated ids to tokens.

--- a/src/translator_pool.cc
+++ b/src/translator_pool.cc
@@ -118,7 +118,7 @@ namespace ctranslate2 {
       stats.num_tokens += hypotheses[0].size();
       for (size_t n = 0; n < hypotheses.size(); ++n) {
         if (with_scores)
-          out << scores[n] << " ||| ";
+          out << (result.has_scores() ? scores[n] : 0) << " ||| ";
         for (size_t i = 0; i < hypotheses[n].size(); ++i) {
           if (i > 0)
             out << ' ';

--- a/tests/translator_test.cc
+++ b/tests/translator_test.cc
@@ -327,3 +327,14 @@ TEST(TranslatorTest, InvalidNumHypotheses) {
   std::vector<std::string> input = {"آ" ,"ت" ,"ز" ,"م" ,"و" ,"ن"};
   EXPECT_THROW(translator.translate(input, options), std::invalid_argument);
 }
+
+TEST(TranslatorTest, IgnoreScore) {
+  Translator translator = default_translator();
+  TranslationOptions options;
+  options.beam_size = 1;
+  options.return_scores = false;
+  const std::vector<std::string> input = {"آ" ,"ت" ,"ز" ,"م" ,"و" ,"ن"};
+  const TranslationResult result = translator.translate(input, options);
+  EXPECT_FALSE(result.has_scores());
+  EXPECT_EQ(result.output(), (std::vector<std::string>{"a", "t", "z", "m", "o", "n"}));
+}


### PR DESCRIPTION
Additional optimizations are possible when the output scores are not required. For example, we can skip the final LogSoftMax during greedy search.