### PR TITLE
Use C++ types when declaring Python arguments

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -28,7 +28,7 @@ _maybe_add_library_root("CTRANSLATE2")
 ctranslate2_module = Extension(
     "ctranslate2.translator",
     sources=["translator.cc"],
-    extra_compile_args=["-std=c++11"],
+    extra_compile_args=["-std=c++17"],
     include_dirs=include_dirs,
     library_dirs=library_dirs,
     libraries=["ctranslate2"])

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -48,7 +48,7 @@ def test_compute_type():
     model_path = _get_model_path()
     with pytest.raises(ValueError):
         ctranslate2.Translator(model_path, compute_type="float64")
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         ctranslate2.Translator(model_path, compute_type=["int8", "int16"])
     ctranslate2.Translator(model_path, compute_type="int8")
     ctranslate2.Translator(model_path, compute_type={"cuda": "float16", "cpu": "int8"})
@@ -203,7 +203,6 @@ def test_raw_file_translation_with_prefix(tmpdir):
 def test_empty_translation():
     translator = _get_transliterator()
     assert translator.translate_batch([]) == []
-    assert translator.translate_batch(None) == []
 
 def test_invalid_translation_options():
     translator = _get_transliterator()


### PR DESCRIPTION
This improves the arguments type checking and the output of `help(ctranslate2.Translator)`.