### PR TITLE
Add vectorized softmax CPU kernel

### DIFF
--- a/src/cpu/kernels.h
+++ b/src/cpu/kernels.h
@@ -48,5 +48,15 @@ namespace ctranslate2 {
     template <CpuIsa ISA, typename T>
     T reduce_amax(const T* x, dim_t size);
 
+    template <CpuIsa ISA>
+    void softmax(const float* input,
+                 const int32_t* lengths,
+                 float* output,
+                 dim_t lengths_size,
+                 dim_t batch_size,
+                 dim_t depth,
+                 bool log,
+                 float epsilon);
+
   }
 }

--- a/src/cpu/vec.h
+++ b/src/cpu/vec.h
@@ -77,7 +77,7 @@ namespace ctranslate2 {
 
     };
 
-    template <typename T, CpuIsa ISA>
+    template <typename T, CpuIsa ISA = CpuIsa::GENERIC>
     using vec_type = typename Vec<T, ISA>::value_type;
 
   }

--- a/src/ops/softmax_cpu.cc
+++ b/src/ops/softmax_cpu.cc
@@ -1,8 +1,6 @@
 #include "ctranslate2/ops/softmax.h"
 
-#include <cmath>
-
-#define EPSILON 0.000001f
+#include "cpu/kernels.h"
 
 namespace ctranslate2 {
   namespace ops {
@@ -11,28 +9,18 @@ namespace ctranslate2 {
     void SoftMax::compute(const StorageView& input,
                           const StorageView* lengths,
                           StorageView& output) const {
-      const dim_t total_depth = input.dim(-1);
-      const dim_t batch_size = input.size() / total_depth;
-      #pragma omp parallel for
-      for (dim_t i = 0; i < batch_size; ++i) {
-        const auto* x = input.data<T>() + (i * total_depth);
-        auto* y = output.data<T>() + (i * total_depth);
-        dim_t depth = total_depth;
-        if (lengths) {
-          // Directly set 0 in output for out of range positions.
-          const dim_t batch_index = i * lengths->dim(0) / batch_size;
-          depth = lengths->at<int32_t>(batch_index);
-          primitives<>::fill(y + depth, static_cast<float>(0), total_depth - depth);
-        }
-        auto max = primitives<>::max(x, depth);
-        primitives<>::sub(max, x, y, depth);
-        primitives<>::exp(y, y, depth);
-        auto sum = primitives<>::sum(y, depth);
-        if (_log)
-          primitives<>::sub(std::log(sum) + max, x, y, depth);
-        else
-          primitives<>::mul(1.f / (sum + EPSILON), y, depth);
-      }
+      constexpr float epsilon = 0.000001f;
+      const dim_t depth = input.dim(-1);
+      const dim_t batch_size = input.size() / depth;
+
+      CPU_ISA_DISPATCH((cpu::softmax<ISA>(input.data<T>(),
+                                          lengths ? lengths->data<int32_t>() : nullptr,
+                                          output.data<T>(),
+                                          lengths ? lengths->dim(0) : 0,
+                                          batch_size,
+                                          depth,
+                                          _log,
+                                          epsilon)));
     }
 
 #define DECLARE_IMPL(T)                                                 \

--- a/src/primitives/cpu.cc
+++ b/src/primitives/cpu.cc
@@ -449,7 +449,7 @@ namespace ctranslate2 {
   void primitives<Device::CPU>::exp(const float* x, float* y, dim_t size) {
 #ifdef WITH_MKL
     if (cpu::mayiuse_mkl())
-      return vmsExp(size, x, y, VML_EP | VML_FTZDAZ_ON | VML_ERRMODE_IGNORE);
+      return vsExp(size, x, y);
 #endif
     CPU_ISA_DISPATCH((cpu::exp<ISA>(x, y, size)));
   }
@@ -458,7 +458,7 @@ namespace ctranslate2 {
   void primitives<Device::CPU>::log(const float* x, float* y, dim_t size) {
 #ifdef WITH_MKL
     if (cpu::mayiuse_mkl())
-      return vmsLn(size, x, y, VML_EP | VML_FTZDAZ_ON | VML_ERRMODE_IGNORE);
+      return vsLn(size, x, y);
 #endif
     CPU_ISA_DISPATCH((cpu::log<ISA>(x, y, size)));
   }


### PR DESCRIPTION
The differences with the previous implementation are the following:

- `exp(x - x_max)` is now computed in one pass.
- For LogSoftMax, intermediate values are no longer written in the output matrix.
- Numerical precision of the exp() function is improved.