### PR TITLE
Relax StorageView assignment checks

### DIFF
--- a/src/layers/attention.cc
+++ b/src/layers/attention.cc
@@ -186,8 +186,8 @@ namespace ctranslate2 {
           split_heads(values_proj, split_values);
 
           if (cached_keys != nullptr) {
-            swap(*cached_keys, split_keys);
-            swap(*cached_values, split_values);
+            *cached_keys = std::move(split_keys);
+            *cached_values = std::move(split_values);
             split_keys.shallow_copy(*cached_keys);
             split_values.shallow_copy(*cached_values);
           }
@@ -203,13 +203,13 @@ namespace ctranslate2 {
 
         if (cached_keys != nullptr) {
           if (cached_keys->empty()) {
-            swap(*cached_keys, split_keys);
-            swap(*cached_values, split_values);
+            *cached_keys = std::move(split_keys);
+            *cached_values = std::move(split_values);
           } else {
             StorageView& tmp = keys_proj;  // Reuse storage.
-            swap(*cached_keys, tmp);
+            tmp = std::move(*cached_keys);
             ops::Concat(2)({&tmp, &split_keys}, *cached_keys);
-            swap(*cached_values, tmp);
+            tmp = std::move(*cached_values);
             ops::Concat(2)({&tmp, &split_values}, *cached_values);
           }
           split_keys.shallow_copy(*cached_keys);

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -112,9 +112,7 @@ namespace ctranslate2 {
       // Second pass to move variables and update the associated aliases.
       for (auto* variable : variables_to_move) {
         void* prev_buffer = variable->buffer();
-
-        StorageView variable_device = variable->to(device);
-        swap(*variable, variable_device);
+        *variable = variable->to(device);
 
         auto it = buffer_to_aliases.find(prev_buffer);
         if (it != buffer_to_aliases.end()) {
@@ -336,7 +334,7 @@ namespace ctranslate2 {
         quantize_op(tmp_variable, target_variable, *saved_scale);
       }
 
-      swap(variable, target_variable);
+      variable = std::move(target_variable);
     }
 
     void Model::finalize() {
@@ -370,11 +368,9 @@ namespace ctranslate2 {
         } else if (!variable.is_scalar()) {
           // Other parameters may be converted from or to float16 (e.g. bias).
           if (variable.dtype() == DataType::FLOAT && target_dtype == DataType::FLOAT16) {
-            StorageView half_variable = variable.to_float16();
-            swap(variable, half_variable);
+            variable = variable.to_float16();
           } else if (variable.dtype() == DataType::FLOAT16 && target_dtype == DataType::FLOAT) {
-            StorageView float_variable = variable.to_float();
-            swap(variable, float_variable);
+            variable = variable.to_float();
           }
         }
       }

--- a/src/models/transformer.cc
+++ b/src/models/transformer.cc
@@ -268,7 +268,7 @@ namespace ctranslate2 {
       for (size_t l = 0; l < _layers.size(); ++l) {
         (*_layers[l])(input, lengths, output);
         if (l + 1 < _layers.size())
-          swap(input, output);
+          input = std::move(output);
       }
       _output_norm(output, output);
     }
@@ -362,7 +362,7 @@ namespace ctranslate2 {
                       _with_encoder_attention ? &state.at("memory_values_" + l_str) : nullptr,
                       layer_out,
                       l + 1 == _layers.size() ? attention : nullptr);
-        swap(layer_in, layer_out);
+        layer_in = std::move(layer_out);
       }
 
       if (logits) {


### PR DESCRIPTION
Allow assigning a storage that has a different dtype or is on another device.