### PR TITLE
Use TopK kernel adapted from FasterTransformer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ project(ctranslate2)
 option(WITH_MKL "Compile with Intel MKL backend" ON)
 option(WITH_DNNL "Compile with DNNL backend" OFF)
 option(WITH_CUDA "Compile with CUDA backend" OFF)
-option(WITH_TENSORRT "Compile with TensorRT (required for TopK with k > 1)" ON)
 option(ENABLE_CPU_DISPATCH "Compile CPU kernels for multiple ISA and dispatch at runtime" ON)
 option(ENABLE_PROFILING "Compile with profiling support" OFF)
 option(LIB_ONLY "Do not compile clients" OFF)
@@ -282,31 +281,6 @@ if (WITH_CUDA)
 
   cuda_select_nvcc_arch_flags(ARCH_FLAGS ${CUDA_ARCH_LIST})
   list(APPEND CUDA_NVCC_FLAGS ${ARCH_FLAGS})
-
-  if(WITH_TENSORRT)
-    find_library(TENSORRT_LIBRARY NAMES nvinfer)
-    find_path(TENSORRT_INCLUDE_DIR NAMES NvInfer.h)
-    if(NOT TENSORRT_LIBRARY OR NOT TENSORRT_INCLUDE_DIR)
-      message(FATAL_ERROR "TensorRT not found")
-    else()
-      message(STATUS "Found TensorRT library: ${TENSORRT_LIBRARY}")
-      message(STATUS "Found TensorRT include directory: ${TENSORRT_INCLUDE_DIR}")
-    endif()
-
-    if(NOT MSVC)
-      # TensorRT 6 header generates a lot of deprecating warnings. Ignore them.
-      set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Wno-deprecated-declarations")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
-    endif()
-
-    add_definitions(-DCT2_WITH_TENSORRT)
-    list(APPEND PRIVATE_INCLUDE_DIRECTORIES
-      ${TENSORRT_INCLUDE_DIR}
-      )
-    list(APPEND LIBRARIES
-      ${TENSORRT_LIBRARY}
-      )
-  endif()
 
   message(STATUS "NVCC compilation flags: ${CUDA_NVCC_FLAGS}")
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The project is production-oriented and comes with [backward compatibility guaran
 * **Parallel translations**<br/>CPU translations can be run efficiently in parallel without duplicating the model data in memory.
 * **Dynamic memory usage**<br/>The memory usage changes dynamically depending on the request size while still meeting performance requirements thanks to caching allocators on both CPU and GPU.
 * **Automatic CPU detection and code dispatch**<br/>The fastest code path is selected at runtime based on the CPU (Intel or AMD) and the supported instruction set architectures (AVX, AVX2, or AVX512).
-* **Ligthweight on disk**<br/>Models can be quantized below 100MB with minimal accuracy loss. A full featured Docker image supporting GPU and CPU requires less than 1GB.
+* **Ligthweight on disk**<br/>Models can be quantized below 100MB with minimal accuracy loss. A full featured Docker image supporting GPU and CPU requires less than 400MB.
 * **Simple integration**<br/>The project has few dependencies and exposes [translation APIs](#translating) in Python and C++ to cover most integration needs.
 * **Interactive decoding**<br/>[Advanced decoding features](docs/decoding.md) allow autocompleting a partial translation and returning alternatives at a specific location in the translation.
 
@@ -266,7 +266,6 @@ The project uses [CMake](https://cmake.org/) for compilation. The following opti
 | WITH_CUDA | **OFF**, ON | Compiles with the CUDA backend |
 | WITH_DNNL | **OFF**, ON | Compiles with the oneDNN backend (a.k.a. DNNL) |
 | WITH_MKL | OFF, **ON** | Compiles with the Intel MKL backend |
-| WITH_TENSORRT | OFF, **ON** | Compiles with TensorRT (required for beam search decoding on GPU) |
 | WITH_TESTS | **OFF**, ON | Compiles the tests |
 
 Some build options require external dependencies:
@@ -277,9 +276,6 @@ Some build options require external dependencies:
   * [oneDNN](https://github.com/oneapi-src/oneDNN) (>=1.5)
 * `-DWITH_CUDA=ON` requires:
   * [cuBLAS](https://developer.nvidia.com/cublas) (>=10.0)
-  * `-DWITH_TENSORRT=ON` requires:
-    * [TensorRT](https://developer.nvidia.com/tensorrt) (>=6.0,<7.0)
-    * [cuDNN](https://developer.nvidia.com/cudnn) (>=7.5)
 
 Multiple backends can be enabled for a single build. When building with both Intel MKL and oneDNN, the backend will be selected at runtime based on the CPU information.
 

--- a/docker/Dockerfile.centos7-gpu
+++ b/docker/Dockerfile.centos7-gpu
@@ -1,8 +1,5 @@
 ARG CUDA_VERSION=10.0
-FROM nvidia/cuda:${CUDA_VERSION}-cudnn7-devel-centos7 as builder
-
-ENV TENSORRT_MAJOR_VERSION=6
-ENV TENSORRT_VERSION=${TENSORRT_MAJOR_VERSION}.0.1
+FROM nvidia/cuda:${CUDA_VERSION}-devel-centos7 as builder
 
 RUN export CUDA_SHORT_VERSION=`echo $CUDA_VERSION | cut -d'.' -f 1,2` && \
     yum install -y epel-release centos-release-scl-rh && \
@@ -11,8 +8,6 @@ RUN export CUDA_SHORT_VERSION=`echo $CUDA_VERSION | cut -d'.' -f 1,2` && \
         devtoolset-8-gcc-c++ \
         gcc \
         gcc-c++ \
-        libnvinfer${TENSORRT_MAJOR_VERSION}-${TENSORRT_VERSION}-1.cuda${CUDA_SHORT_VERSION} \
-        libnvinfer-devel-${TENSORRT_VERSION}-1.cuda${CUDA_SHORT_VERSION} \
         make \
         python3-devel \
         wget && \
@@ -89,9 +84,7 @@ RUN cp -P ${DNNL_DIR}/lib/*.so* /root/ctranslate2/lib64 && \
     cp -P $([ $CUDA_VERSION = "10.0.130" ] \
         && echo /usr/local/cuda/lib64/libcublas.so* \
         || echo /lib64/libcublas*.so*) \
-        /root/ctranslate2/lib64 && \
-    cp -P /lib64/libcudnn.so* /root/ctranslate2/lib64 && \
-    cp -P /lib64/libnvinfer.so* /root/ctranslate2/lib64
+        /root/ctranslate2/lib64
 
 FROM nvidia/cuda:${CUDA_VERSION}-base-centos7
 

--- a/docker/Dockerfile.ubuntu-gpu
+++ b/docker/Dockerfile.ubuntu-gpu
@@ -1,9 +1,6 @@
 ARG UBUNTU_VERSION=18.04
 ARG CUDA_VERSION=10.0
-FROM nvidia/cuda:${CUDA_VERSION}-cudnn7-devel-ubuntu${UBUNTU_VERSION} as builder
-
-ENV TENSORRT_MAJOR_VERSION=6
-ENV TENSORRT_VERSION=${TENSORRT_MAJOR_VERSION}.0.1
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} as builder
 
 RUN export CUDA_SHORT_VERSION=`echo $CUDA_VERSION | cut -d'.' -f 1,2` && \
     apt-get update && \
@@ -13,8 +10,6 @@ RUN export CUDA_SHORT_VERSION=`echo $CUDA_VERSION | cut -d'.' -f 1,2` && \
         ca-certificates \
         python3-dev \
         gnupg2 \
-        libnvinfer${TENSORRT_MAJOR_VERSION}=${TENSORRT_VERSION}-1+cuda${CUDA_SHORT_VERSION} \
-        libnvinfer-dev=${TENSORRT_VERSION}-1+cuda${CUDA_SHORT_VERSION} \
         wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -94,9 +89,7 @@ RUN cp -P ${DNNL_DIR}/lib/*.so* /root/ctranslate2/lib && \
     cp -P $([ $CUDA_VERSION = "10.0.130" ] \
         && echo /usr/local/cuda/lib64/libcublas.so* \
         || echo /usr/lib/x86_64-linux-gnu/libcublas*.so*) \
-        /root/ctranslate2/lib && \
-    cp -P /usr/lib/x86_64-linux-gnu/libcudnn.so* /root/ctranslate2/lib && \
-    cp -P /usr/lib/x86_64-linux-gnu/libnvinfer.so* /root/ctranslate2/lib
+        /root/ctranslate2/lib
 
 FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu${UBUNTU_VERSION}
 

--- a/src/cuda/utils.h
+++ b/src/cuda/utils.h
@@ -1,14 +1,9 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 #include <cuda_runtime.h>
 #include <cublas_v2.h>
-
-#ifdef CT2_WITH_TENSORRT
-#  include <NvInfer.h>
-#endif
 
 #include "ctranslate2/types.h"
 #include "ctranslate2/utils.h"
@@ -68,40 +63,6 @@ namespace ctranslate2 {
     };
 
     ThrustAllocator& get_thrust_allocator();
-
-#ifdef CT2_WITH_TENSORRT
-    class TensorRTLayer {
-    public:
-      virtual ~TensorRTLayer();
-
-    protected:
-      void run(void** bindings, const std::vector<nvinfer1::Dims>& input_dims);
-
-      // These methods are called on the first call to run().
-      virtual void build_network(nvinfer1::INetworkDefinition* network) = 0;
-      virtual void set_builder_config(nvinfer1::IBuilderConfig*) {};
-      virtual void set_optimization_profile(nvinfer1::IOptimizationProfile* profile) = 0;
-
-    private:
-      void build();
-      int _device = 0;
-      nvinfer1::ICudaEngine* _engine = nullptr;
-      nvinfer1::IExecutionContext* _execution_context = nullptr;
-    };
-
-    template <typename T>
-    struct TensorRTType;
-
-    template<>
-    struct TensorRTType<float> {
-      static constexpr nvinfer1::DataType type = nvinfer1::DataType::kFLOAT;
-    };
-
-    template<>
-    struct TensorRTType<float16_t> {
-      static constexpr nvinfer1::DataType type = nvinfer1::DataType::kHALF;
-    };
-#endif
 
   }
 }

--- a/src/ops/topk_gpu.cu
+++ b/src/ops/topk_gpu.cu
@@ -1,106 +1,55 @@
 #include "ctranslate2/ops/topk.h"
 
-#include <unordered_map>
+#include "cuda/utils.h"
+#include "cuda/helpers.h"
 
-#include "../cuda/utils.h"
+namespace fastertransformer {
+
+#define MAX_BLOCKS_PER_BEAM 8
+
+  template <typename T>
+  void topK_kernelLauncher(const T* log_probs,
+                           int* topk_tmp_id_buf,
+                           T* topk_tmp_val_buf,
+                           int* topk_id_buf,
+                           T* topk_val_buf,
+                           const int batch_size,
+                           const int beams_per_batch,
+                           const int k,
+                           const int vocab_size,
+                           cudaStream_t stream);
+
+}
 
 namespace ctranslate2 {
   namespace ops {
-
-#ifdef CT2_WITH_TENSORRT
-    template <typename T>
-    class TopKLayer : public cuda::TensorRTLayer {
-    public:
-      TopKLayer(dim_t k)
-        : _k(k)
-        , _first_depth(0) {
-      }
-
-      void operator()(const StorageView& x, StorageView& values, StorageView& indices) {
-        const dim_t depth = x.dim(-1);
-        const dim_t batch_size = x.size() / depth;
-
-        if (_first_depth == 0)
-          _first_depth = depth;
-
-        void* bindings[3] = {
-          const_cast<T*>(x.data<T>()),
-          values.data<T>(),
-          indices.data<int32_t>()
-        };
-
-        run(bindings, {nvinfer1::Dims2(batch_size, depth)});
-      }
-
-    protected:
-      void build_network(nvinfer1::INetworkDefinition* network) override {
-        nvinfer1::ITensor* input = network->addInput("x",
-                                                     cuda::TensorRTType<T>::type,
-                                                     nvinfer1::Dims2(-1, -1));
-        nvinfer1::ITopKLayer* topk = network->addTopK(*input, nvinfer1::TopKOperation::kMAX, _k, 2);
-        nvinfer1::ITensor* values_t = topk->getOutput(0);
-        nvinfer1::ITensor* indices_t = topk->getOutput(1);
-        network->markOutput(*values_t);
-        network->markOutput(*indices_t);
-        values_t->setName("values");
-        values_t->setType(cuda::TensorRTType<T>::type);
-        indices_t->setName("indices");
-        indices_t->setType(nvinfer1::DataType::kINT32);
-      }
-
-      void set_builder_config(nvinfer1::IBuilderConfig* config) override {
-        config->setMaxWorkspaceSize(1 << 30);
-        if (std::is_same<T, float16_t>::value) {
-          config->setFlag(nvinfer1::BuilderFlag::kFP16);
-        }
-      }
-
-      void set_optimization_profile(nvinfer1::IOptimizationProfile* profile) override {
-        // Optimize for the first seen depth which covers the standard use case
-        // of running TopK over a static vocabulary size.
-        profile->setDimensions("x",
-                               nvinfer1::OptProfileSelector::kMIN,
-                               nvinfer1::Dims2(1, _first_depth));
-        profile->setDimensions("x",
-                               nvinfer1::OptProfileSelector::kOPT,
-                               nvinfer1::Dims2(64, _first_depth));
-        profile->setDimensions("x",
-                               nvinfer1::OptProfileSelector::kMAX,
-                               nvinfer1::Dims2(1024, _first_depth));
-      }
-
-    private:
-      dim_t _k;
-      dim_t _first_depth;
-    };
-
-    template <typename DataType>
-    static TopKLayer<DataType>& get_trt_topk_layer(dim_t k) {
-      static thread_local std::unordered_map<dim_t, TopKLayer<DataType>> layer_cache;
-      auto it = layer_cache.find(k);
-      if (it == layer_cache.end())
-        it = layer_cache.emplace(k, TopKLayer<DataType>(k)).first;
-      return it->second;
-    }
-#endif
 
     template <Device D, typename DataType, typename IndexType>
     void TopK::compute(const StorageView& x,
                        StorageView& values,
                        StorageView& indices) const {
-#ifdef CT2_WITH_TENSORRT
-      get_trt_topk_layer<DataType>(_k)(x, values, indices);
-#else
-      if (_k > 1)
-        throw std::runtime_error("TopK with k > 1 requires TensorRT");
       const dim_t depth = x.dim(-1);
       const dim_t batch_size = x.size() / depth;
-      primitives<D>::row_max(x.data<DataType>(),
-                             batch_size,
-                             depth,
-                             values.data<DataType>(),
-                             indices.data<IndexType>());
-#endif
+      const dim_t temp_size = batch_size * _k * MAX_BLOCKS_PER_BEAM;
+
+      auto* topk_tmp_id = static_cast<IndexType*>(
+        primitives<D>::alloc_data(temp_size * sizeof (IndexType)));
+      auto* topk_tmp_val = static_cast<DataType*>(
+        primitives<D>::alloc_data(temp_size * sizeof (DataType)));
+
+      fastertransformer::topK_kernelLauncher(cuda::device_cast(x.data<DataType>()),
+                                             cuda::device_cast(topk_tmp_id),
+                                             cuda::device_cast(topk_tmp_val),
+                                             cuda::device_cast(indices.data<IndexType>()),
+                                             cuda::device_cast(values.data<DataType>()),
+                                             batch_size,
+                                             1,
+                                             _k,
+                                             depth,
+                                             cuda::get_cuda_stream());
+
+      primitives<D>::free_data(topk_tmp_id);
+      primitives<D>::free_data(topk_tmp_val);
     }
 
 #define DECLARE_IMPL(T)                                                 \
@@ -113,4 +62,254 @@ namespace ctranslate2 {
     DECLARE_IMPL(float16_t)
 
   }
+}
+
+// The kernels below were initially developed in FasterTransformer
+// https://github.com/NVIDIA/DeepLearningExamples/blob/master/FasterTransformer/v3.0/fastertransformer/cuda/topk_kernels.cu
+// which comes with the following license:
+
+/*
+  Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// We use an adaptation of these kernels that was proposed in MarianNMT
+// https://github.com/rhenry-nv/marian-dev/blob/gpu_optimizations/src/3rd_party/topk.cuh
+// which comes with the following license:
+
+
+/*
+  MIT License
+
+  Copyright (c) 2016 Marcin Junczys-Dowmunt, the University of Edinburgh, Adam
+  Mickiewicz University
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#include <cub/cub.cuh>
+
+namespace fastertransformer {
+
+#define NOT_FOUND -1
+
+  template <typename T>
+  __device__ __forceinline__ bool greater(const T& a, const T& b) {
+    return a > b;
+  }
+
+#if !CUDA_CAN_USE_HALF
+  template<>
+  __device__ __forceinline__ bool greater(const __half& a, const __half& b) {
+    return float(a) > float(b);
+  }
+#endif
+
+  template <typename T>
+  struct TopK {
+    int p = NOT_FOUND;
+    T u = cub::FpLimits<T>::Lowest();
+
+    __device__ __forceinline__ void insert(T elem, int elem_id) {
+      if (greater(elem, u)) {
+        u = elem;
+        p = elem_id;
+      }
+    }
+
+    __device__ __forceinline__ void init() {
+      u = cub::FpLimits<T>::Lowest();
+      p = NOT_FOUND;
+    }
+  };
+
+  template <typename T>
+  __device__ __forceinline__ TopK<T>
+  reduce_topk_op(const TopK<T>& a, const TopK<T>& b) {
+    return greater(a.u, b.u) ? a : b;
+  }
+
+  template<typename T, int BLOCK_SIZE_, int BLOCKS_PER_BEAM_>
+  __global__ void topk_stage_1(T* log_probs,
+                               int* topk_tmp_id_buf,
+                               T* topk_tmp_val_buf,
+                               const int k,
+                               const int vocab_size) {
+    typedef cub::BlockReduce<TopK<T>, BLOCK_SIZE_> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+
+    const int tid = threadIdx.x;
+    const int bid = blockIdx.x;
+    const int row_id = bid / BLOCKS_PER_BEAM_; // row id for log_probs
+    const int block_lane = bid % BLOCKS_PER_BEAM_; // block id for a beam
+    const int tmp_log_buf_index = row_id * vocab_size;
+    const int tmp_topk_buf_index = row_id * BLOCKS_PER_BEAM_ * k + block_lane * k;
+    TopK<T> partial;
+
+    for (int ite = 0; ite < k; ite++) {
+      partial.init();
+      #pragma unroll
+      for (int elem_id = tid + block_lane * BLOCK_SIZE_;
+           elem_id < vocab_size;
+           elem_id += BLOCK_SIZE_ * BLOCKS_PER_BEAM_) {
+        int index = elem_id + tmp_log_buf_index;
+        partial.insert(log_probs[index], index);
+      }
+
+      TopK<T> total = BlockReduce(temp_storage).Reduce(partial, reduce_topk_op<T>);
+
+      if (tid == 0) {
+        const int index = tmp_topk_buf_index + ite;
+        topk_tmp_id_buf[index] = total.p;
+        topk_tmp_val_buf[index] = total.u;
+        // If we found a max, blank out the value in the log prob array before starting the next iteration
+        if (total.p != NOT_FOUND)
+          log_probs[total.p] = cub::FpLimits<T>::Lowest();
+      }
+      __syncthreads();
+    }
+
+    // Update prob array with original values.
+    for (int beam = tid; beam < k; beam += BLOCK_SIZE_) {
+      const int index = tmp_topk_buf_index + beam;
+      int k_idx = topk_tmp_id_buf[index];
+      if (k_idx != NOT_FOUND)
+        log_probs[k_idx] = topk_tmp_val_buf[index];
+    }
+  }
+
+  template<typename T, int BLOCK_SIZE_, int BLOCKS_PER_BEAM_>
+  __global__ void topk_stage_2(const int* __restrict topk_tmp_id_buf,
+                               T* topk_tmp_val_buf,
+                               int* topk_id_buf,
+                               T* topk_val_buf,
+                               const int beams_per_batch,
+                               const int vocab_size,
+                               const int k) {
+
+    const int size = beams_per_batch * k * BLOCKS_PER_BEAM_;
+    const int tid = threadIdx.x;
+    const int batch_id = blockIdx.x;
+
+    typedef cub::BlockReduce<TopK<T>, BLOCK_SIZE_> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    extern __shared__ char array[];
+    T *s_val = topk_tmp_val_buf + batch_id * size;
+    TopK<T> *topks = (TopK<T>*)(array);
+
+    TopK<T> partial;
+
+    for (int ite = 0; ite < k; ite++) {
+      partial.init();
+      #pragma unroll
+      for (int i = tid; i < size; i+= BLOCK_SIZE_) {
+        partial.insert(s_val[i], i);
+      }
+
+      TopK<T> total = BlockReduce(temp_storage).Reduce(partial, reduce_topk_op<T>);
+
+      if (tid == 0) {
+        topks[ite] = total;
+        s_val[total.p] = cub::FpLimits<T>::Lowest();
+      }
+      __syncthreads();
+    }
+
+    for (int beam = tid; beam < k; beam += BLOCK_SIZE_) {
+      int indexInRow = topks[beam].p == NOT_FOUND? 0: topks[beam].p;
+      int id = topk_tmp_id_buf[batch_id * size + indexInRow];
+      id = id == NOT_FOUND? 0 : id; // If no max found, all values were equal to T::min so just return 0
+      const int offset = batch_id * k + beam;
+      topk_id_buf[offset] = id % vocab_size;
+      topk_val_buf[offset] = topks[beam].u;
+    }
+  }
+
+#define CASE_K(K,BLOCK_SIZE_1_, BLOCK_SIZE_2_, BLOCKS_PER_BEAM_)        \
+  case K:                                                               \
+  topk_stage_1<T, BLOCK_SIZE_1_, BLOCKS_PER_BEAM_>                      \
+  <<<batch_size * beams_per_batch * BLOCKS_PER_BEAM_, BLOCK_SIZE_1_, 0, stream>>>( \
+    const_cast<T*>(log_probs),                                          \
+    topk_tmp_id_buf,                                                    \
+    topk_tmp_val_buf,                                                   \
+    k, vocab_size);                                                     \
+  topk_stage_2<T, BLOCK_SIZE_2_, BLOCKS_PER_BEAM_>                      \
+  <<<batch_size, BLOCK_SIZE_2_, K * sizeof(TopK<T>), stream>>>(         \
+    topk_tmp_id_buf,                                                    \
+    topk_tmp_val_buf,                                                   \
+    topk_id_buf,                                                        \
+    topk_val_buf,                                                       \
+    beams_per_batch,                                                    \
+    vocab_size,                                                         \
+    k);                                                                 \
+  break
+
+  template <typename T>
+  void topK_kernelLauncher(const T* log_probs,
+                           int* topk_tmp_id_buf,
+                           T* topk_tmp_val_buf,
+                           int* topk_id_buf,
+                           T* topk_val_buf,
+                           const int batch_size,
+                           const int beams_per_batch,
+                           const int k,
+                           const int vocab_size,
+                           cudaStream_t stream) {
+    switch (k) {
+      CASE_K(1,128,128,MAX_BLOCKS_PER_BEAM);
+      CASE_K(2,128,128,MAX_BLOCKS_PER_BEAM);
+      CASE_K(4,128,128,MAX_BLOCKS_PER_BEAM);
+      CASE_K(6,128,128,MAX_BLOCKS_PER_BEAM);
+      CASE_K(8,128,128,MAX_BLOCKS_PER_BEAM);
+      CASE_K(10,128,128,MAX_BLOCKS_PER_BEAM);
+      CASE_K(16,128,128,5);
+      CASE_K(32,256,128,1);
+      CASE_K(64,256,256,1);
+    default:
+      topk_stage_1<T, 128, 1>
+        <<<batch_size * beams_per_batch * 1, 128, 0, stream>>>(const_cast<T*>(log_probs),
+                                                               topk_tmp_id_buf,
+                                                               topk_tmp_val_buf,
+                                                               k,
+                                                               vocab_size);
+
+      topk_stage_2<T, 128, 1>
+        <<<batch_size, 128, k * sizeof(TopK<T>), stream>>>(topk_tmp_id_buf,
+                                                           topk_tmp_val_buf,
+                                                           topk_id_buf,
+                                                           topk_val_buf,
+                                                           beams_per_batch,
+                                                           vocab_size,
+                                                           k);
+      break;
+    }
+  }
+
 }


### PR DESCRIPTION
The FasterTransformer repo from NVIDIA has a [TopK kernel](https://github.com/NVIDIA/DeepLearningExamples/blob/master/FasterTransformer/v3.0/fastertransformer/cuda/topk_kernels.cu) that is comparable to the one included in TensorRT. We use an adaptation of this kernel that is [currently being proposed](https://github.com/rhenry-nv/marian-dev/blob/gpu_optimizations/src/3rd_party/topk.cuh) in MarianNMT.

I checked with the [helpful benchmark script](https://github.com/OpenNMT/CTranslate2/tree/master/tools/benchmark) that the new implementation has similar (or better) performance than the current one. New values are in bold.

| Beam size | Compute type | Tokens per second | Max. GPU memory | Max. system memory | BLEU |
| -- | -- | --- | --- | --- | --- |
| 1 |  float | 4575.7<br>**4977.2** | 2204MB<br>**882MB** | 1289MB<br>**312MB** | 25.82<br>**=** |
| 2 |  float | 3654.1<br>**3897.0** | 2532MB<br>**900MB** | 1280MB<br>**308MB** | 26.39<br>**=** |
| 4 |  float | 2641.8<br>**2663.7** | 2794MB<br>**1084MB** | 1284MB<br>**307MB** | 26.77<br>**=** |
| 4 |  float16 | 3827.8<br>**4057.6** | 1238MB<br>**824MB** | 1304MB<br>**366MB** | 26.78<br>**26.80** |
| 5 |  float | 1745.4<br>**1721.5** | 1630MB<br>**1208MB** | 1281MB<br>**306MB** | 26.98<br>**=** |
| 10 |  float | 1016.8<br>**1009.1** | 3840MB<br>**1674MB** | 1299MB<br>**306MB** | 27.08<br>**=** |

It is slightly slower for large beam sizes but in most cases it is faster and uses less memory. The Docker image goes from 1.03GB to 380MB without TensorRT.

Closes #178.