### PR TITLE
Move masking inside SoftMax CUDA kernel

### DIFF
--- a/tests/benchmark_ops.cc
+++ b/tests/benchmark_ops.cc
@@ -53,6 +53,20 @@ void benchmark_softmax(Device device) {
   BENCHMARK(softmax_op(x, y), 10000);
 }
 
+void benchmark_masked_softmax(Device device) {
+  const dim_t batch_size = 32;
+  const dim_t num_heads = 8;
+  const dim_t max_source = 24;
+  const dim_t max_target = 36;
+  StorageView lengths({batch_size}, std::vector<int32_t>(batch_size, max_source - 5), device);
+  StorageView x({batch_size, num_heads, max_source, max_target},
+                rand_vector(batch_size * num_heads * max_source * max_target),
+                device);
+  StorageView y(x.device());
+  const ops::SoftMax softmax_op{};
+  BENCHMARK(softmax_op(x, lengths, y), 10000);
+}
+
 void benchmark_topk(Device device) {
   const size_t k = 4;
   const size_t batch_size = 8;
@@ -116,6 +130,8 @@ int main(int argc, char* argv[]) {
     benchmark_layer_norm(device);
   else if (op == "softmax")
     benchmark_softmax(device);
+  else if (op == "masked_softmax")
+    benchmark_masked_softmax(device);
   else if (op == "topk")
     benchmark_topk(device);
   else if (op == "gemm")


### PR DESCRIPTION
This avoids copying and masking the data before calling the kernel.