### PR TITLE
Fix parallel translations from multiple Python threads

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -84,3 +84,5 @@ Also see the [`TranslationOptions`](../include/ctranslate2/translator.h) structu
 * `translator.unload_model(to_cpu=False)`<br/>Unload the model attached to this translator but keep enough runtime context to quickly resume translation on the initial device. When `to_cpu` is `True`, the model is moved to the CPU memory and not fully unloaded.
 * `translator.load_model()`<br/>Load the model back to the initial device.
 * `del translator`<br/>Release the translator resources.
+
+When using multiple Python threads, the application should ensure that no translations are running before calling these functions.


### PR DESCRIPTION
An exclusive lock was added to make the methods `translate` and `{load,unload}_model` mutually exclusive. However, this also makes concurrent calls to `translate` mutually exclusive.

The true fix would be to use a shared lock but this proved to be a bit complex to add without C++17 support.

For simplicity, we remove this locking mechanism for now and defer this responsibility to the application. This is also consistent with `del translator` which was never thread safe.