### PR TITLE
Generalize GEMM output rescaling to other input transpositions

### DIFF
--- a/include/ctranslate2/ops/dequantize.h
+++ b/include/ctranslate2/ops/dequantize.h
@@ -8,10 +8,14 @@ namespace ctranslate2 {
     class Dequantize : public BinaryOp {
     public:
       void operator()(const StorageView& x, const StorageView& scale, StorageView& y) const override;
-      void operator()(const StorageView& gemm_output,
-                      const StorageView& input_scale,
-                      const StorageView& weight_scale,
-                      StorageView& output) const;
+
+      // Rescales the int32 GEMM output to float32, given the input scales.
+      void operator()(const StorageView& c,
+                      const StorageView& a_scale,
+                      const StorageView& b_scale,
+                      const bool transpose_a,
+                      const bool transpose_b,
+                      StorageView& y) const;
 
     };
 

--- a/include/ctranslate2/primitives/primitives.h
+++ b/include/ctranslate2/primitives/primitives.h
@@ -158,9 +158,11 @@ namespace ctranslate2 {
     static void dequantize_batch(const T* x, const float* scale, float* y,
                                  dim_t x_size, dim_t scale_size, float shift = 0);
 
-    static void rescale_output(const int32_t* x,
-                               const float* input_scales,
-                               const float* weigh_scales,
+    static void rescale_output(const int32_t* c,
+                               const float* a_scales,
+                               const float* b_scales,
+                               const bool transpose_a,
+                               const bool transpose_b,
                                float* y,
                                dim_t batch_size,
                                dim_t depth);

--- a/src/layers/common.cc
+++ b/src/layers/common.cc
@@ -104,7 +104,12 @@ namespace ctranslate2 {
         StorageView qoutput(DataType::INT32, device);
         ops::Quantize()(input, qinput, qinput_scale, _u8_shift);
         _gemm_op(qinput, *weight, qoutput, compensation);
-        ops::Dequantize()(qoutput, qinput_scale, *qscale, output);
+        ops::Dequantize()(qoutput,
+                          qinput_scale,
+                          *qscale,
+                          /*trans_a=*/false,
+                          /*trans_b=*/true,
+                          output);
       } else {
         _gemm_op(input, *weight, output);
       }

--- a/src/primitives/cpu.cc
+++ b/src/primitives/cpu.cc
@@ -392,9 +392,11 @@ namespace ctranslate2 {
   }
 
   template<>
-  void primitives<Device::CPU>::rescale_output(const int32_t* x,
-                                               const float* input_scales,
-                                               const float* weight_scales,
+  void primitives<Device::CPU>::rescale_output(const int32_t* c,
+                                               const float* a_scales,
+                                               const float* b_scales,
+                                               const bool transpose_a,
+                                               const bool transpose_b,
                                                float* y,
                                                dim_t batch_size,
                                                dim_t depth) {
@@ -402,7 +404,9 @@ namespace ctranslate2 {
     for (dim_t i = 0; i < batch_size; ++i) {
       for (dim_t j = 0; j < depth; ++j) {
         const dim_t index = j + i * depth;
-        y[index] = static_cast<float>(x[index]) / (input_scales[i] * weight_scales[j]);
+        const float a_scale = transpose_a ? a_scales[j] : a_scales[i];
+        const float b_scale = transpose_b ? b_scales[j] : b_scales[i];
+        y[index] = static_cast<float>(c[index]) / (a_scale * b_scale);
       }
     }
   }

--- a/tests/benchmark_ops.cc
+++ b/tests/benchmark_ops.cc
@@ -89,7 +89,7 @@ void benchmark_dequantize(Device device) {
   StorageView weight_scale({1536}, DataType::FLOAT, device);
   StorageView y(device);
   const ops::Dequantize dequantize_op{};
-  BENCHMARK(dequantize_op(x, input_scale, weight_scale, y), 100000);
+  BENCHMARK(dequantize_op(x, input_scale, weight_scale, false, true, y), 100000);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
The previous implementation assumed `(!transpose_a && transpose_b)`.