### PR TITLE
Add framework for manual vectorization and automatic dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(ctranslate2)
 option(WITH_MKL "Compile with Intel MKL backend" ON)
 option(WITH_CUDA "Compile with CUDA backend" OFF)
 option(WITH_TENSORRT "Compile with TensorRT (required for TopK with k > 1)" ON)
+option(ENABLE_CPU_DISPATCH "Compile CPU kernels for multiple ISA and dispatch at runtime" ON)
 option(ENABLE_PROFILING "Compile with profiling support" OFF)
 option(LIB_ONLY "Do not compile clients" OFF)
 option(WITH_TESTS "Compile the tests" OFF)
@@ -59,10 +60,14 @@ find_package(Threads)
 
 set(INCLUDE_DIRECTORIES
   ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/src
   )
 set(SOURCES
   src/decoding.cc
   src/devices.cc
+  src/cpu/cpu_info.cc
+  src/cpu/cpu_isa.cc
+  src/cpu/kernels.cc
   src/layers/attention.cc
   src/layers/decoder.cc
   src/layers/common.cc
@@ -111,6 +116,29 @@ set(LIBRARIES
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
   )
+
+macro(ct2_compile_kernels_for_isa isa flag)
+  configure_file(
+    src/cpu/kernels.cc
+    ${CMAKE_CURRENT_BINARY_DIR}/kernels_${isa}.cc
+    COPYONLY)
+  set_source_files_properties(
+    ${CMAKE_CURRENT_BINARY_DIR}/kernels_${isa}.cc
+    PROPERTIES COMPILE_FLAGS ${flag})
+  list(APPEND SOURCES ${CMAKE_CURRENT_BINARY_DIR}/kernels_${isa}.cc)
+endmacro()
+
+if(ENABLE_CPU_DISPATCH)
+  message(STATUS "Compiling for multiple CPU ISA and enabling runtime dispatch")
+  add_definitions(-DCT2_WITH_CPU_DISPATCH)
+  if(WIN32)
+    ct2_compile_kernels_for_isa(avx "/arch:AVX")
+    ct2_compile_kernels_for_isa(avx2 "/arch:AVX2")
+  else()
+    ct2_compile_kernels_for_isa(avx "-mavx")
+    ct2_compile_kernels_for_isa(avx2 "-mavx2")
+  endif()
+endif()
 
 if(NOT OPENMP_RUNTIME STREQUAL "NONE")
   if(NOT WIN32)

--- a/src/cpu/cpu_info.cc
+++ b/src/cpu/cpu_info.cc
@@ -1,0 +1,95 @@
+#include "cpu_info.h"
+
+#include <string>
+
+#ifdef _WIN32
+#  include <intrin.h>
+#  include <immintrin.h>
+#else
+#  include <cpuid.h>
+#endif
+
+namespace ctranslate2 {
+  namespace cpu {
+
+    static void get_cpuid(unsigned int eax_in, unsigned int* data) {
+#ifdef _WIN32
+      __cpuid(reinterpret_cast<int*>(data), static_cast<int>(eax_in));
+#else
+      __cpuid(eax_in, data[0], data[1], data[2], data[3]);
+#endif
+    }
+
+    static void get_cpuid_ex(unsigned int eax_in, unsigned int ecx_in, unsigned int* data) {
+#ifdef _WIN32
+      __cpuidex(reinterpret_cast<int*>(data), static_cast<int>(eax_in), static_cast<int>(ecx_in));
+#else
+      __cpuid_count(eax_in, ecx_in, data[0], data[1], data[2], data[3]);
+#endif
+    }
+
+    static uint64_t get_bv()
+    {
+#ifdef _WIN32
+      return _xgetbv(0);
+#else
+      unsigned int eax, edx;
+      __asm__ volatile("xgetbv" : "=a"(eax), "=d"(edx) : "c"(0));
+      return (static_cast<uint64_t>(edx) << 32) | eax;
+#endif
+    }
+
+    struct CPUInfo {
+      std::string vendor;
+      bool sse41 = false;
+      bool avx = false;
+      bool avx2 = false;
+
+      CPUInfo() {
+        unsigned int data[4];
+        const unsigned int& eax = data[0];
+        const unsigned int& ebx = data[1];
+        const unsigned int& ecx = data[2];
+        const unsigned int& edx = data[3];
+
+        get_cpuid(0, data);
+        const unsigned int max_num = eax;
+        vendor = (std::string(reinterpret_cast<const char*>(&ebx), 4)
+                  + std::string(reinterpret_cast<const char*>(&edx), 4)
+                  + std::string(reinterpret_cast<const char*>(&ecx), 4));
+
+        get_cpuid(1, data);
+        sse41 = ecx & (1 << 19);
+        const bool osxsave = ecx & (1 << 27);
+        if (osxsave && (get_bv() & 6) == 6) {
+          avx = ecx & (1 << 28);
+        }
+
+        if (max_num >= 7) {
+          get_cpuid_ex(7, 0, data);
+          avx2 = avx && (ebx & (1 << 5));
+        }
+      }
+
+    };
+
+    static CPUInfo cpu_info;
+
+    bool cpu_is_intel() {
+      return cpu_info.vendor == "GenuineIntel";
+    }
+
+    bool cpu_supports_sse41() {
+      return cpu_info.sse41;
+    }
+
+    bool cpu_supports_avx() {
+      return cpu_info.avx;
+    }
+
+    bool cpu_supports_avx2() {
+      return cpu_info.avx2;
+    }
+
+  }
+}

--- a/src/cpu/cpu_info.h
+++ b/src/cpu/cpu_info.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace ctranslate2 {
+  namespace cpu {
+
+    // Functions returning some info about the current CPU.
+
+    bool cpu_is_intel();
+    bool cpu_supports_sse41();
+    bool cpu_supports_avx();
+    bool cpu_supports_avx2();
+
+  }
+}

--- a/src/cpu/cpu_isa.cc
+++ b/src/cpu/cpu_isa.cc
@@ -1,0 +1,55 @@
+#include "cpu_isa.h"
+
+#include "ctranslate2/utils.h"
+#include "cpu_info.h"
+
+namespace ctranslate2 {
+  namespace cpu {
+
+    static CpuIsa try_isa(const std::string& name, CpuIsa cpu_isa, bool supported) {
+#ifdef CT2_WITH_CPU_DISPATCH
+      if (!supported) {
+        throw std::invalid_argument("The CPU does not support " + name);
+      } else {
+        return cpu_isa;
+      }
+#else
+      (void)cpu_isa;
+      (void)supported;
+      throw std::invalid_argument("This CTranslate2 binary was not compiled with "
+                                  + name + " support");
+#endif
+    }
+
+    static CpuIsa init_isa() {
+      const std::string env_isa = read_string_from_env("CT2_FORCE_CPU_ISA");
+      if (!env_isa.empty()) {
+        if (env_isa == "AVX2") {
+          return try_isa(env_isa, CpuIsa::AVX2, cpu_supports_avx2());
+        } else if (env_isa == "AVX") {
+          return try_isa(env_isa, CpuIsa::AVX, cpu_supports_avx());
+        } else if (env_isa == "GENERIC") {
+          return CpuIsa::GENERIC;
+        } else {
+          throw std::invalid_argument("Invalid CPU ISA: " + env_isa);
+        }
+      }
+
+#ifdef CT2_WITH_CPU_DISPATCH
+      if (cpu_supports_avx2()) {
+        return CpuIsa::AVX2;
+      } else if (cpu_supports_avx()) {
+        return CpuIsa::AVX;
+      }
+#endif
+
+      return CpuIsa::GENERIC;
+    }
+
+    CpuIsa get_cpu_isa() {
+      static CpuIsa cpu_isa = init_isa();
+      return cpu_isa;
+    }
+
+  }
+}

--- a/src/cpu/cpu_isa.h
+++ b/src/cpu/cpu_isa.h
@@ -1,0 +1,44 @@
+#pragma once
+
+namespace ctranslate2 {
+  namespace cpu {
+
+    enum class CpuIsa {
+      GENERIC,
+      AVX,
+      AVX2,
+    };
+
+    // Returns the CPU ISA to dispatch to.
+    CpuIsa get_cpu_isa();
+
+  }
+}
+
+#define CPU_ISA_CASE(CPU_ISA, STMTS)            \
+  case CPU_ISA: {                               \
+    const cpu::CpuIsa ISA = CPU_ISA;            \
+    STMTS;                                      \
+    break;                                      \
+  }
+
+#define CPU_ISA_DEFAULT(STMTS)                          \
+  default: {                                            \
+    const cpu::CpuIsa ISA = cpu::CpuIsa::GENERIC;       \
+    STMTS;                                              \
+    break;                                              \
+  }
+
+#ifdef CT2_WITH_CPU_DISPATCH
+#  define CPU_ISA_DISPATCH(STMTS)                             \
+  switch (cpu::get_cpu_isa()) {                               \
+    CPU_ISA_CASE(cpu::CpuIsa::AVX2, SINGLE_ARG(STMTS))        \
+    CPU_ISA_CASE(cpu::CpuIsa::AVX, SINGLE_ARG(STMTS))         \
+    CPU_ISA_DEFAULT(SINGLE_ARG(STMTS))                        \
+  }
+#else
+#  define CPU_ISA_DISPATCH(STMTS)                             \
+  switch (cpu::get_cpu_isa()) {                               \
+    CPU_ISA_DEFAULT(SINGLE_ARG(STMTS))                        \
+  }
+#endif

--- a/src/cpu/kernels.cc
+++ b/src/cpu/kernels.cc
@@ -1,0 +1,135 @@
+#include "cpu/kernels.h"
+
+#if defined(__AVX2__)
+#  define TARGET_ISA CpuIsa::AVX2
+#  include "cpu/vec_avx.h"
+#elif defined(__AVX__)
+#  define TARGET_ISA CpuIsa::AVX
+#  include "cpu/vec_avx.h"
+#else
+#  define TARGET_ISA CpuIsa::GENERIC
+#  include "cpu/vec.h"
+#endif
+
+namespace ctranslate2 {
+  namespace cpu {
+
+    template <dim_t vec_width, typename Function>
+    static void vectorized_iter(dim_t size, const Function& func) {
+      const dim_t num_trailing = size % vec_width;
+      const dim_t num_vecs = num_trailing == 0 ? size : size - num_trailing;
+
+      for (dim_t i = 0; i < num_vecs; i += vec_width) {
+        func(i, vec_width);
+      }
+
+      if (num_trailing != 0) {
+        func(num_vecs, num_trailing);
+      }
+    }
+
+    template <CpuIsa ISA, typename T, typename Function>
+    static void vectorized_unary_transform(const T* x, T* y, dim_t size, const Function& func) {
+      vectorized_iter<Vec<T, ISA>::width>(size,
+                                          [x, y, &func](dim_t i, dim_t width) {
+                                            const auto v = Vec<T, ISA>::load(x + i, width);
+                                            Vec<T, ISA>::store(func(v), y + i, width);
+                                          });
+    }
+
+    template <CpuIsa ISA, typename T, typename Function>
+    static void vectorized_binary_transform(const T* a,
+                                            const T* b,
+                                            T* c,
+                                            dim_t size,
+                                            const Function& func) {
+      vectorized_iter<Vec<T, ISA>::width>(size,
+                                          [a, b, c, &func](dim_t i, dim_t width) {
+                                            const auto v1 = Vec<T, ISA>::load(a + i, width);
+                                            const auto v2 = Vec<T, ISA>::load(b + i, width);
+                                            Vec<T, ISA>::store(func(v1, v2), c + i, width);
+                                          });
+    }
+
+    template <CpuIsa ISA, typename T>
+    void rcp(const T* x, T* y, dim_t size) {
+      vectorized_unary_transform<ISA>(x, y, size, Vec<T, ISA>::rcp);
+    }
+
+    template <CpuIsa ISA, typename T>
+    void add(T a, const T* x, T* y, dim_t size) {
+      const auto vec_a = Vec<T, ISA>::load(a);
+      vectorized_unary_transform<ISA>(x, y, size,
+                                      [vec_a](vec_type<T, ISA> v) {
+                                        return Vec<T, ISA>::add(v, vec_a);
+                                      });
+    }
+
+    template <CpuIsa ISA, typename T>
+    void add(const T* a, const T* b, T* c, dim_t size) {
+      vectorized_binary_transform<ISA>(a, b, c, size, Vec<T, ISA>::add);
+    }
+
+    template <CpuIsa ISA, typename T>
+    void sub(const T* a, const T* b, T* c, dim_t size) {
+      vectorized_binary_transform<ISA>(a, b, c, size, Vec<T, ISA>::sub);
+    }
+
+    template <CpuIsa ISA, typename T>
+    void mul(T a, const T* x, T* y, dim_t size) {
+      const auto vec_a = Vec<T, ISA>::load(a);
+      vectorized_unary_transform<ISA>(x, y, size,
+                                      [vec_a](vec_type<T, ISA> v) {
+                                        return Vec<T, ISA>::mul(v, vec_a);
+                                      });
+    }
+
+    template <CpuIsa ISA, typename T>
+    void mul(const T* a, const T* b, T* c, dim_t size) {
+      vectorized_binary_transform<ISA>(a, b, c, size, Vec<T, ISA>::mul);
+    }
+
+    template <CpuIsa ISA, typename T>
+    void max(T a, const T* x, T* y, dim_t size) {
+      const auto vec_a = Vec<T, ISA>::load(a);
+      vectorized_unary_transform<ISA>(x, y, size,
+                                      [vec_a](vec_type<T, ISA> v) {
+                                        return Vec<T, ISA>::max(v, vec_a);
+                                      });
+    }
+
+    template <CpuIsa ISA, typename T>
+    void max(const T* a, const T* b, T* c, dim_t size) {
+      vectorized_binary_transform<ISA>(a, b, c, size, Vec<T, ISA>::max);
+    }
+
+    template <CpuIsa ISA, typename T>
+    void min(T a, const T* x, T* y, dim_t size) {
+      const auto vec_a = Vec<T, ISA>::load(a);
+      vectorized_unary_transform<ISA>(x, y, size,
+                                      [vec_a](vec_type<T, ISA> v) {
+                                        return Vec<T, ISA>::min(v, vec_a);
+                                      });
+    }
+
+    template <CpuIsa ISA, typename T>
+    void min(const T* a, const T* b, T* c, dim_t size) {
+      vectorized_binary_transform<ISA>(a, b, c, size, Vec<T, ISA>::min);
+    }
+
+#define DECLARE_IMPL(T)                                                 \
+    template void rcp<TARGET_ISA>(const T* x, T* y, dim_t size);        \
+    template void add<TARGET_ISA>(T a, const T* x, T* y, dim_t size);   \
+    template void add<TARGET_ISA>(const T* a, const T* b, T* c, dim_t size); \
+    template void sub<TARGET_ISA>(const T* a, const T* b, T* c, dim_t size); \
+    template void mul<TARGET_ISA>(T a, const T* x, T* y, dim_t size);   \
+    template void mul<TARGET_ISA>(const T* a, const T* b, T* c, dim_t size); \
+    template void max<TARGET_ISA>(T a, const T* x, T* y, dim_t size);   \
+    template void max<TARGET_ISA>(const T* a, const T* b, T* c, dim_t size); \
+    template void min<TARGET_ISA>(T a, const T* x, T* y, dim_t size);   \
+    template void min<TARGET_ISA>(const T* a, const T* b, T* c, dim_t size);
+
+    DECLARE_ALL_TYPES(DECLARE_IMPL)
+
+  }
+}

--- a/src/cpu/kernels.h
+++ b/src/cpu/kernels.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "ctranslate2/types.h"
+#include "cpu_isa.h"
+
+namespace ctranslate2 {
+  namespace cpu {
+
+    template <CpuIsa ISA, typename T>
+    void rcp(const T* x, T* y, dim_t size);
+
+    template <CpuIsa ISA, typename T>
+    void add(T a, const T* x, T* y, dim_t size);
+    template <CpuIsa ISA, typename T>
+    void add(const T* a, const T* b, T* c, dim_t size);
+
+    template <CpuIsa ISA, typename T>
+    void sub(const T* a, const T* b, T* c, dim_t size);
+
+    template <CpuIsa ISA, typename T>
+    void mul(T a, const T* x, T* y, dim_t size);
+    template <CpuIsa ISA, typename T>
+    void mul(const T* a, const T* b, T* c, dim_t size);
+
+    template <CpuIsa ISA, typename T>
+    void max(T a, const T* x, T* y, dim_t size);
+    template <CpuIsa ISA, typename T>
+    void max(const T* a, const T* b, T* c, dim_t size);
+
+    template <CpuIsa ISA, typename T>
+    void min(T a, const T* x, T* y, dim_t size);
+    template <CpuIsa ISA, typename T>
+    void min(const T* a, const T* b, T* c, dim_t size);
+
+  }
+}

--- a/src/cpu/vec.h
+++ b/src/cpu/vec.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <algorithm>
+
+#include "ctranslate2/types.h"
+
+namespace ctranslate2 {
+  namespace cpu {
+
+    // Interface for vectorized types.
+    template <typename T, CpuIsa ISA>
+    struct Vec {
+
+      using value_type = T;
+      static constexpr dim_t width = 1;
+
+      static value_type load(T value) {
+        return value;
+      }
+
+      static value_type load(const T* ptr, dim_t count = width) {
+        (void)count;
+        return *ptr;
+      }
+
+      static void store(value_type value, T* ptr, dim_t count = width) {
+        (void)count;
+        *ptr = value;
+      }
+
+      static value_type rcp(value_type a) {
+        return static_cast<T>(1) / a;
+      }
+
+      static value_type max(value_type a, value_type b) {
+        return std::max(a, b);
+      }
+
+      static value_type min(value_type a, value_type b) {
+        return std::min(a, b);
+      }
+
+      static value_type add(value_type a, value_type b) {
+        return a + b;
+      }
+
+      static value_type sub(value_type a, value_type b) {
+        return a - b;
+      }
+
+      static value_type mul(value_type a, value_type b) {
+        return a * b;
+      }
+
+    };
+
+    template <typename T, CpuIsa ISA>
+    using vec_type = typename Vec<T, ISA>::value_type;
+
+  }
+}

--- a/src/cpu/vec_avx.h
+++ b/src/cpu/vec_avx.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <immintrin.h>
+
+#include "vec.h"
+
+#if defined(__GNUC__)
+#  define __ct2_align32__ __attribute__((aligned(32)))
+#elif defined(_WIN32)
+#  define __ct2_align32__ __declspec(align(32))
+#else
+#  define __ct2_align32__
+#endif
+
+namespace ctranslate2 {
+  namespace cpu {
+
+    template<>
+    struct Vec<float, TARGET_ISA> {
+
+      using value_type = __m256;
+      static constexpr dim_t width = 8;
+
+      static value_type load(float value) {
+        return _mm256_set1_ps(value);
+      }
+
+      static value_type load(const float* ptr, dim_t count = width) {
+        if (count == width) {
+          return _mm256_loadu_ps(ptr);
+        } else {
+          __ct2_align32__ float tmp_values[width];
+          std::fill_n(tmp_values, width, 0);
+          std::copy_n(ptr, count, tmp_values);
+          return _mm256_loadu_ps(tmp_values);
+        }
+      }
+
+      static void store(value_type value, float* ptr, dim_t count = width) {
+        if (count == width) {
+          _mm256_storeu_ps(ptr, value);
+        } else {
+          __ct2_align32__ float tmp_values[width];
+          _mm256_storeu_ps(tmp_values, value);
+          std::copy_n(tmp_values, count, ptr);
+        }
+      }
+
+      static value_type rcp(value_type a) {
+        return _mm256_rcp_ps(a);
+      }
+
+      static value_type max(value_type a, value_type b) {
+        return _mm256_max_ps(a, b);
+      }
+
+      static value_type min(value_type a, value_type b) {
+        return _mm256_min_ps(a, b);
+      }
+
+      static value_type add(value_type a, value_type b) {
+        return _mm256_add_ps(a, b);
+      }
+
+      static value_type sub(value_type a, value_type b) {
+        return _mm256_sub_ps(a, b);
+      }
+
+      static value_type mul(value_type a, value_type b) {
+        return _mm256_mul_ps(a, b);
+      }
+
+    };
+
+  }
+}


### PR DESCRIPTION
This PR adds a proper framework to write vectorized kernels that target multiple CPU architectures. The dispatch is done at runtime based on CPUID output (can also be forced with the environment variable `CT2_FORCE_CPU_ISA`).

More generally this will help writing more vectorized code without relying on Intel MKL.