### PR TITLE
Add ModelReader interface to customize model file loading

### DIFF
--- a/include/ctranslate2/models/sequence_to_sequence.h
+++ b/include/ctranslate2/models/sequence_to_sequence.h
@@ -13,7 +13,7 @@ namespace ctranslate2 {
     public:
       const Vocabulary& get_source_vocabulary() const;
       const Vocabulary& get_target_vocabulary() const;
-      const VocabularyMap& get_vocabulary_map() const;
+      const VocabularyMap* get_vocabulary_map() const;
 
       // Makes new graph to execute this model. Graphs returned by these function
       // should support being executed in parallel without duplicating the model
@@ -22,7 +22,7 @@ namespace ctranslate2 {
       virtual std::unique_ptr<layers::Decoder> make_decoder() const = 0;
 
     protected:
-      SequenceToSequenceModel(const std::string& path, size_t spec_revision);
+      SequenceToSequenceModel(ModelReader& model_reader, size_t spec_revision);
 
       std::unique_ptr<const Vocabulary> _source_vocabulary;
       std::unique_ptr<const Vocabulary> _target_vocabulary;

--- a/include/ctranslate2/models/transformer.h
+++ b/include/ctranslate2/models/transformer.h
@@ -12,7 +12,7 @@ namespace ctranslate2 {
     class TransformerModel : public SequenceToSequenceModel
     {
     public:
-      TransformerModel(const std::string& path, size_t spec_revision, size_t num_heads = 0);
+      TransformerModel(ModelReader& model_reader, size_t spec_revision, size_t num_heads = 0);
       size_t num_heads() const;
       bool with_relative_position() const;
       size_t current_spec_revision() const override;

--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -96,6 +96,8 @@ namespace ctranslate2 {
 
     // Change the model while keeping the same device and compute type as the previous model.
     void set_model(const std::string& model_dir);
+    void set_model(models::ModelReader& model_reader);
+
     void set_model(const std::shared_ptr<const models::Model>& model);
 
     // Detach the model from this translator, which becomes unusable until set_model is called.

--- a/include/ctranslate2/utils.h
+++ b/include/ctranslate2/utils.h
@@ -24,8 +24,6 @@ namespace ctranslate2 {
 
   std::mt19937& get_random_generator();
 
-  bool file_exists(const std::string& path);
-
   void* aligned_alloc(size_t size, size_t alignment);
   void aligned_free(void* ptr);
 

--- a/include/ctranslate2/vocabulary.h
+++ b/include/ctranslate2/vocabulary.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <istream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -15,7 +16,7 @@ namespace ctranslate2 {
     static const std::string bos_token;
     static const std::string eos_token;
 
-    Vocabulary(const std::string& path);
+    Vocabulary(std::istream& in);
 
     const std::string& to_token(size_t id) const;
     size_t to_id(const std::string& token) const;

--- a/include/ctranslate2/vocabulary_map.h
+++ b/include/ctranslate2/vocabulary_map.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <istream>
 #include <set>
 #include <unordered_map>
 #include <string>
@@ -17,7 +18,7 @@ namespace ctranslate2 {
   // and provides methods to map input tokens to possible target tokens.
   class VocabularyMap {
   public:
-    VocabularyMap(const std::string& map_path, const Vocabulary& vocabulary);
+    VocabularyMap(std::istream& map_file, const Vocabulary& vocabulary);
 
     bool empty() const;
 

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -8,6 +8,8 @@
 namespace ctranslate2 {
   namespace models {
 
+    static const std::string binary_file = "model.bin";
+
     template <typename T>
     T consume(std::istream& in) {
       T val;
@@ -137,7 +139,7 @@ namespace ctranslate2 {
     }
 
 
-    Model::Model(const std::string&, size_t spec_revision)
+    Model::Model(ModelReader&, size_t spec_revision)
       : _spec_revision(spec_revision) {
     }
 
@@ -397,7 +399,7 @@ namespace ctranslate2 {
       }
     }
 
-    static Model* create_model(const std::string& path,
+    static Model* create_model(ModelReader& model_reader,
                                const std::string& spec,
                                size_t spec_revision) {
       Model* model = nullptr;
@@ -406,11 +408,11 @@ namespace ctranslate2 {
       // compatibility. Now all Transformer variants are saved under TransformerSpec.
 
       if (spec.empty() || spec == "TransformerBase")
-        model = new TransformerModel(path, spec_revision, /*num_heads=*/8);
+        model = new TransformerModel(model_reader, spec_revision, /*num_heads=*/8);
       else if (spec == "TransformerBig")
-        model = new TransformerModel(path, spec_revision, /*num_heads=*/16);
+        model = new TransformerModel(model_reader, spec_revision, /*num_heads=*/16);
       else if (spec == "TransformerSpec")
-        model = new TransformerModel(path, spec_revision);
+        model = new TransformerModel(model_reader, spec_revision);
       else
         throw std::invalid_argument("Unsupported model spec " + spec);
 
@@ -443,10 +445,17 @@ namespace ctranslate2 {
                                              Device device,
                                              int device_index,
                                              ComputeType compute_type) {
-      const std::string model_path = path + "/model.bin";
-      std::ifstream model_file(model_path, std::ios_base::in | std::ios_base::binary);
-      if (!model_file.is_open())
-        throw std::runtime_error("failed to load the model " + model_path);
+      ModelFileReader model_reader(path);
+      return load(model_reader, device, device_index, compute_type);
+    }
+
+    std::shared_ptr<const Model> Model:: load(ModelReader& model_reader,
+                                              Device device,
+                                              int device_index,
+                                              ComputeType compute_type) {
+      std::unique_ptr<std::istream> model_file_ptr = model_reader.get_required_file(binary_file,
+                                                                                    /*binary=*/true);
+      std::istream& model_file = *model_file_ptr;
 
       // See the model serialization in python/ctranslate2/specs/model_spec.py.
       const auto binary_version = consume<uint32_t>(model_file);
@@ -461,7 +470,7 @@ namespace ctranslate2 {
         spec_revision = 1;
       }
 
-      Model* model = create_model(path, spec, spec_revision);
+      Model* model = create_model(model_reader, spec, spec_revision);
       model->set_device(device, device_index);
       model->set_compute_type(compute_type);
 
@@ -512,7 +521,37 @@ namespace ctranslate2 {
     }
 
     bool contains_model(const std::string& path) {
-      return file_exists(path + "/model.bin");
+      return bool(ModelFileReader(path).get_file(binary_file));
+    }
+
+
+    std::unique_ptr<std::istream> ModelReader::get_required_file(const std::string& filename,
+                                                                 const bool binary) {
+      std::unique_ptr<std::istream> file = get_file(filename, binary);
+      if (!file)
+        throw std::runtime_error("Unable to open file '" + filename
+                                 + "' in model '" + get_model_id() + "'");
+      return file;
+    }
+
+
+    ModelFileReader::ModelFileReader(std::string model_dir, std::string path_separator)
+      : _model_dir(std::move(model_dir))
+      , _path_separator(std::move(path_separator)) {
+    }
+
+    std::string ModelFileReader::get_model_id() const {
+      return _model_dir;
+    }
+
+    std::unique_ptr<std::istream> ModelFileReader::get_file(const std::string& filename,
+                                                            const bool binary) {
+      const std::string path = _model_dir + _path_separator + filename;
+      const std::ios_base::openmode mode = binary ? std::ios_base::binary : std::ios_base::in;
+      std::unique_ptr<std::istream> stream(new std::ifstream(path, mode));
+      if (!stream || !(*stream))
+        return nullptr;
+      return stream;
     }
 
   }

--- a/src/models/sequence_to_sequence.cc
+++ b/src/models/sequence_to_sequence.cc
@@ -3,15 +3,35 @@
 namespace ctranslate2 {
   namespace models {
 
-    SequenceToSequenceModel::SequenceToSequenceModel(const std::string& path, size_t spec_revision)
-      : Model(path, spec_revision) {
-      try {
-        _shared_vocabulary.reset(new Vocabulary(path + "/shared_vocabulary.txt"));
-      } catch (std::exception&) {
-        _source_vocabulary.reset(new Vocabulary(path + "/source_vocabulary.txt"));
-        _target_vocabulary.reset(new Vocabulary(path + "/target_vocabulary.txt"));
+    static const std::string shared_vocabulary_file = "shared_vocabulary.txt";
+    static const std::string source_vocabulary_file = "source_vocabulary.txt";
+    static const std::string target_vocabulary_file = "target_vocabulary.txt";
+    static const std::string vmap_file = "vmap.txt";
+
+    SequenceToSequenceModel::SequenceToSequenceModel(ModelReader& model_reader, size_t spec_revision)
+      : Model(model_reader, spec_revision) {
+      {
+        auto shared_vocabulary = model_reader.get_file(shared_vocabulary_file);
+        if (shared_vocabulary) {
+          _shared_vocabulary.reset(new Vocabulary(*shared_vocabulary));
+        } else {
+          {
+            auto source_vocabulary = model_reader.get_required_file(source_vocabulary_file);
+            _source_vocabulary.reset(new Vocabulary(*source_vocabulary));
+          }
+          {
+            auto target_vocabulary = model_reader.get_required_file(target_vocabulary_file);
+            _target_vocabulary.reset(new Vocabulary(*target_vocabulary));
+          }
+        }
       }
-      _vocabulary_map.reset(new VocabularyMap(path + "/vmap.txt", get_target_vocabulary()));
+
+      {
+        auto vmap = model_reader.get_file(vmap_file);
+        if (vmap) {
+          _vocabulary_map.reset(new VocabularyMap(*vmap, get_target_vocabulary()));
+        }
+      }
     }
 
     const Vocabulary& SequenceToSequenceModel::get_source_vocabulary() const {
@@ -22,8 +42,8 @@ namespace ctranslate2 {
       return _shared_vocabulary ? *_shared_vocabulary : *_target_vocabulary;
     }
 
-    const VocabularyMap& SequenceToSequenceModel::get_vocabulary_map() const {
-      return *_vocabulary_map;
+    const VocabularyMap* SequenceToSequenceModel::get_vocabulary_map() const {
+      return _vocabulary_map.get();
     }
 
   }

--- a/src/models/transformer.cc
+++ b/src/models/transformer.cc
@@ -34,10 +34,10 @@ namespace ctranslate2 {
       return name;
     }
 
-    TransformerModel::TransformerModel(const std::string& path,
+    TransformerModel::TransformerModel(ModelReader& model_reader,
                                        size_t spec_revision,
                                        size_t num_heads)
-      : SequenceToSequenceModel(path, spec_revision)
+      : SequenceToSequenceModel(model_reader, spec_revision)
       , _num_heads(num_heads) {
     }
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1,6 +1,5 @@
 #include "ctranslate2/utils.h"
 
-#include <sys/stat.h>
 #include <chrono>
 #include <cstdlib>
 
@@ -111,11 +110,6 @@ namespace ctranslate2 {
     static thread_local std::mt19937 generator(
       std::chrono::system_clock::now().time_since_epoch().count());
     return generator;
-  }
-
-  bool file_exists(const std::string& path) {
-    struct stat buffer;
-    return stat(path.c_str(), &buffer) == 0;
   }
 
   void* aligned_alloc(size_t size, size_t alignment) {

--- a/src/vocabulary.cc
+++ b/src/vocabulary.cc
@@ -13,10 +13,7 @@ namespace ctranslate2 {
   // memory upfront and avoid multiple re-allocations and copies.
   constexpr size_t VOCABULARY_SIZE_HINT = 50000;
 
-  Vocabulary::Vocabulary(const std::string& path) {
-    std::ifstream in(path);
-    if (!in.is_open())
-      throw std::invalid_argument("Unable to open the vocabulary file `" + path + "`");
+  Vocabulary::Vocabulary(std::istream& in) {
     _token_to_id.reserve(VOCABULARY_SIZE_HINT);
     _id_to_token.reserve(VOCABULARY_SIZE_HINT);
     std::string line;

--- a/src/vocabulary_map.cc
+++ b/src/vocabulary_map.cc
@@ -4,12 +4,8 @@
 
 namespace ctranslate2 {
 
-  VocabularyMap::VocabularyMap(const std::string& map_path, const Vocabulary& vocabulary)
+  VocabularyMap::VocabularyMap(std::istream& map_file, const Vocabulary& vocabulary)
     : _vocabulary_size(vocabulary.size()) {
-    std::ifstream map_file(map_path);
-    if (!map_file.is_open())
-      return;
-
     std::string line;
     while (std::getline(map_file, line)) {
       std::string token;


### PR DESCRIPTION
@panosk Can you look if you can implement your loading logic based on the `ModelReader` interface? You would need to override 2 methods:

* `get_model_id`: returns a string identifying the model to be read (name, path, location, etc.)
* `get_file`: given a filename in the model directory, returns an input stream over its content

(See also the `ModelFileReader` as an example.)

If I understood your use case correctly, you should be able to comply to this interface. Let me know.

Closes #192.