### PR TITLE
Remove padding when running the encoder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ set(SOURCES
   src/ops/quantize.cc
   src/ops/quantize_cpu.cc
   src/primitives/cpu.cc
+  src/padder.cc
   src/profiler.cc
   src/sampling.cc
   src/storage_view.cc

--- a/include/ctranslate2/layers/attention.h
+++ b/include/ctranslate2/layers/attention.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ctranslate2/layers/common.h"
+#include "ctranslate2/padder.h"
 
 namespace ctranslate2 {
   namespace layers {
@@ -29,7 +30,8 @@ namespace ctranslate2 {
                       StorageView& output,
                       StorageView* cached_keys = nullptr,
                       StorageView* cached_values = nullptr,
-                      StorageView* attention = nullptr) const;
+                      StorageView* attention = nullptr,
+                      const Padder* padder = nullptr) const;
     private:
       const dim_t _num_heads;
       const std::vector<Dense> _linear;

--- a/include/ctranslate2/models/transformer.h
+++ b/include/ctranslate2/models/transformer.h
@@ -3,6 +3,7 @@
 // This file defines the execution engine for a TransformerSpec model.
 
 #include "ctranslate2/layers/layers.h"
+#include "ctranslate2/padder.h"
 
 #include "sequence_to_sequence.h"
 
@@ -61,6 +62,7 @@ namespace ctranslate2 {
       TransformerEncoderLayer(const TransformerModel& model, const std::string& scope);
       void operator()(const StorageView& input,
                       const StorageView& lengths,
+                      const Padder& padder,
                       StorageView& output) const;
     private:
       const layers::MultiHeadAttention _self_attention;

--- a/include/ctranslate2/padder.h
+++ b/include/ctranslate2/padder.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "ops/gather.h"
+#include "storage_view.h"
+
+namespace ctranslate2 {
+
+  // This class can be used to dynamically remove or add padding.
+  // This is useful to save on computation when lengths are very different.
+  class Padder {
+  public:
+    // If max_time is negative, it is set to the maximum length.
+    Padder(const StorageView& lengths, const dim_t max_time = -1);
+
+    // Merge batch and time dimensions and remove padding.
+    void remove_padding(StorageView& x) const;
+
+    // Split first dimension into batch and time dimensions and add padding.
+    void add_padding(StorageView& x) const;
+
+  private:
+    dim_t _batch_size;
+    dim_t _max_time;
+    StorageView _padding_to_flat;
+    StorageView _flat_to_padding;
+    const ops::Gather _gather_op;
+  };
+
+}

--- a/src/padder.cc
+++ b/src/padder.cc
@@ -1,0 +1,59 @@
+#include "ctranslate2/padder.h"
+
+#include <algorithm>
+
+namespace ctranslate2 {
+
+  Padder::Padder(const StorageView& lengths, const dim_t max_time)
+    : _batch_size(lengths.size()) {
+    const std::vector<int32_t> lengths_vec = lengths.to_vector<int32_t>();
+    if (max_time < 0)
+      _max_time = *std::max_element(lengths_vec.begin(), lengths_vec.end());
+    else
+      _max_time = max_time;
+
+    const dim_t max_size = _max_time * _batch_size;
+    std::vector<int32_t> padding_to_flat;
+    std::vector<int32_t> flat_to_padding;
+    padding_to_flat.reserve(max_size);
+    flat_to_padding.reserve(max_size);
+
+    dim_t padding_offset = 0;
+    dim_t no_padding_offset = 0;
+
+    for (dim_t i = 0; i < _batch_size; ++i) {
+      const dim_t length = lengths_vec[i];
+      for (dim_t t = 0; t < length; ++t) {
+        padding_to_flat.push_back(padding_offset + t);
+        flat_to_padding.push_back(no_padding_offset + t);
+      }
+      for (dim_t t = length; t < _max_time; ++t) {
+        flat_to_padding.push_back(no_padding_offset + length - 1);
+      }
+      padding_offset += _max_time;
+      no_padding_offset += length;
+    }
+
+    const Device device = lengths.device();
+    _padding_to_flat = StorageView({no_padding_offset}, padding_to_flat, device);
+    _flat_to_padding = StorageView({padding_offset}, flat_to_padding, device);
+  }
+
+  void Padder::remove_padding(StorageView& x) const {
+    Shape shape = x.shape();
+    shape[1] *= shape[0];
+    shape.erase(shape.begin());
+    x.reshape(shape);
+    _gather_op(x, _padding_to_flat);
+  }
+
+  void Padder::add_padding(StorageView& x) const {
+    _gather_op(x, _flat_to_padding);
+    Shape shape = x.shape();
+    shape[0] /= _batch_size;
+    shape.insert(shape.begin(), _batch_size);
+    x.reshape(shape);
+  }
+
+
+}

--- a/tests/layers_test.cc
+++ b/tests/layers_test.cc
@@ -1,5 +1,6 @@
 #include "test_utils.h"
 #include "ctranslate2/layers/layers.h"
+#include "ctranslate2/padder.h"
 
 TEST(LayerTest, MakeRelativePositions1D) {
   const StorageView positions = layers::make_relative_positions(4, 2, true);
@@ -15,4 +16,20 @@ TEST(LayerTest, MakeRelativePositions2D) {
       0, 1, 2, 3,
       0, 0, 1, 2});
   expect_storage_eq(positions, expected);
+}
+
+TEST(LayerTest, Padder) {
+  const StorageView lengths({3}, std::vector<int32_t>{2, 3, 1});
+  const Padder padder(lengths, /*max_time=*/4);
+
+  StorageView x({3, 4}, std::vector<int32_t>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+  const StorageView wo_padding({6}, std::vector<int32_t>{0, 1, 4, 5, 6, 8});
+  const StorageView w_padding({3, 4}, std::vector<int32_t>{0, 1, 1, 1, 4, 5, 6, 6, 8, 8, 8, 8});
+
+  padder.remove_padding(x);
+  ASSERT_EQ(x.rank(), 1);
+  expect_storage_eq(x, wo_padding);
+  padder.add_padding(x);
+  ASSERT_EQ(x.rank(), 2);
+  expect_storage_eq(x, w_padding);
 }


### PR DESCRIPTION
The time dimension is only required to compute position encoding and attention. For other operations, we can merge the batch and time dimensions and remove padding to save on computation. This is especially beneficial for inputs that have sentences with very different lengths.