### PR TITLE
Force intra_threads to 1 when running model on GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ The total number of computing threads launched by the process is summarized by t
 num_threads = inter_threads * intra_threads
 ```
 
-Note that these options are only defined for CPU translation. In particular, `inter_threads` is forced to 1 when executing on GPU.
+Note that these options are only defined for CPU translation and are forced to 1 when executing on GPU.
 
 ### Do you provide a translation server?
 


### PR DESCRIPTION
When unset, this option defaults to the number of CPU cores. This
creates unnecessary overhead for the small amount of work that needs
to be done on CPU when running a model on GPU. This work is mostly
related to concatenating and reordering small vectors during beam
search.