### PR TITLE
Experimental integration of MKL's packed GEMM

### DIFF
--- a/include/ctranslate2/layers/common.h
+++ b/include/ctranslate2/layers/common.h
@@ -26,6 +26,7 @@ namespace ctranslate2 {
       void mask_weights(const StorageView& index);
       void reset_mask();
     private:
+      bool _packed_weight;
       const StorageView& _weight;
       const StorageView* _bias;
       const StorageView* _qscale;

--- a/include/ctranslate2/models/model.h
+++ b/include/ctranslate2/models/model.h
@@ -61,6 +61,9 @@ namespace ctranslate2 {
       // Returns true if the variable is the weight of a linear/dense layer.
       virtual bool is_linear_weight(const std::string& variable_name) const;
 
+      // Returns true if the variable can be pre-packed.
+      virtual bool is_packable(const std::string& variable_name) const;
+
       // Models can override these methods to execute some transformations if needed
       // (e.g. a variable name changed in a newer spec revision).
       virtual void register_variable(const std::string& name, StorageView& variable);

--- a/include/ctranslate2/models/transformer.h
+++ b/include/ctranslate2/models/transformer.h
@@ -21,6 +21,7 @@ namespace ctranslate2 {
     protected:
       bool is_quantizable(const std::string& variable_name) const override;
       bool is_linear_weight(const std::string& variable_name) const override;
+      bool is_packable(const std::string& variable_name) const override;
       void register_variable(const std::string& name, StorageView& variable) override;
       void finalize() override;
 

--- a/include/ctranslate2/ops/gemm.h
+++ b/include/ctranslate2/ops/gemm.h
@@ -7,7 +7,12 @@ namespace ctranslate2 {
 
     class Gemm : public Op {
     public:
-      Gemm(float alpha = 1, float beta = 1, bool trans_a = false, bool trans_b = false);
+      Gemm(float alpha = 1,
+           float beta = 1,
+           bool trans_a = false,
+           bool trans_b = false,
+           bool a_is_packed = false,
+           bool b_is_packed = false);
 
       void operator()(const StorageView& a,
                       const StorageView& b,
@@ -29,6 +34,8 @@ namespace ctranslate2 {
       float _beta;
       bool _trans_a;
       bool _trans_b;
+      bool _a_is_packed;
+      bool _b_is_packed;
     };
 
   }

--- a/include/ctranslate2/ops/matmul.h
+++ b/include/ctranslate2/ops/matmul.h
@@ -54,6 +54,7 @@ namespace ctranslate2 {
         } else {
           y.resize({m, n});
           primitives<D>::gemm(a.data<In>(), b.data<In>(),
+                              false, false,
                               _trans_a, _trans_b,
                               m, n, k,
                               _alpha, beta, y.data<Out>());

--- a/include/ctranslate2/ops/matmul.h
+++ b/include/ctranslate2/ops/matmul.h
@@ -54,7 +54,7 @@ namespace ctranslate2 {
         } else {
           y.resize({m, n});
           primitives<D>::gemm(a.data<In>(), b.data<In>(),
-                              false, false,
+                              /*a_is_packed=*/false, /*b_is_packed=*/false,
                               _trans_a, _trans_b,
                               m, n, k,
                               _alpha, beta, y.data<Out>());

--- a/include/ctranslate2/primitives/primitives.h
+++ b/include/ctranslate2/primitives/primitives.h
@@ -189,8 +189,19 @@ namespace ctranslate2 {
                                         int32_t* compensation);
     static bool prefer_u8s8s32_gemm();
 
+    // If dest is not passed, returns the number of bytes required to store the packed data,
+    // or 0 if packing is not supported.
+    template <typename T>
+    static dim_t gemm_pack_b(const T* b,
+                             const bool transpose_b,
+                             const dim_t k,
+                             const dim_t n,
+                             const float alpha,
+                             T* dest = nullptr);
+
     template <typename In, typename Out>
     static void gemm(const In* a, const In* b,
+                     bool a_is_packed, bool b_is_packed,
                      bool transpose_a, bool transpose_b,
                      dim_t m, dim_t n, dim_t k,
                      float alpha, float beta,

--- a/include/ctranslate2/utils.h
+++ b/include/ctranslate2/utils.h
@@ -8,6 +8,9 @@
 
 namespace ctranslate2 {
 
+  std::string read_string_from_env(const char* var, const std::string& default_value = "");
+  bool read_bool_from_env(const char* var, const bool default_value = false);
+
   // Check feature support.
   bool mayiuse_int16(Device device, int device_index = 0);
   bool mayiuse_int8(Device device, int device_index = 0);

--- a/src/layers/common.cc
+++ b/src/layers/common.cc
@@ -61,7 +61,12 @@ namespace ctranslate2 {
       , _partial_bias(_weight.device(), DataType::FLOAT)
       , _partial_qscale(_weight.device(), DataType::FLOAT)
       , _partial_u8_shift_compensation(_weight.device(), DataType::INT32)
-      , _gemm_op(1, 0, false, true, false, _packed_weight) {
+      , _gemm_op(/*alpha=*/1,
+                 /*beta=*/0,
+                 /*trans_a=*/false,
+                 /*trans_b=*/true,
+                 /*a_is_packed=*/false,
+                 _packed_weight) {
     }
 
     void Dense::mask_weights(const StorageView& index) {

--- a/src/layers/common.cc
+++ b/src/layers/common.cc
@@ -38,8 +38,21 @@ namespace ctranslate2 {
     }
 
 
+    static const StorageView& get_linear_weight(const models::Model& model,
+                                                const std::string& scope,
+                                                bool* is_packed) {
+      const StorageView* weight = model.get_variable_if_exists(scope + "/weight_packed");
+      if (weight) {
+        *is_packed = true;
+        return *weight;
+      }
+      *is_packed = false;
+      return model.get_variable(scope + "/weight");
+    }
+
     Dense::Dense(const models::Model& model, const std::string& scope)
-      : _weight(model.get_variable(scope + "/weight"))
+      : _packed_weight(false)
+      , _weight(get_linear_weight(model, scope, &_packed_weight))
       , _bias(model.get_variable_if_exists(scope + "/bias"))
       , _qscale(model.get_variable_if_exists(scope + "/weight_scale"))
       , _u8_shift_compensation(model.get_variable_if_exists(scope + "/weight_compensation"))
@@ -48,10 +61,12 @@ namespace ctranslate2 {
       , _partial_bias(_weight.device(), DataType::FLOAT)
       , _partial_qscale(_weight.device(), DataType::FLOAT)
       , _partial_u8_shift_compensation(_weight.device(), DataType::INT32)
-      , _gemm_op(1, 0, false, true) {
+      , _gemm_op(1, 0, false, true, false, _packed_weight) {
     }
 
     void Dense::mask_weights(const StorageView& index) {
+      if (_packed_weight)
+        throw std::runtime_error("Can't mask pre-packed weight");
       ops::Gather()(_weight, index, _partial_weight);
       if (_u8_shift_compensation)
         ops::Gather()(*_u8_shift_compensation, index, _partial_u8_shift_compensation);

--- a/src/models/transformer.cc
+++ b/src/models/transformer.cc
@@ -62,6 +62,12 @@ namespace ctranslate2 {
       return is_quantizable(variable_name) && variable_name.find("embeddings") == std::string::npos;
     }
 
+    bool TransformerModel::is_packable(const std::string& variable_name) const {
+      // Disallow packing for the last linear layer which can be dynamically masked.
+      return (is_linear_weight(variable_name)
+              && variable_name.find("projection") == std::string::npos);
+    }
+
     void TransformerModel::register_variable(const std::string& name, StorageView& variable) {
       std::string var_name = name;
       if (_spec_revision == 1)

--- a/src/ops/gemm.cc
+++ b/src/ops/gemm.cc
@@ -7,6 +7,7 @@ namespace ctranslate2 {
 
     template <Device D, typename In, typename Out>
     static void run_gemm(const StorageView& a, const StorageView& b, const StorageView* c,
+                         bool a_is_packed, bool b_is_packed,
                          bool transpose_a, bool transpose_b,
                          dim_t m, dim_t n, dim_t k,
                          float alpha, float beta,
@@ -32,6 +33,7 @@ namespace ctranslate2 {
       }
 
       primitives<D>::gemm(a_data, b_data,
+                          a_is_packed, b_is_packed,
                           transpose_a, transpose_b,
                           m, n, k,
                           alpha, beta,
@@ -40,11 +42,18 @@ namespace ctranslate2 {
     }
 
 
-    Gemm::Gemm(float alpha, float beta, bool trans_a, bool trans_b)
+    Gemm::Gemm(float alpha,
+               float beta,
+               bool trans_a,
+               bool trans_b,
+               bool a_is_packed,
+               bool b_is_packed)
       : _alpha(alpha)
       , _beta(beta)
       , _trans_a(trans_a)
-      , _trans_b(trans_b) {
+      , _trans_b(trans_b)
+      , _a_is_packed(a_is_packed)
+      , _b_is_packed(b_is_packed) {
     }
 
     void Gemm::operator()(const StorageView& a,
@@ -80,6 +89,7 @@ namespace ctranslate2 {
       case DataType::INT8:
         DEVICE_DISPATCH(a.device(),
                         (run_gemm<D, int8_t, int32_t>(a, b, c,
+                                                      _a_is_packed, _b_is_packed,
                                                       _trans_a, _trans_b,
                                                       m, n, k,
                                                       _alpha, _beta,
@@ -91,6 +101,7 @@ namespace ctranslate2 {
         if (a.device() != Device::CPU)
           throw std::invalid_argument("INT16 GEMM is only supported on CPU");
         run_gemm<Device::CPU, int16_t, int32_t>(a, b, c,
+                                                _a_is_packed, _b_is_packed,
                                                 _trans_a, _trans_b,
                                                 m, n, k,
                                                 _alpha, _beta,
@@ -101,6 +112,7 @@ namespace ctranslate2 {
       case DataType::FLOAT:
         DEVICE_DISPATCH(a.device(),
                         (run_gemm<D, float, float>(a, b, c,
+                                                   _a_is_packed, _b_is_packed,
                                                    _trans_a, _trans_b,
                                                    m, n, k,
                                                    _alpha, _beta,

--- a/src/primitives/cuda.cu
+++ b/src/primitives/cuda.cu
@@ -511,6 +511,7 @@ namespace ctranslate2 {
   template<>
   template<>
   void primitives<Device::CUDA>::gemm(const float* a, const float* b,
+                                      bool, bool,
                                       bool transpose_a, bool transpose_b,
                                       dim_t m, dim_t n, dim_t k,
                                       float alpha, float beta,
@@ -538,6 +539,7 @@ namespace ctranslate2 {
   template<>
   template<>
   void primitives<Device::CUDA>::gemm(const int8_t* a, const int8_t* b,
+                                      bool, bool,
                                       bool transpose_a, bool transpose_b,
                                       dim_t m, dim_t n, dim_t k,
                                       float alpha, float beta,

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -22,6 +22,18 @@
 
 namespace ctranslate2 {
 
+  std::string read_string_from_env(const char* var, const std::string& default_value) {
+    const char* value = std::getenv(var);
+    if (!value)
+      return default_value;
+    return value;
+  }
+
+  bool read_bool_from_env(const char* var, const bool default_value) {
+    const std::string value_str = read_string_from_env(var, default_value ? "1" : "0");
+    return value_str == "1" || value_str == "true" || value_str == "TRUE";
+  }
+
 #ifdef WITH_MKL
   static bool mkl_has_fast_int_gemm() {
 #  if __INTEL_MKL__ > 2019 || (__INTEL_MKL__ == 2019 && __INTEL_MKL_UPDATE__ >= 5)


### PR DESCRIPTION
See https://software.intel.com/en-us/articles/introducing-the-new-packed-apis-for-gemm for context.

The implementation is disabled by default as it requires further testing to better determine when it beneficial and when it is not. It can be enabled by setting the environment variable `CT2_USE_EXPERIMENTAL_PACKED_GEMM=1`.