### PR TITLE
Fix and disable padding to a multiple of 16 for INT8

### DIFF
--- a/include/ctranslate2/models/model.h
+++ b/include/ctranslate2/models/model.h
@@ -37,7 +37,12 @@ namespace ctranslate2 {
 
       Device device() const;
       int device_index() const;
+
+      // The requested compute type.
       ComputeType compute_type() const;
+      // The compute type that is effectively used.
+      ComputeType effective_compute_type() const;
+
       ScopedDeviceSetter get_scoped_device_setter() const;
 
       // If the model contains variables, they will be moved to the new device.
@@ -83,6 +88,7 @@ namespace ctranslate2 {
       std::unordered_map<std::string, StorageView> _variable_index;
       size_t _spec_revision;
       ComputeType _compute_type = ComputeType::DEFAULT;
+      ComputeType _effective_compute_type = ComputeType::DEFAULT;
 
     private:
       void process_linear_weights();

--- a/include/ctranslate2/models/transformer.h
+++ b/include/ctranslate2/models/transformer.h
@@ -102,6 +102,7 @@ namespace ctranslate2 {
                       StorageView& output) override;
     private:
       const layers::Embeddings _embeddings;
+      const ComputeType _compute_type;
       const std::unique_ptr<PositionEncoder> _position_encoder;
       const layers::LayerNorm _output_norm;
       std::vector<std::unique_ptr<const TransformerEncoderLayer>> _layers;
@@ -127,6 +128,7 @@ namespace ctranslate2 {
       bool should_reorder_state(const std::string& name) const override;
     private:
       const bool _with_encoder_attention;
+      const ComputeType _compute_type;
       const layers::Embeddings _embeddings;
       const std::unique_ptr<PositionEncoder> _position_encoder;
       const layers::LayerNorm _output_norm;

--- a/include/ctranslate2/padder.h
+++ b/include/ctranslate2/padder.h
@@ -9,8 +9,9 @@ namespace ctranslate2 {
   // This is useful to save on computation when lengths are very different.
   class Padder {
   public:
-    static inline bool allow_padding_removal(const Device device, const DataType dtype) {
-      return device == Device::CPU || dtype == DataType::FLOAT;
+    static inline bool allow_padding_removal(const Device device,
+                                             const ComputeType compute_type) {
+      return device == Device::CPU || compute_type != ComputeType::FLOAT16;
     }
 
     // If max_time is negative, it is set to the maximum length.

--- a/include/ctranslate2/types.h
+++ b/include/ctranslate2/types.h
@@ -30,10 +30,15 @@ namespace ctranslate2 {
   };
 
   ComputeType str_to_compute_type(const std::string& compute_type);
-  DataType compute_type_to_data_type(const ComputeType compute_type,
-                                     const DataType weights_type,
-                                     const Device device,
-                                     const int device_index,
-                                     const bool enable_fallback = false);
+
+  // Returns the final compute type based on model weights and device information.
+  ComputeType resolve_compute_type(const ComputeType compute_type,
+                                   const DataType weights_type,
+                                   const Device device,
+                                   const int device_index,
+                                   const bool enable_fallback = false);
+
+  // Gets the weights data type for the given compute type.
+  DataType compute_type_to_data_type(const ComputeType compute_type);
 
 }

--- a/include/ctranslate2/utils.h
+++ b/include/ctranslate2/utils.h
@@ -21,7 +21,9 @@ namespace ctranslate2 {
   bool mayiuse_float16(Device device, int device_index = 0);
   bool mayiuse_int16(Device device, int device_index = 0);
   bool mayiuse_int8(Device device, int device_index = 0);
-  dim_t get_preferred_size_multiple(DataType dtype, Device device, int device_index = 0);
+  dim_t get_preferred_size_multiple(ComputeType compute_type,
+                                    Device device,
+                                    int device_index = 0);
 
   void set_num_threads(size_t num_threads);
 

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -152,6 +152,10 @@ namespace ctranslate2 {
       return _compute_type;
     }
 
+    ComputeType Model::effective_compute_type() const {
+      return _effective_compute_type;
+    }
+
     void Model::set_device(const Device device, const int index) {
       move_variables(_variable_index, _device, _device_index, device, index);
       _device = device;
@@ -305,10 +309,11 @@ namespace ctranslate2 {
         }
       }
 
-      const DataType target_dtype = compute_type_to_data_type(_compute_type,
-                                                              model_dtype,
-                                                              _device,
-                                                              _device_index);
+      _effective_compute_type = resolve_compute_type(_compute_type,
+                                                     model_dtype,
+                                                     _device,
+                                                     _device_index);
+      const DataType target_dtype = compute_type_to_data_type(_effective_compute_type);
 
       for (auto& variable_pair : _variable_index) {
         const auto& name = variable_pair.first;

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -141,9 +141,10 @@ namespace ctranslate2 {
     std::vector<std::vector<size_t>> target_prefix_ids = _target_vocabulary->to_ids(target_prefix);
 
     const Device device = _model->device();
-    const int device_index = _model->device_index();
-    const DataType dtype = _encoder->output_type();
-    const dim_t preferred_size_multiple = get_preferred_size_multiple(dtype, device, device_index);
+    const dim_t preferred_size_multiple = get_preferred_size_multiple(
+      _model->effective_compute_type(),
+      device,
+      _model->device_index());
     std::pair<StorageView, StorageView> inputs = layers::make_sequence_inputs(
       source_ids,
       device,
@@ -152,7 +153,7 @@ namespace ctranslate2 {
     StorageView& lengths = inputs.second;
 
     // Encode sequence.
-    StorageView encoded(dtype, device);
+    StorageView encoded(_encoder->output_type(), device);
     (*_encoder)(ids, lengths, encoded);
 
     // If set, extract the subset of candidates to generate.

--- a/src/types.cc
+++ b/src/types.cc
@@ -42,47 +42,47 @@ namespace ctranslate2 {
                                 "or backend do not support efficient " + name + " computation.");
   }
 
-  DataType compute_type_to_data_type(const ComputeType compute_type,
-                                     const DataType weights_type,
-                                     const Device device,
-                                     const int device_index,
-                                     const bool enable_fallback) {
+  ComputeType resolve_compute_type(const ComputeType compute_type,
+                                   const DataType weights_type,
+                                   const Device device,
+                                   const int device_index,
+                                   const bool enable_fallback) {
     switch (compute_type) {
 
     case ComputeType::FLOAT: {
-      return DataType::FLOAT;
+      return ComputeType::FLOAT;
     }
 
     case ComputeType::FLOAT16: {
       if (mayiuse_float16(device, device_index))
-        return DataType::FLOAT16;
+        return ComputeType::FLOAT16;
       if (!enable_fallback)
         unsupported_compute_type("float16");
-      return DataType::FLOAT;
+      return ComputeType::FLOAT;
     }
 
     case ComputeType::INT16: {
       if (mayiuse_int16(device, device_index))
-        return DataType::INT16;
+        return ComputeType::INT16;
       if (!enable_fallback)
         unsupported_compute_type("int16");
       if (device == Device::CPU && mayiuse_int8(device, device_index))
-        return DataType::INT8;
+        return ComputeType::INT8;
       if (device == Device::CUDA && mayiuse_float16(device, device_index))
-        return DataType::FLOAT16;
-      return DataType::FLOAT;
+        return ComputeType::FLOAT16;
+      return ComputeType::FLOAT;
     }
 
     case ComputeType::INT8: {
       if (mayiuse_int8(device, device_index))
-        return DataType::INT8;
+        return ComputeType::INT8;
       if (!enable_fallback)
         unsupported_compute_type("int8");
       if (device == Device::CPU && mayiuse_int16(device, device_index))
-        return DataType::INT16;
+        return ComputeType::INT16;
       if (device == Device::CUDA && mayiuse_float16(device, device_index))
-        return DataType::FLOAT16;
-      return DataType::FLOAT;
+        return ComputeType::FLOAT16;
+      return ComputeType::FLOAT;
     }
 
     default: {
@@ -105,13 +105,28 @@ namespace ctranslate2 {
         break;
       }
 
-      return compute_type_to_data_type(inferred_compute_type,
-                                       weights_type,
-                                       device,
-                                       device_index,
-                                       /*enable_fallback=*/true);
+      return resolve_compute_type(inferred_compute_type,
+                                  weights_type,
+                                  device,
+                                  device_index,
+                                  /*enable_fallback=*/true);
     }
 
+    }
+  }
+
+  DataType compute_type_to_data_type(const ComputeType compute_type) {
+    switch (compute_type) {
+    case ComputeType::FLOAT:
+      return DataType::FLOAT;
+    case ComputeType::INT8:
+      return DataType::INT8;
+    case ComputeType::INT16:
+      return DataType::INT16;
+    case ComputeType::FLOAT16:
+      return DataType::FLOAT16;
+    default:
+      throw std::invalid_argument("resolve_compute_type should be called first");
     }
   }
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -139,16 +139,14 @@ namespace ctranslate2 {
     }
   }
 
-  dim_t get_preferred_size_multiple(DataType dtype, Device device, int device_index) {
+  dim_t get_preferred_size_multiple(ComputeType compute_type, Device device, int device_index) {
 #ifdef CT2_WITH_CUDA
     if (device == Device::CUDA) {
-      if (dtype == DataType::FLOAT16 && cuda::gpu_has_fp16_tensor_cores(device_index))
+      if (compute_type == ComputeType::FLOAT16 && cuda::gpu_has_fp16_tensor_cores(device_index))
         return 8;
-      if (dtype == DataType::INT8 && cuda::gpu_has_int8_tensor_cores(device_index))
-        return 16;
     }
 #else
-    (void)dtype;
+    (void)compute_type;
     (void)device;
     (void)device_index;
 #endif


### PR DESCRIPTION
The previous logic was incorrect and the padding was not applied. The code checked the layers output type which can only be float32 or float16. Instead, it should check the global compute type.

After fixing this issue, it appears padding to a multiple of 16 does not help. So let's disable it for now and gather more data.