### PR TITLE
Add tokenization and detokenization hooks for file translation API

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -76,7 +76,9 @@ stats = translator.translate_file(
     use_vmap: bool = False,
     with_scores: bool = False,
     sampling_topk: int = 1,
-    sampling_temperature: float = 1)
+    sampling_temperature: float = 1,
+    tokenize_fn: callable = None,   # Function with signature: string -> list of strings
+    detokenize_fn: callable = None) # Function with signature: list of strings -> string
 ```
 
 Also see the [`TranslationOptions`](../include/ctranslate2/translator.h) structure for more details about the options.

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -69,6 +69,39 @@ def test_file_translation(tmpdir):
     assert stats[1] == 2  # Number of translated examples.
     assert isinstance(stats[2], float)  # Total time in milliseconds.
 
+def test_raw_file_translation(tmpdir):
+    input_path = str(tmpdir.join("input.txt"))
+    output_path = str(tmpdir.join("output.txt"))
+    with open(input_path, "w") as input_file:
+        input_file.write("آتزمون")
+        input_file.write("\n")
+        input_file.write("آتشيسون")
+        input_file.write("\n")
+
+    translator = ctranslate2.Translator(_get_model_path())
+    tokenize_fn = lambda text: list(text)
+    detokenize_fn = lambda tokens: "".join(tokens)
+    max_batch_size = 4
+
+    with pytest.raises(ValueError):
+        translator.translate_file(
+            input_path, output_path, max_batch_size, tokenize_fn=tokenize_fn)
+    with pytest.raises(ValueError):
+        translator.translate_file(
+            input_path, output_path, max_batch_size, detokenize_fn=detokenize_fn)
+
+    translator.translate_file(
+        input_path,
+        output_path,
+        max_batch_size,
+        tokenize_fn=tokenize_fn,
+        detokenize_fn=detokenize_fn)
+
+    with open(output_path) as output_file:
+        lines = output_file.readlines()
+        assert lines[0].strip() == "atzmon"
+        assert lines[1].strip() == "achison"
+
 def test_empty_translation():
     translator = _get_transliterator()
     assert translator.translate_batch([]) == []


### PR DESCRIPTION
This makes it possible to translate a raw file without saving the intermediate tokenized files.