### PR TITLE
Support pinning translators to CPU cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Some environment variables can be configured to customize the execution:
 * `CT2_CUDA_ALLOW_FLOAT16`: Allow using FP16 computation on GPU even if the device does not have efficient FP16 support.
 * `CT2_CUDA_CACHING_ALLOCATOR_CONFIG`: Tune the CUDA caching allocator (see [Performance](docs/performance.md)).
 * `CT2_FORCE_CPU_ISA`: Force CTranslate2 to select a specific instruction set architecture (ISA). Possible values are: `GENERIC`, `AVX`, `AVX2`. Note: this does not impact backend libraries (such as Intel MKL) which usually have their own environment variables to configure ISA dispatching.
+* `CT2_TRANSLATORS_CORE_OFFSET`: If set to a non negative value, parallel translators are pinned to cores in the range `[offset, offset + inter_threads]`. Requires `intra_threads` to 1.
 * `CT2_USE_EXPERIMENTAL_PACKED_GEMM`: Enable the packed GEMM API for Intel MKL (see [Performance](docs/performance.md)).
 * `CT2_USE_MKL`: Force CTranslate2 to use (or not) Intel MKL. By default, the runtime automatically decides whether to use Intel MKL or not based on the CPU vendor.
 * `CT2_VERBOSE`: Enable some verbose logs to help debugging the run configuration.

--- a/include/ctranslate2/utils.h
+++ b/include/ctranslate2/utils.h
@@ -12,6 +12,7 @@ namespace ctranslate2 {
   bool string_to_bool(const std::string& str);
   std::string read_string_from_env(const char* var, const std::string& default_value = "");
   bool read_bool_from_env(const char* var, const bool default_value = false);
+  int read_int_from_env(const char* var, const int default_value = 0);
 
   bool verbose_mode();
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -40,6 +40,13 @@ namespace ctranslate2 {
     return string_to_bool(read_string_from_env(var, default_value ? "1" : "0"));
   }
 
+  int read_int_from_env(const char* var, const int default_value) {
+    const std::string value = read_string_from_env(var);
+    if (value.empty())
+      return default_value;
+    return std::stoi(value);
+  }
+
   bool verbose_mode() {
     static const bool verbose = read_bool_from_env("CT2_VERBOSE");
     return verbose;


### PR DESCRIPTION
This is useful when translating large files with many parallel translators (inter_threads), like in the WNGT efficiency task.