### PR TITLE
Add coverage penalty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /.vs
 /build
 CMake*.json
+.idea
+python/build/
+python/ctranslate2.egg-info/
+python/dist/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(SOURCES
   src/models/sequence_to_sequence.cc
   src/models/transformer.cc
   src/ops/add.cc
+  src/ops/min_max.cc
   src/ops/concat.cc
   src/ops/concat_split_cpu.cc
   src/ops/dequantize.cc

--- a/cli/translate.cc
+++ b/cli/translate.cc
@@ -39,6 +39,8 @@ int main(int argc, char* argv[]) {
      cxxopts::value<bool>()->default_value("false"))
     ("length_penalty", "Length penalty to apply during beam search",
      cxxopts::value<float>()->default_value("0"))
+    ("coverage_penalty", "Coverage penalty to apply during beam search",
+     cxxopts::value<float>()->default_value("0"))
     ("max_sent_length", "Maximum sentence length to produce.",
      cxxopts::value<size_t>()->default_value("250"))
     ("min_sent_length", "Minimum sentence length to produce.",
@@ -84,6 +86,7 @@ int main(int argc, char* argv[]) {
   options.batch_type = ctranslate2::str_to_batch_type(args["batch_type"].as<std::string>());
   options.beam_size = args["beam_size"].as<size_t>();
   options.length_penalty = args["length_penalty"].as<float>();
+  options.coverage_penalty = args["coverage_penalty"].as<float>();
   options.sampling_topk = args["sampling_topk"].as<size_t>();
   options.sampling_temperature = args["sampling_temperature"].as<float>();
   options.max_decoding_length = args["max_sent_length"].as<size_t>();

--- a/docs/python.md
+++ b/docs/python.md
@@ -47,6 +47,7 @@ output = translator.translate_batch(
     beam_size=2,               # Beam size (set 1 to run greedy search).
     num_hypotheses=1,          # Number of hypotheses to return (should be <= beam_size).
     length_penalty=0,          # Length penalty constant to use during beam search.
+    coverage_penalty=0,        # Converage penalty constant to use during beam search.
     max_decoding_length=250,   # Maximum prediction length.
     min_decoding_length=1,     # Minimum prediction length.
     use_vmap=False,            # Use the vocabulary mapping file saved in this model.
@@ -69,6 +70,7 @@ stats = translator.translate_file(
     beam_size=2,
     num_hypotheses=1,
     length_penalty=0,
+    coverage_penalty=0,
     max_decoding_length=250,
     min_decoding_length=1,
     use_vmap=False,

--- a/include/ctranslate2/decoding.h
+++ b/include/ctranslate2/decoding.h
@@ -27,7 +27,7 @@ namespace ctranslate2 {
 
   class BeamSearch : public SearchStrategy {
   public:
-    BeamSearch(const dim_t beam_size, const float length_penalty = 0);
+    BeamSearch(const dim_t beam_size, const float length_penalty = 0, const float coverage_penalty = 0);
 
     void
     search(layers::Decoder& decoder,
@@ -47,6 +47,7 @@ namespace ctranslate2 {
   private:
     const dim_t _beam_size;
     const float _length_penalty;
+    const float _coverage_penalty;
   };
 
   class GreedySearch : public SearchStrategy {

--- a/include/ctranslate2/ops/log.h
+++ b/include/ctranslate2/ops/log.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "op.h"
+
+namespace ctranslate2 {
+  namespace ops {
+
+    class Log : public UnaryOp {
+    public:
+      void operator()(const StorageView& x, StorageView& y) const {
+        PROFILE("Log");
+        compute<float>(x, y);
+      }
+
+    private:
+      template <typename T>
+      void compute(const StorageView& x, StorageView& y) const {
+        y.resize_as(x);
+        primitives<>::log(x.data<T>(), y.data<T>(), x.size());
+      }
+    };
+
+  }
+}

--- a/include/ctranslate2/ops/min_max.h
+++ b/include/ctranslate2/ops/min_max.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "op.h"
+
+namespace ctranslate2 {
+  namespace ops {
+
+    class Min : public BinaryOp {
+    public:
+      void operator()(const StorageView& a, const StorageView& b, StorageView& c) const override;
+
+    private:
+      template <Device D, typename T>
+      void compute(const StorageView& a, const StorageView& b, StorageView& c) const {
+        c.resize_as(a);
+        if (b.is_scalar()) {
+          primitives<D>::min(b.data<T>()[0], a.data<T>(), c.data<T>(), c.size());
+        } else {
+          primitives<D>::min(a.data<T>(), b.data<T>(), c.data<T>(), c.size());
+        }
+      }
+    };
+
+    class Max : public BinaryOp {
+    public:
+      void operator()(const StorageView& a, const StorageView& b, StorageView& c) const override;
+
+    private:
+      template <Device D, typename T>
+      void compute(const StorageView& a, const StorageView& b, StorageView& c) const {
+        c.resize_as(a);
+        if (b.is_scalar()) {
+          primitives<D>::max(b.data<T>()[0], a.data<T>(), c.data<T>(), c.size());
+        } else {
+          primitives<D>::max(a.data<T>(), b.data<T>(), c.data<T>(), c.size());
+        }
+      }
+    };
+
+  }
+}

--- a/include/ctranslate2/ops/ops.h
+++ b/include/ctranslate2/ops/ops.h
@@ -28,3 +28,5 @@
 #include "transpose.h"
 #include "dequantize.h"
 #include "unsqueeze.h"
+#include "min_max.h"
+#include "log.h"

--- a/include/ctranslate2/primitives/primitives.h
+++ b/include/ctranslate2/primitives/primitives.h
@@ -97,6 +97,28 @@ namespace ctranslate2 {
     static void sub(const T* a, const T* b, T* c, dim_t size);
 
     template <typename T>
+    static void max(T a, const T* x, T* y, dim_t size);
+
+    template <typename T>
+    static void max(const T* a, const T* b, T* c, dim_t size);
+
+    template <typename T>
+    static void max(T a, T* y, dim_t size) {
+      max(a, y, y, size);
+    }
+
+    template <typename T>
+    static void min(T a, const T* x, T* y, dim_t size);
+
+    template <typename T>
+    static void min(const T* a, const T* b, T* c, dim_t size);
+
+    template <typename T>
+    static void min(T a, T* y, dim_t size) {
+      min(a, y, y, size);
+    }
+
+    template <typename T>
     static void mul(T a, const T* x, T* y, dim_t size);
 
     template <typename T>

--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -27,6 +27,8 @@ namespace ctranslate2 {
     size_t beam_size = 2;
     // Length penalty value to apply during beam search.
     float length_penalty = 0;
+    // Coverage value to apply during beam search.
+    float coverage_penalty = 0;
 
     // Decoding length constraints.
     size_t max_decoding_length = 250;

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -82,6 +82,7 @@ public:
                            size_t beam_size,
                            size_t num_hypotheses,
                            float length_penalty,
+                           float coverage_penalty,
                            size_t max_decoding_length,
                            size_t min_decoding_length,
                            bool use_vmap,
@@ -99,6 +100,7 @@ public:
       options.batch_type = ctranslate2::str_to_batch_type(batch_type);
       options.beam_size = beam_size;
       options.length_penalty = length_penalty;
+      options.coverage_penalty = coverage_penalty;
       options.sampling_topk = sampling_topk;
       options.sampling_temperature = sampling_temperature;
       options.max_decoding_length = max_decoding_length;
@@ -126,6 +128,7 @@ public:
                            size_t beam_size,
                            size_t num_hypotheses,
                            float length_penalty,
+                           float coverage_penalty,
                            size_t max_decoding_length,
                            size_t min_decoding_length,
                            bool use_vmap,
@@ -151,6 +154,7 @@ public:
       options.batch_type = ctranslate2::str_to_batch_type(batch_type);
       options.beam_size = beam_size;
       options.length_penalty = length_penalty;
+      options.coverage_penalty = coverage_penalty;
       options.sampling_topk = sampling_topk;
       options.sampling_temperature = sampling_temperature;
       options.max_decoding_length = max_decoding_length;
@@ -273,6 +277,7 @@ PYBIND11_MODULE(translator, m)
          py::arg("beam_size")=2,
          py::arg("num_hypotheses")=1,
          py::arg("length_penalty")=0,
+         py::arg("coverage_penalty")=0,
          py::arg("max_decoding_length")=250,
          py::arg("min_decoding_length")=1,
          py::arg("use_vmap")=false,
@@ -290,6 +295,7 @@ PYBIND11_MODULE(translator, m)
          py::arg("beam_size")=2,
          py::arg("num_hypotheses")=1,
          py::arg("length_penalty")=0,
+         py::arg("coverage_penalty")=0,
          py::arg("max_decoding_length")=250,
          py::arg("min_decoding_length")=1,
          py::arg("use_vmap")=false,

--- a/src/decoding.cc
+++ b/src/decoding.cc
@@ -1,11 +1,10 @@
 #include "ctranslate2/decoding.h"
+
 #include <cmath>
 #include <limits>
 #include <map>
 
 #include "ctranslate2/ops/ops.h"
-#include "ctranslate2/ops/min_max.h"
-#include "ctranslate2/ops/log.h"
 #include "./device_dispatch.h"
 
 namespace ctranslate2 {
@@ -67,7 +66,8 @@ namespace ctranslate2 {
 
   BeamSearch::BeamSearch(const dim_t beam_size, const float length_penalty, const float coverage_penalty)
     : _beam_size(beam_size)
-    , _length_penalty(length_penalty), _coverage_penalty(coverage_penalty) {
+    , _length_penalty(length_penalty)
+    , _coverage_penalty(coverage_penalty) {
   }
 
   void
@@ -205,7 +205,7 @@ namespace ctranslate2 {
           coverage = attention_step;
         }else{
           gather(coverage, gather_indices);
-          ops::Add()(attention_step, coverage, coverage );
+          ops::Add()(attention_step, coverage, coverage);
         }
 
         auto penalty = StorageView({cur_batch_size * _beam_size, 1}, coverage.dtype(), coverage.device());
@@ -217,7 +217,7 @@ namespace ctranslate2 {
         tmp.reshape({row, col});
         ops::MatMul()(tmp, StorageView({col, 1}, 1.0f, coverage.device()), penalty);
         ops::Mul()(penalty, StorageView(_coverage_penalty), penalty);
-        ops::Add()(penalty,topk_scores,topk_scores);
+        ops::Add()(penalty, topk_scores, topk_scores);
       }
 
       if (attention) {

--- a/src/decoding.cc
+++ b/src/decoding.cc
@@ -318,8 +318,6 @@ namespace ctranslate2 {
         gather(topk_ids, keep_batches);
         gather(topk_log_probs, keep_batches);
         gather(alive_seq, keep_batches);
-       
-        alive_seq.reshape({cur_batch_size * _beam_size, alive_seq.dim(-1)});
         if (attention)
           gather(alive_attention, keep_batches);
 
@@ -342,7 +340,6 @@ namespace ctranslate2 {
           gather(coverage, keep_batches);
           coverage.reshape({cur_batch_size * _beam_size, coverage.dim(2), coverage.dim(3)});
         }
-
       } else {
         decoder.gather_state(state, gather_indices.to(device));
       }

--- a/src/decoding.cc
+++ b/src/decoding.cc
@@ -157,7 +157,7 @@ namespace ctranslate2 {
       float length_penalty_weight = 1.0;
       if (_length_penalty != 0) {
         length_penalty_weight = std::pow((5.0 + static_cast<float>(step + 1)) / 6.0, _length_penalty);
-        ops::Mul()(log_probs, StorageView(1.f / length_penalty_weight, log_probs.device()), log_probs);
+        ops::Mul()(log_probs, StorageView(1.f / length_penalty_weight), log_probs);
       }
 
       // Penalize end_id, if configured.
@@ -214,8 +214,8 @@ namespace ctranslate2 {
         int row = std::accumulate(tmp.shape().begin(), tmp.shape().end()-1,	1,std::multiplies<int>());
         int col = tmp.shape().back();
         tmp.reshape({row, col});
-        ops::MatMul()(tmp, StorageView({col, 1}, 1.0f, coverage.device()), penalty);
-        ops::Mul()(penalty, StorageView(_coverage_penalty, penalty.device()), penalty);
+        ops::MatMul()(tmp, StorageView({col, 1}, 1.0f), penalty);
+        ops::Mul()(penalty, StorageView(_coverage_penalty), penalty);
         ops::Add()(penalty, topk_scores, topk_scores);
       }
 

--- a/src/decoding.cc
+++ b/src/decoding.cc
@@ -175,7 +175,7 @@ namespace ctranslate2 {
       topk_log_probs = topk_scores;
       // Recover the true log probs if length penalty was applied.
       if (_length_penalty != 0)
-        ops::Mul()(topk_log_probs, StorageView(length_penalty_weight, topk_log_probs.device()), topk_log_probs);
+        ops::Mul()(topk_log_probs, StorageView(length_penalty_weight), topk_log_probs);
 
       // Unflatten the ids.
       gather_indices.resize({cur_batch_size * _beam_size});
@@ -211,8 +211,8 @@ namespace ctranslate2 {
         auto tmp = StorageView(coverage.shape(), coverage.dtype(), coverage.device());
         ops::Min()(coverage, 1.0f, tmp);
         ops::Log()(tmp, tmp);
-        int row = std::accumulate(tmp.shape().begin(), tmp.shape().end()-1,	1,std::multiplies<int>());
-        int col = tmp.shape().back();
+        const dim_t col = tmp.dim(-1);
+        const dim_t row = tmp.size() / col;
         tmp.reshape({row, col});
         ops::MatMul()(tmp, StorageView({col, 1}, 1.0f), penalty);
         ops::Mul()(penalty, StorageView(_coverage_penalty), penalty);

--- a/src/ops/min_max.cc
+++ b/src/ops/min_max.cc
@@ -1,0 +1,18 @@
+#include "ctranslate2/ops/min_max.h"
+
+#include "../device_dispatch.h"
+
+namespace ctranslate2 {
+  namespace ops {
+
+    void Min::operator()(const StorageView& a, const StorageView& b, StorageView& c) const {
+      PROFILE("Min");
+      DEVICE_DISPATCH(a.device(), TYPE_DISPATCH(a.dtype(), (compute<D, T>(a, b, c))));
+    }
+
+    void Max::operator()(const StorageView& a, const StorageView& b, StorageView& c) const {
+      PROFILE("Max");
+      DEVICE_DISPATCH(a.device(), TYPE_DISPATCH(a.dtype(), (compute<D, T>(a, b, c))));
+    }
+  }
+}

--- a/src/primitives/cpu.cc
+++ b/src/primitives/cpu.cc
@@ -234,6 +234,34 @@ namespace ctranslate2 {
 
   template<>
   template <typename T>
+  void primitives<Device::CPU>::max(T a, const T* x, T* y, dim_t size){
+    unary_transform(x, y, size, [&a](T v) { return a > v ? a : v; });
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::CPU>::max(const T* a, const T* b, T* c, dim_t size){
+    binary_transform(a, b, c, size, [](const T &a, const T& b){
+      return std::max<T>(a, b);
+    });
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::CPU>::min(T a, const T* x, T* y, dim_t size){
+    unary_transform(x, y, size, [&a](T v) { return a > v ? v : a; });
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::CPU>::min(const T* a, const T* b, T* c, dim_t size){
+    binary_transform(a, b, c, size, [](const T &a, const T& b){
+      return std::min<T>(a, b);
+    });
+  }
+
+  template<>
+  template <typename T>
   void primitives<Device::CPU>::mul(T a, const T* x, T* y, dim_t size) {
     unary_transform(x, y, size, [&a](T v) { return v * a; });
   }
@@ -781,6 +809,14 @@ namespace ctranslate2 {
                                                dim_t a_size, dim_t b_size); \
   template void                                                         \
   primitives<Device::CPU>::sub(const T* a, const T* b, T* c, dim_t size); \
+  template void                                                         \
+  primitives<Device::CPU>::min(T a, const T* x, T* y, dim_t size);      \
+  template void                                                         \
+  primitives<Device::CPU>::min(const T* a, const T* b, T* c, dim_t size); \
+  template void                                                         \
+  primitives<Device::CPU>::max(T a, const T* x, T* y, dim_t size);     \
+  template void                                                         \
+  primitives<Device::CPU>::max(const T* a, const T* b, T* c, dim_t size); \
   template void                                                         \
   primitives<Device::CPU>::mul(T a, const T* x, T* y, dim_t size);      \
   template void                                                         \

--- a/src/primitives/cuda.cu
+++ b/src/primitives/cuda.cu
@@ -661,6 +661,14 @@ namespace ctranslate2 {
   template void                                                         \
   primitives<Device::CUDA>::sub(const T* a, const T* b, T* c, dim_t size); \
   template void                                                         \
+  primitives<Device::CUDA>::min(T a, const T* x, T* y, dim_t size);      \
+  template void                                                         \
+  primitives<Device::CUDA>::min(const T* a, const T* b, T* c, dim_t size); \
+  template void                                                         \
+  primitives<Device::CUDA>::max(T a, const T* x, T* y, dim_t size);     \
+  template void                                                         \
+  primitives<Device::CUDA>::max(const T* a, const T* b, T* c, dim_t size); \
+  template void                                                         \
   primitives<Device::CUDA>::mul(T a, const T* x, T* y, dim_t size);     \
   template void                                                         \
   primitives<Device::CUDA>::mul(const T* a, const T* b, T* c, dim_t size); \

--- a/src/primitives/cuda.cu
+++ b/src/primitives/cuda.cu
@@ -219,6 +219,30 @@ namespace ctranslate2 {
 
   template<>
   template <typename T>
+  void primitives<Device::CUDA>::min(T a, const T* x, T* y, dim_t size) {
+    unary_transform(x, y, size, thrust::placeholders::_1 > a ? a : thrust::placeholders::_1);
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::CUDA>::min(const T* a, const T* b, T* c, dim_t size) {
+    binary_transform(a, b, c, size, thrust::min<T>());
+  }
+
+ template<>
+  template <typename T>
+  void primitives<Device::CUDA>::max(T a, const T* x, T* y, dim_t size) {
+    unary_transform(x, y, size, thrust::placeholders::_1 > a ? thrust::placeholders::_1 : a);
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::CUDA>::max(const T* a, const T* b, T* c, dim_t size) {
+    binary_transform(a, b, c, size, thrust::max<T>());
+  }
+
+  template<>
+  template <typename T>
   void primitives<Device::CUDA>::mul(T a, const T* x, T* y, dim_t size) {
     unary_transform(x, y, size, thrust::placeholders::_1 * a);
   }

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -91,7 +91,7 @@ namespace ctranslate2 {
     if (options.beam_size == 1)
       strategy = new GreedySearch();
     else
-      strategy = new BeamSearch(options.beam_size, options.length_penalty);
+      strategy = new BeamSearch(options.beam_size, options.length_penalty, options.coverage_penalty);
 
     return std::unique_ptr<const SearchStrategy>(strategy);
   }

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -596,7 +596,7 @@ TEST_P(OpDeviceTest, ReLU) {
 TEST_P(OpDeviceTest, Log) {
   Device device = GetParam();
   float abs_diff = 1e-6;
-  std::vector<float > input_vec({0, 1, 1.5, 2, 2.5, 3, 3.5, 4});
+  std::vector<float > input_vec({0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4});
   std::vector<float > output_vec;
   output_vec.reserve(input_vec.size());
   std::transform(input_vec.begin(), input_vec.end(), std::back_inserter(output_vec),

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -595,13 +595,7 @@ TEST_P(OpDeviceTest, ReLU) {
 
 TEST_P(OpDeviceTest, Log) {
   Device device = GetParam();
-  float abs_diff = 0;
-#ifdef WITH_MKL
-  // the result of Log between vmsLn(WITH_MKL) and std::log has a bit different.
-  if(device == Device::CPU) {
-    abs_diff = 1e-6;
-  };
-#endif
+  float abs_diff = 1e-6;
   std::vector<float > input_vec({0, 1, 1.5, 2, 2.5, 3, 3.5, 4});
   std::vector<float > output_vec;
   output_vec.reserve(input_vec.size());

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -592,6 +592,66 @@ TEST_P(OpDeviceTest, ReLU) {
   expect_storage_eq(output, expected);
 }
 
+TEST_P(OpDeviceTest, Log) {
+  Device device = GetParam();
+  std::vector<float > input_vec({0, 1, 1.5, 2, 2.5, 3, 3.5, 4});
+  std::vector<float > output_vec;
+  output_vec.reserve(input_vec.size());
+  std::transforme(input_vec.begin(), input_vec.end(), std::back_inserter(output_vec),
+          [](const float& i){return std::log(i)});
+  StorageView input({2, 4}, input_vec, device);
+  StorageView expected({2, 4}, output_vec, device);
+  StorageView output(device);
+  ops::Log()(input, output);
+  expect_storage_eq(output, expected);
+}
+
+template <typename T, typename Ops, typename Func>
+void TestMinMax(const Ops& ops, const Func& func){
+  Device device = GetParam();
+  {
+    std::vector<T > input_vec1({0, 1, 1.5, 2, 2.5, 3, 3.5, 4});
+    std::vector<T > input_vec2({0, -1, 1.5, -2, 2.5, -3, -3.5, 4});
+    std::vector<T > output_vec;
+    output_vec.reserve(input_vec.size());
+    std::transforme(input_vec1.begin(), input_vec1.end(), input_vec2.begin(),std::back_inserter(output_vec),
+            [&func](const T& left, const T& right){return func(left, right);});
+    StorageView input1({2, 4}, input_vec1, device);
+    StorageView input2({2, 4}, input_vec2, device);
+    StorageView expected({2, 4}, output_vec, device);
+    StorageView output(device);
+    ops(input1, input2, output);
+    expect_storage_eq(output, expected);
+  }
+  {
+    std::vector<T > input_vec({0, 1, 1.5, 2, 2.5, 3, 3.5, 4});
+    T compare_val = 3;
+    std::vector<T > output_vec;
+    output_vec.reserve(input_vec.size());
+    std::transforme(input_vec.begin(), input_vec.end(), std::back_inserter(output_vec),
+            [&compare_val, &func](const T& i){return func(left, right);});
+    StorageView input({2, 4}, input_vec, device);
+    StorageView expected({2, 4}, output_vec, device);
+    StorageView output(device);
+    ops(input, StorageView(compare_val), output);
+    expect_storage_eq(output, expected);
+  }
+}
+
+TEST_P(OpDeviceTest, Min) {
+  auto ops = ops::Min();
+  TestMinMax<float>(ops, [](float left, float right){
+    return left > right? right : left;
+  });
+}
+
+TEST_P(OpDeviceTest, Max) {
+  auto ops = ops::Max();
+  TestMinMax<float>(ops, [](float left, float right){
+    return left > right? left : right;
+  });
+}
+
 INSTANTIATE_TEST_CASE_P(CPU, OpDeviceTest, ::testing::Values(Device::CPU));
 #ifdef WITH_CUDA
 INSTANTIATE_TEST_CASE_P(CUDA, OpDeviceTest, ::testing::Values(Device::CUDA));

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -595,6 +595,13 @@ TEST_P(OpDeviceTest, ReLU) {
 
 TEST_P(OpDeviceTest, Log) {
   Device device = GetParam();
+  float abs_diff = 0;
+#ifdef WITH_MKL
+  // the result of Log between vmsLn(WITH_MKL) and std::log has a bit different.
+  if(device == Device::CPU) {
+    abs_diff = 1e-6;
+  };
+#endif
   std::vector<float > input_vec({0, 1, 1.5, 2, 2.5, 3, 3.5, 4});
   std::vector<float > output_vec;
   output_vec.reserve(input_vec.size());
@@ -604,7 +611,7 @@ TEST_P(OpDeviceTest, Log) {
   StorageView expected({2, 4}, output_vec, device);
   StorageView output(device);
   ops::Log()(input, output);
-  expect_storage_eq(output, expected);
+  expect_storage_eq(output, expected, abs_diff);
 }
 
 template <typename T, typename Ops, typename Func>


### PR DESCRIPTION
This PR adds a vanilla coverage penalty for translation. It corresponding to `stepwise_penalty=False` and `cov_pen="wu"` in OpenNMT-py, and it is the same as the implementation in OpenNMT-tf.

And I have tested it in my project.

Please @guillaumekln have a look.

Closes #176.