### PR TITLE
Enable parallelism from Python when setting max_batch_size

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -96,9 +96,11 @@ Also see the [`TranslationOptions`](../include/ctranslate2/translator.h) structu
 
 ### Note on parallel CPU translations
 
-For CPU translations, the parameter `inter_threads` controls the number of batches a `Translator` instance can process in parallel. The `translate_file` method automatically takes advantage of this parallelization.
+For CPU translations, the parameter `inter_threads` controls the number of batches a `Translator` instance can process in parallel. Parallel translations are enabled in the following cases:
 
-However, extra work may be needed when using the `translate_batch` method because multiple translations should be started concurrently from Python. If you are using a multithreaded HTTP server, this may already be the case. For other cases, you could use a [`ThreadPoolExecutor`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor) to submit multiple translations:
+* When calling `translate_file`.
+* When calling `translate_batch` and setting `max_batch_size`: the input will be split according to `max_batch_size` and each sub-batch will be translated in parallel.
+* When calling `translate_batch` from multiple Python threads. If you are using a multithreaded HTTP server, this may already be the case. For other cases, you could use a [`ThreadPoolExecutor`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor) to submit multiple concurrent translations:
 
 ```python
 import concurrent.futures

--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -103,17 +103,9 @@ namespace ctranslate2 {
     void assert_has_model() const;
 
     std::vector<TranslationResult>
-    run_batch_translation_sorted(const std::vector<std::vector<std::string>>& source,
-                                 const std::vector<std::vector<std::string>>* target_prefix,
-                                 const TranslationOptions& options);
-    std::vector<TranslationResult>
     run_batch_translation(const std::vector<std::vector<std::string>>& source,
-                          const std::vector<std::vector<std::string>>* target_prefix,
+                          const std::vector<std::vector<std::string>>& target_prefix,
                           const TranslationOptions& options);
-    TranslationResult
-    run_translation(const std::vector<std::string>& source,
-                    const std::vector<std::string>* target_prefix,
-                    const TranslationOptions& options);
 
     std::shared_ptr<const models::Model> _model;
     std::unique_ptr<layers::Encoder> _encoder;
@@ -122,5 +114,18 @@ namespace ctranslate2 {
     const Vocabulary* _source_vocabulary;
     const Vocabulary* _target_vocabulary;
   };
+
+  struct TranslationBatch {
+    std::vector<std::vector<std::string>> source;
+    std::vector<std::vector<std::string>> target_prefix;
+    std::vector<size_t> example_index;  // Index of each example in the original input.
+  };
+
+  // Rebatch the input according to the translation options.
+  // This function can also reorder the examples to improve efficiency.
+  std::vector<TranslationBatch>
+  rebatch_input(const std::vector<std::vector<std::string>>& source,
+                const std::vector<std::vector<std::string>>& target_prefix,
+                const TranslationOptions& options);
 
 }

--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -9,6 +9,9 @@
 
 namespace ctranslate2 {
 
+  class Translator;
+  class TranslatorPool;
+
   struct TranslationOptions {
     // Maximum batch size to run the model on (set 0 to forward the input as is).
     // When more inputs are passed to translate(), they will be internally sorted by length
@@ -52,6 +55,16 @@ namespace ctranslate2 {
     // used with a target prefix to provide alternatives at a specifc location in the
     // translation.
     bool return_alternatives = false;
+
+    void validate() const;
+
+  private:
+    // Internal options.
+    bool validated = false;
+    bool rebatch_input = true;
+
+    friend class Translator;
+    friend class TranslatorPool;
   };
 
   // This class holds all information required to translate from a model. Copying
@@ -124,8 +137,8 @@ namespace ctranslate2 {
   // Rebatch the input according to the translation options.
   // This function can also reorder the examples to improve efficiency.
   std::vector<TranslationBatch>
-  rebatch_input(const std::vector<std::vector<std::string>>& source,
-                const std::vector<std::vector<std::string>>& target_prefix,
-                const TranslationOptions& options);
+  rebatch_translation_input(const std::vector<std::vector<std::string>>& source,
+                            const std::vector<std::vector<std::string>>& target_prefix,
+                            const TranslationOptions& options);
 
 }

--- a/include/ctranslate2/translator_pool.h
+++ b/include/ctranslate2/translator_pool.h
@@ -50,6 +50,11 @@ namespace ctranslate2 {
                                         TranslationOptions options,
                                         bool blocking=false);
 
+    // Run a translation synchronously.
+    TranslationOutput translate_batch(const TranslationInput& source,
+                                      const TranslationInput& target_prefix,
+                                      TranslationOptions options);
+
     // Translate a stream in parallel.
     // Results will be written in order as they are available so the stream content is
     // never stored fully in memory
@@ -92,8 +97,10 @@ namespace ctranslate2 {
         batch_reader.add(new StreamReader<TargetReader>(*target, target_reader));
       }
 
-      while (batch_reader.has_next()) {
+      while (true) {
         auto batch = batch_reader.get_next(read_batch_size, options.batch_type);
+        if (batch[0].empty())
+          break;
         results.emplace(post(std::move(batch[0]),
                              target
                              ? std::move(batch[1])

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -234,9 +234,9 @@ public:
       options.return_attention = return_attention;
       options.return_alternatives = return_alternatives;
 
-      results = _translator_pool.post(source,
-                                      finalize_optional_batch(target_prefix),
-                                      std::move(options)).get();
+      results = _translator_pool.translate_batch(source,
+                                                 finalize_optional_batch(target_prefix),
+                                                 options);
     }
 
     py::list py_results(results.size());

--- a/src/batch_reader.cc
+++ b/src/batch_reader.cc
@@ -10,6 +10,17 @@ namespace ctranslate2 {
     throw std::invalid_argument("Invalid batch type: " + batch_type);
   }
 
+  template <typename T>
+  static size_t get_batch_size_increment(const std::vector<T>& example,
+                                         const BatchType batch_type) {
+    switch (batch_type) {
+    case BatchType::Tokens:
+      return example.size();
+    default:
+      return 1;
+    };
+  }
+
   std::vector<std::vector<std::string>>
   BatchReader::get_next(const size_t max_batch_size,
                         const BatchType batch_type) {
@@ -18,7 +29,7 @@ namespace ctranslate2 {
 
     size_t batch_size = 0;
 
-    while (has_next()) {
+    while (has_next_element()) {
       const size_t batch_size_increment = get_batch_size_increment(peek_next_element(),
                                                                    batch_type);
       if (batch_size > 0 && batch_size + batch_size_increment > max_batch_size)
@@ -36,7 +47,7 @@ namespace ctranslate2 {
   {
   }
 
-  bool VectorReader::has_next() const {
+  bool VectorReader::has_next_element() const {
     return _index < _examples.size();
   }
 
@@ -57,27 +68,16 @@ namespace ctranslate2 {
                                 const BatchType batch_type) {
     std::vector<std::vector<std::vector<std::string>>> batches;
     batches.resize(_readers.size());
+    batches[0] = _readers[0]->get_next(max_batch_size, batch_type);
 
-    if (has_next()) {
-      batches[0] = _readers[0]->get_next(max_batch_size, batch_type);
-
-      const size_t batch_size = batches[0].size();
-      for (size_t i = 1; i < _readers.size(); ++i) {
-        batches[i] = _readers[i]->get_next(batch_size);
-        if (batches[i].size() != batch_size)
-          throw std::runtime_error("One input stream has less elements than the others");
-      }
+    const size_t batch_size = batches[0].size();
+    for (size_t i = 1; i < _readers.size(); ++i) {
+      batches[i] = _readers[i]->get_next(batch_size);
+      if (batches[i].size() != batch_size)
+        throw std::runtime_error("One input stream has less elements than the others");
     }
 
     return batches;
-  }
-
-  bool ParallelBatchReader::has_next() const {
-    for (const auto& reader : _readers) {
-      if (reader->has_next())
-        return true;
-    }
-    return false;
   }
 
 }

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -10,30 +10,12 @@
 namespace ctranslate2 {
 
   template <typename T>
-  static std::vector<size_t>
-  sort_from_longest_to_shortest(const std::vector<std::vector<T>>& examples) {
-    std::vector<size_t> sorted_to_original_index(examples.size());
-    std::iota(sorted_to_original_index.begin(), sorted_to_original_index.end(), 0);
-    std::sort(sorted_to_original_index.begin(), sorted_to_original_index.end(),
-              [&examples](size_t i1, size_t i2) {
-                return examples[i1].size() > examples[i2].size();
-              });
-
-    std::vector<size_t> original_to_sorted_index(examples.size());
-    for (size_t i = 0; i < sorted_to_original_index.size(); ++i) {
-      const size_t original_index = sorted_to_original_index[i];
-      original_to_sorted_index[original_index] = i;
-    }
-    return original_to_sorted_index;
-  }
-
-  template <typename T>
   static std::vector<T> index_vector(const std::vector<T>& v,
-                                     const std::vector<size_t>& new_index) {
+                                     const std::vector<size_t>& index) {
     std::vector<T> new_v;
-    new_v.resize(v.size());
-    for (size_t i = 0; i < v.size(); ++i)
-      new_v[new_index[i]] = v[i];
+    new_v.resize(index.size());
+    for (size_t i = 0; i < index.size(); ++i)
+      new_v[i] = v[index[i]];
     return new_v;
   }
 
@@ -135,122 +117,27 @@ namespace ctranslate2 {
                                   + std::to_string(batch_size) + " for source and "
                                   + std::to_string(target_prefix.size()) + " for target prefix");
 
-    if (batch_size == 0)
-      return std::vector<TranslationResult>();
+    const TranslationResult empty_result(options.num_hypotheses, options.return_attention);
+    std::vector<TranslationResult> results(batch_size, empty_result);
 
-    const auto is_empty = [](const std::vector<std::string>& tokens) { return tokens.empty(); };
-    const bool no_source_is_empty = std::none_of(source.begin(), source.end(), is_empty);
-    const bool with_prefix = !std::all_of(target_prefix.begin(), target_prefix.end(), is_empty);
-    const bool allow_batch_prefix = !options.return_alternatives;
-
-    // Fast path for the common case.
-    if (no_source_is_empty && (!with_prefix || allow_batch_prefix))
-      return run_batch_translation_sorted(source, with_prefix ? &target_prefix : nullptr, options);
-
-    std::vector<TranslationResult> with_prefix_results;
-    std::vector<std::vector<std::string>> non_empty_source;
-    std::vector<std::vector<std::string>> prefix;
-    non_empty_source.reserve(batch_size);
-    if (with_prefix) {
-      prefix.reserve(batch_size);
-      if (!allow_batch_prefix) {
-        with_prefix_results.reserve(batch_size);
-      }
+    for (const auto& batch : rebatch_input(source, target_prefix, options)) {
+      auto batch_results = run_batch_translation(batch.source, batch.target_prefix, options);
+      for (size_t i = 0; i < batch_results.size(); ++i)
+        results[batch.example_index[i]] = std::move(batch_results[i]);
     }
 
-    for (size_t i = 0; i < batch_size; ++i) {
-      if (source[i].empty())
-        continue;
-      if (with_prefix) {
-        if (allow_batch_prefix) {
-          non_empty_source.emplace_back(source[i]);
-          prefix.emplace_back(target_prefix[i]);
-        } else if (!target_prefix.empty()) {
-          with_prefix_results.emplace_back(run_translation(source[i], &target_prefix[i], options));
-        }
-      } else {
-        non_empty_source.emplace_back(source[i]);
-      }
-    }
-
-    // Run batch translation of all other non empty examples.
-    std::vector<TranslationResult> results;
-    if (!non_empty_source.empty())
-      results = run_batch_translation_sorted(non_empty_source,
-                                             with_prefix && allow_batch_prefix ? &prefix : nullptr,
-                                             options);
-    std::vector<TranslationResult> final_results;
-    final_results.reserve(batch_size);
-
-    // Build the final results vector.
-    for (size_t i = 0, non_empty_index = 0, with_prefix_index = 0; i < batch_size; ++i) {
-      if (source[i].empty())
-        final_results.emplace_back(options.num_hypotheses, options.return_attention);
-      else if (with_prefix && !allow_batch_prefix && !target_prefix[i].empty())
-        final_results.emplace_back(std::move(with_prefix_results[with_prefix_index++]));
-      else
-        final_results.emplace_back(std::move(results[non_empty_index++]));
-    }
-
-    return final_results;
-  }
-
-  std::vector<TranslationResult>
-  Translator::run_batch_translation_sorted(const std::vector<std::vector<std::string>>& source,
-                                           const std::vector<std::vector<std::string>>* target_prefix,
-                                           const TranslationOptions& options) {
-    // Sorting the source input has 2 benefits:
-    //
-    // 1. When max_batch_size is smaller that the number of inputs, we prefer translating
-    //    together sentences that have a similar length for improved efficiency.
-    // 2. Decoding functions remove finished translations from the batch. On CPU, arrays are
-    //    updated in place so it is more efficient to remove content at the end. Shorter sentences
-    //    are more likely to finish first so we sort the batch accordingly.
-    const std::vector<size_t> sorted_index = sort_from_longest_to_shortest(source);
-
-    ParallelBatchReader batch_reader;
-    batch_reader.add(new VectorReader(index_vector(source, sorted_index)));
-    if (target_prefix)
-      batch_reader.add(new VectorReader(index_vector(*target_prefix, sorted_index)));
-
-    size_t max_batch_size = options.max_batch_size;
-    BatchType batch_type = options.batch_type;
-    if (max_batch_size == 0) {
-      max_batch_size = source.size();
-      batch_type = BatchType::Examples;
-    }
-
-    std::vector<TranslationResult> results;
-    results.reserve(source.size());
-
-    while (batch_reader.has_next()) {
-      const auto batch = batch_reader.get_next(max_batch_size, batch_type);
-      const auto& source_batch = batch[0];
-      const auto* target_prefix_batch = target_prefix ? &batch[1] : nullptr;
-
-      for (auto& result : run_batch_translation(source_batch, target_prefix_batch, options))
-        results.emplace_back(std::move(result));
-    }
-
-    // Reorder results based on original batch index.
-    std::vector<TranslationResult> final_results;
-    final_results.reserve(results.size());
-    for (auto index : sorted_index)
-      final_results.emplace_back(std::move(results[index]));
-    return final_results;
+    return results;
   }
 
   std::vector<TranslationResult>
   Translator::run_batch_translation(const std::vector<std::vector<std::string>>& source,
-                                    const std::vector<std::vector<std::string>>* target_prefix,
+                                    const std::vector<std::vector<std::string>>& target_prefix,
                                     const TranslationOptions& options) {
     PROFILE("run_batch_translation");
     auto scoped_device_setter = _model->get_scoped_device_setter();
 
     std::vector<std::vector<size_t>> source_ids = _source_vocabulary->to_ids(source);
-    std::vector<std::vector<size_t>> target_prefix_ids;
-    if (target_prefix)
-      target_prefix_ids = _target_vocabulary->to_ids(*target_prefix);
+    std::vector<std::vector<size_t>> target_prefix_ids = _target_vocabulary->to_ids(target_prefix);
 
     const Device device = _model->device();
     const int device_index = _model->device_index();
@@ -306,7 +193,7 @@ namespace ctranslate2 {
       *make_search_strategy(options),
       *make_sampler(options),
       start_ids,
-      target_prefix ? &target_prefix_ids : nullptr,
+      !target_prefix_ids.empty() ? &target_prefix_ids : nullptr,
       !output_ids_map.empty() ? &output_ids_map : nullptr,
       end_id,
       options.max_decoding_length,
@@ -337,18 +224,6 @@ namespace ctranslate2 {
       final_results.emplace_back(make_translation_result(std::move(result), *_target_vocabulary));
     }
     return final_results;
-  }
-
-  TranslationResult
-  Translator::run_translation(const std::vector<std::string>& source,
-                              const std::vector<std::string>* target_prefix,
-                              const TranslationOptions& options) {
-    if (!target_prefix)
-      return run_batch_translation({source}, nullptr, options)[0];
-    else {
-      std::vector<std::vector<std::string>> batch_target_prefix(1, *target_prefix);
-      return run_batch_translation({source}, &batch_target_prefix, options)[0];
-    }
   }
 
   Device Translator::device() const {
@@ -411,6 +286,72 @@ namespace ctranslate2 {
   void Translator::assert_has_model() const {
     if (!_model)
       throw std::runtime_error("No model is attached to this translator");
+  }
+
+  std::vector<TranslationBatch>
+  rebatch_input(const std::vector<std::vector<std::string>>& source,
+                const std::vector<std::vector<std::string>>& target_prefix,
+                const TranslationOptions& options) {
+    const size_t global_batch_size = source.size();
+    size_t max_batch_size = options.max_batch_size;
+    BatchType batch_type = options.batch_type;
+    if (options.return_alternatives) {
+      max_batch_size = 1;  // Disable batching in return_alternatives mode.
+      batch_type = BatchType::Examples;
+    } else if (max_batch_size == 0) {
+      max_batch_size = global_batch_size;
+      batch_type = BatchType::Examples;
+    }
+
+    // Sorting the source inputs from the longest to the shortest has 2 benefits:
+    //
+    // 1. When max_batch_size is smaller that the number of inputs, we prefer translating
+    //    together sentences that have a similar length for improved efficiency.
+    // 2. Decoding functions remove finished translations from the batch. On CPU, arrays are
+    //    updated in place so it is more efficient to remove content at the end. Shorter sentences
+    //    are more likely to finish first so we sort the batch accordingly.
+    std::vector<size_t> example_index(global_batch_size);
+    std::iota(example_index.begin(), example_index.end(), 0);
+    std::sort(example_index.begin(), example_index.end(),
+              [&source](size_t i1, size_t i2) {
+                return source[i1].size() > source[i2].size();
+              });
+
+    // Ignore empty examples.
+    // As example_index is sorted from longest to shortest, we simply pop empty examples
+    // from the back.
+    while (!example_index.empty() && source[example_index.back()].empty())
+      example_index.pop_back();
+
+    std::vector<TranslationBatch> batches;
+    if (example_index.empty())
+      return batches;
+
+    ParallelBatchReader batch_reader;
+    batch_reader.add(new VectorReader(index_vector(source, example_index)));
+    if (!target_prefix.empty())
+      batch_reader.add(new VectorReader(index_vector(target_prefix, example_index)));
+
+    for (size_t offset = 0;;) {
+      auto batch = batch_reader.get_next(max_batch_size, batch_type);
+      if (batch[0].empty())
+        break;
+
+      TranslationBatch translation_batch;
+      translation_batch.source = std::move(batch[0]);
+      if (batch.size() > 1)
+        translation_batch.target_prefix = std::move(batch[1]);
+
+      const size_t batch_size = translation_batch.source.size();
+      translation_batch.example_index.insert(translation_batch.example_index.begin(),
+                                             example_index.begin() + offset,
+                                             example_index.begin() + offset + batch_size);
+      offset += batch_size;
+
+      batches.emplace_back(std::move(translation_batch));
+    }
+
+    return batches;
   }
 
 }

--- a/src/translator_pool.cc
+++ b/src/translator_pool.cc
@@ -52,13 +52,15 @@ namespace ctranslate2 {
   TranslationOutput TranslatorPool::translate_batch(const TranslationInput& source,
                                                     const TranslationInput& target_prefix,
                                                     TranslationOptions options) {
+    options.validate();
+    options.validated = true;
+
     if (source.empty())
       return TranslationOutput();
 
     // Rebatch the input and post each sub-batch in the translation queue.
-    std::vector<TranslationBatch> batches = rebatch_input(source, target_prefix, options);
-    options.max_batch_size = 0;  // Reset max_batch_size as it has been applied.
-    options.batch_type = BatchType::Examples;
+    auto batches = rebatch_translation_input(source, target_prefix, options);
+    options.rebatch_input = false;
 
     std::vector<std::future<TranslationOutput>> futures;
     futures.reserve(batches.size());


### PR DESCRIPTION
In this change, the `max_batch_size` splitting is done before posting the batch in the translation queue. This enables parallel translations from Python when setting `inter_threads` > 1.

This PR also cleans up the rebatching logic, which was a bit complex.

Closes #243.