### PR TITLE
Pass translation inputs by value to post() method

### DIFF
--- a/include/ctranslate2/translator_pool.h
+++ b/include/ctranslate2/translator_pool.h
@@ -41,12 +41,12 @@ namespace ctranslate2 {
 
     // Run a translation job asynchronously.
     // With blocking=true it will block if there is already too much work pending.
-    std::future<TranslationOutput> post(const TranslationInput& source,
-                                        const TranslationOptions& options,
+    std::future<TranslationOutput> post(TranslationInput source,
+                                        TranslationOptions options,
                                         bool blocking=false);
-    std::future<TranslationOutput> post(const TranslationInput& source,
-                                        const TranslationInput& target_prefix,
-                                        const TranslationOptions& options,
+    std::future<TranslationOutput> post(TranslationInput source,
+                                        TranslationInput target_prefix,
+                                        TranslationOptions options,
                                         bool blocking=false);
 
     // Translate a stream in parallel.
@@ -82,7 +82,7 @@ namespace ctranslate2 {
         const size_t batch_size_increment = get_batch_size_increment(tokens, options.batch_type);
 
         if (batch_size > 0 && batch_size + batch_size_increment > read_batch_size) {
-          results.emplace(post(batch_tokens, options, true));
+          results.emplace(post(std::move(batch_tokens), options, true));
           batch_tokens.clear();
           batch_size = 0;
           pop_results(false /* blocking */);
@@ -94,7 +94,7 @@ namespace ctranslate2 {
       }
 
       if (!batch_tokens.empty())
-        results.emplace(post(batch_tokens, options, true));
+        results.emplace(post(std::move(batch_tokens), options, true));
 
       pop_results(true /* blocking */);
     }
@@ -184,9 +184,9 @@ namespace ctranslate2 {
 
   private:
     struct TranslationJob {
-      TranslationJob(const TranslationInput& source_,
-                     const TranslationInput& target_prefix_,
-                     const TranslationOptions& options_)
+      TranslationJob(TranslationInput source_,
+                     TranslationInput target_prefix_,
+                     TranslationOptions options_)
         : source(source_)
         , target_prefix(target_prefix_)
         , options(options_) {

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -212,8 +212,8 @@ public:
 
     assert_model_is_ready();
 
-    const auto source_input = batch_to_vector(source);
-    const auto target_prefix_input = batch_to_vector(target_prefix, /*optional=*/true);
+    auto source_input = batch_to_vector(source);
+    auto target_prefix_input = batch_to_vector(target_prefix, /*optional=*/true);
     std::vector<ctranslate2::TranslationResult> results;
 
     {
@@ -235,7 +235,9 @@ public:
       options.return_attention = return_attention;
       options.return_alternatives = return_alternatives;
 
-      results = _translator_pool.post(source_input, target_prefix_input, options).get();
+      results = _translator_pool.post(std::move(source_input),
+                                      std::move(target_prefix_input),
+                                      std::move(options)).get();
     }
 
     py::list py_results(results.size());


### PR DESCRIPTION
2 benefits:

* translation inputs can be moved to the work queue
* this clarifies that post() takes a copy of the inputs