### PR TITLE
Do not include origin of the raised exceptions in release builds

### DIFF
--- a/include/ctranslate2/utils.h
+++ b/include/ctranslate2/utils.h
@@ -33,8 +33,12 @@ namespace ctranslate2 {
   void* aligned_alloc(size_t size, size_t alignment);
   void aligned_free(void* ptr);
 
-#define THROW_EXCEPTION(EXCEPTION, MESSAGE)                             \
+#ifdef NDEBUG
+#  define THROW_EXCEPTION(EXCEPTION, MESSAGE) throw EXCEPTION(MESSAGE)
+#else
+#  define THROW_EXCEPTION(EXCEPTION, MESSAGE)                           \
   throw EXCEPTION(std::string(__FILE__) + ":" + std::to_string(__LINE__) + ": " + MESSAGE)
+#endif
 #define THROW_RUNTIME_ERROR(MESSAGE) THROW_EXCEPTION(std::runtime_error, MESSAGE)
 #define THROW_INVALID_ARGUMENT(MESSAGE) THROW_EXCEPTION(std::invalid_argument, MESSAGE)
 


### PR DESCRIPTION
The file and line location of where the exception was raised in mostly an information for debug.