### PR TITLE
Continue building for Python 3.5 for now

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -51,6 +51,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
@@ -65,7 +66,7 @@ setup(
     keywords="opennmt nmt neural machine translation cuda mkl inference quantization",
     packages=find_packages(exclude=["bin"]),
     ext_modules=[ctranslate2_module],
-    python_requires=">=3.6",
+    python_requires=">=3.5",
     install_requires=[
         "numpy",
     ],

--- a/python/tools/build_wheel.sh
+++ b/python/tools/build_wheel.sh
@@ -43,7 +43,7 @@ cd ..
 rm -r build-release
 
 cd python
-for PYTHON_VERSION in cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39
+for PYTHON_VERSION in cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39
 do
     PYTHON_ROOT=/opt/python/$PYTHON_VERSION
     $PYTHON_ROOT/bin/pip install -r install_requirements.txt


### PR DESCRIPTION
Let's continue supporting Python 3.5 a bit longer. We don't use any incompatible features and there is no extra work involved.