### PR TITLE
Upgrade to GCC 8 in CentOS 7 images to build the cli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,8 +289,8 @@ if (WITH_CUDA)
 
     if(NOT MSVC)
       # TensorRT 6 header generates a lot of deprecating warnings. Ignore them.
-      set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -isystem ${TENSORRT_INCLUDE_DIR}")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -isystem ${TENSORRT_INCLUDE_DIR}")
+      set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Wno-deprecated-declarations")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
     endif()
 
     add_definitions(-DWITH_TENSORRT)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ docker pull opennmt/ctranslate2:latest-ubuntu18-gpu
 
 The images include:
 
-* a translation client to directly translate files (only in Ubuntu images)
+* a translation client to directly translate files
 * Python 3 packages (with GPU support)
 * `libctranslate2.so` library development files
 

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -1,9 +1,9 @@
 FROM centos:7 as builder
 
-RUN yum install -y epel-release && \
+RUN yum install -y epel-release centos-release-scl-rh && \
     yum install -y \
-        gcc \
-        gcc-c++ \
+        devtoolset-8-gcc \
+        devtoolset-8-gcc-c++ \
         make \
         python3-devel \
         wget && \
@@ -47,9 +47,9 @@ ENV CTRANSLATE2_ROOT=/root/ctranslate2
 
 RUN mkdir build && \
     cd build && \
+    source scl_source enable devtoolset-8 && \
     cmake -DCMAKE_INSTALL_PREFIX=${CTRANSLATE2_ROOT} \
           -DCMAKE_PREFIX_PATH=${DNNL_DIR} -DWITH_DNNL=ON -DOPENMP_RUNTIME=COMP \
-          -DLIB_ONLY=ON \
           -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" .. && \
     VERBOSE=1 make -j4 && \
     make install
@@ -61,6 +61,7 @@ COPY python python
 WORKDIR /root/ctranslate2-dev/python
 RUN python3 -m pip --no-cache-dir install wheel pybind11==2.4.3 && \
     python3 -m pip freeze | grep pybind11 > /root/ctranslate2/install_requirements.txt && \
+    source scl_source enable devtoolset-8 && \
     python3 setup.py bdist_wheel && \
     python3 setup.py sdist && \
     rm -r build && \
@@ -87,3 +88,5 @@ WORKDIR /opt
 
 ENV CTRANSLATE2_ROOT=/opt/ctranslate2
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CTRANSLATE2_ROOT/lib64
+
+ENTRYPOINT ["/opt/ctranslate2/bin/translate"]

--- a/docker/Dockerfile.centos7-gpu
+++ b/docker/Dockerfile.centos7-gpu
@@ -1,7 +1,9 @@
 FROM nvidia/cuda:10.0-cudnn7-devel-centos7 as builder
 
-RUN yum install -y epel-release && \
+RUN yum install -y epel-release centos-release-scl-rh && \
     yum install -y \
+        devtoolset-8-gcc \
+        devtoolset-8-gcc-c++ \
         gcc \
         gcc-c++ \
         make \
@@ -58,11 +60,12 @@ ENV CTRANSLATE2_ROOT=/root/ctranslate2
 
 RUN mkdir build && \
     cd build && \
+    source scl_source enable devtoolset-8 && \
     cmake -DCMAKE_INSTALL_PREFIX=${CTRANSLATE2_ROOT} \
           -DCMAKE_PREFIX_PATH=${DNNL_DIR} -DWITH_DNNL=ON -DOPENMP_RUNTIME=COMP \
-          -DLIB_ONLY=ON \
           -DWITH_CUDA=ON \
           -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" \
+          -DCUDA_HOST_COMPILER=/usr/bin/cc \
           -DCUDA_NVCC_FLAGS="${CUDA_NVCC_FLAGS}" -DCUDA_ARCH_LIST="${CUDA_ARCH_LIST}" .. && \
     VERBOSE=1 make -j4 && \
     make install
@@ -74,6 +77,7 @@ COPY python python
 WORKDIR /root/ctranslate2-dev/python
 RUN python3 -m pip --no-cache-dir install wheel pybind11==2.4.3 && \
     python3 -m pip freeze | grep pybind11 > /root/ctranslate2/install_requirements.txt && \
+    source scl_source enable devtoolset-8 && \
     python3 setup.py bdist_wheel && \
     python3 setup.py sdist && \
     rm -r build && \
@@ -103,3 +107,5 @@ WORKDIR /opt
 
 ENV CTRANSLATE2_ROOT=/opt/ctranslate2
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CTRANSLATE2_ROOT/lib64
+
+ENTRYPOINT ["/opt/ctranslate2/bin/translate"]


### PR DESCRIPTION
We removed the cli in be25c57b696a67d7398190ed5b723808a805c266 because compiling the library with devtoolset-3 seemed to cause issues in a downstream Docker image. This is apparently no longer an issue when using a more recent devtoolset.

Note that nvcc still requires the GCC version that is shipped with CentOS 7 (see `CUDA_HOST_COMPILER`).