### PR TITLE
Remove encoder outputs padding in first decoder step

### DIFF
--- a/include/ctranslate2/layers/attention.h
+++ b/include/ctranslate2/layers/attention.h
@@ -34,6 +34,7 @@ namespace ctranslate2 {
                       const Padder* padder = nullptr) const;
     private:
       const dim_t _num_heads;
+      const bool _self_attention;
       const std::vector<Dense> _linear;
       const LayerNormStrategy _layer_norm_strategy;
       const LayerNorm _layer_norm;

--- a/include/ctranslate2/models/transformer.h
+++ b/include/ctranslate2/models/transformer.h
@@ -83,7 +83,8 @@ namespace ctranslate2 {
                       StorageView* cached_attn_keys,
                       StorageView* cached_attn_values,
                       StorageView& output,
-                      StorageView* attention = nullptr) const;
+                      StorageView* attention = nullptr,
+                      const Padder* padder = nullptr) const;
     private:
       const layers::MultiHeadAttention _self_attention;
       const std::unique_ptr<const layers::MultiHeadAttention> _encoder_attention;

--- a/include/ctranslate2/padder.h
+++ b/include/ctranslate2/padder.h
@@ -9,6 +9,10 @@ namespace ctranslate2 {
   // This is useful to save on computation when lengths are very different.
   class Padder {
   public:
+    static inline bool allow_padding_removal(const Device device, const DataType dtype) {
+      return device == Device::CPU || dtype != DataType::FLOAT16;
+    }
+
     // If max_time is negative, it is set to the maximum length.
     Padder(const StorageView& lengths,
            const dim_t max_time = -1,


### PR DESCRIPTION
Also remove the encoder outputs from the decoder state as it is no longer needed past the first decoding step.