### PR TITLE
Support selecting indices in the last dimension with Gather op

### DIFF
--- a/include/ctranslate2/ops/gather.h
+++ b/include/ctranslate2/ops/gather.h
@@ -7,7 +7,7 @@ namespace ctranslate2 {
 
     class Gather : public BinaryOp {
     public:
-      Gather(int axis = 0);
+      Gather(const dim_t axis = 0, const dim_t batch_dims = 0);
       using BinaryOp::operator();
 
       void operator()(StorageView& data, const StorageView& input) const;
@@ -17,7 +17,14 @@ namespace ctranslate2 {
 
     private:
       template <Device D, typename T>
-      void compute(const StorageView& data, const StorageView& input, StorageView& output) const;
+      void compute(const StorageView& data,
+                   const StorageView& input,
+                   const dim_t axis,
+                   const dim_t batch_dims,
+                   StorageView& output) const;
+
+      const dim_t _axis;
+      const dim_t _batch_dims;
     };
 
   }

--- a/src/ops/gather_cpu.cc
+++ b/src/ops/gather_cpu.cc
@@ -30,15 +30,15 @@ namespace ctranslate2 {
       } else if (axis == data.rank() - 1 && batch_dims == data.rank() - 1) {
         const dim_t depth = data.dim(-1);
         const dim_t batch_size = data.size() / depth;
-        const dim_t num_elements = input.dim(-1);
+        const dim_t gather_size = input.size() / batch_size;  // Num. elements to gather per batch.
 
         #pragma omp parallel for
         for (dim_t i = 0; i < batch_size; ++i) {
-          const auto* indices_row = indices + i * num_elements;
+          const auto* indices_row = indices + i * gather_size;
           const T* data_row = src + i * depth;
-          T* output_row = dst + i * num_elements;
+          T* output_row = dst + i * gather_size;
 
-          for (dim_t j = 0; j < num_elements; ++j)
+          for (dim_t j = 0; j < gather_size; ++j)
             output_row[j] = data_row[indices_row[j]];
         }
 

--- a/src/ops/gather_cpu.cc
+++ b/src/ops/gather_cpu.cc
@@ -8,18 +8,42 @@ namespace ctranslate2 {
     template <Device D, typename T>
     void Gather::compute(const StorageView& data,
                          const StorageView& input,
+                         const dim_t axis,
+                         const dim_t batch_dims,
                          StorageView& output) const {
       const auto* indices = input.data<int32_t>();
-      const dim_t copy_size = data.stride(0);
-      const dim_t num_indices = input.size();
-
       const T* src = data.data<T>();
       T* dst = output.data<T>();
 
-      #pragma omp parallel for
-      for (dim_t i = 0; i < num_indices; ++i) {
-        const int32_t read_index = indices[i];
-        primitives<Device::CPU>::copy(src + read_index * copy_size, dst + i * copy_size, copy_size);
+      if (axis == 0 && batch_dims == 0) {
+        const dim_t copy_size = data.stride(0);
+        const dim_t num_indices = input.size();
+
+        #pragma omp parallel for
+        for (dim_t i = 0; i < num_indices; ++i) {
+          const int32_t read_index = indices[i];
+          primitives<Device::CPU>::copy(src + read_index * copy_size,
+                                        dst + i * copy_size,
+                                        copy_size);
+        }
+
+      } else if (axis == data.rank() - 1 && batch_dims == data.rank() - 1) {
+        const dim_t depth = data.dim(-1);
+        const dim_t batch_size = data.size() / depth;
+        const dim_t num_elements = input.dim(-1);
+
+        #pragma omp parallel for
+        for (dim_t i = 0; i < batch_size; ++i) {
+          const auto* indices_row = indices + i * num_elements;
+          const T* data_row = src + i * depth;
+          T* output_row = dst + i * num_elements;
+
+          for (dim_t j = 0; j < num_elements; ++j)
+            output_row[j] = data_row[indices_row[j]];
+        }
+
+      } else {
+        throw std::invalid_argument("unsupported gather configuration");
       }
     }
 
@@ -27,6 +51,8 @@ namespace ctranslate2 {
     template void                                               \
     Gather::compute<Device::CPU, T>(const StorageView& data,    \
                                     const StorageView& input,   \
+                                    const dim_t axis,           \
+                                    const dim_t batch_dims,     \
                                     StorageView& output) const;
 
     DECLARE_ALL_TYPES(DECLARE_IMPL)

--- a/src/ops/gather_gpu.cu
+++ b/src/ops/gather_gpu.cu
@@ -10,36 +10,85 @@
 namespace ctranslate2 {
   namespace ops {
 
-    struct map_id {
+    // Functor mapping output index to data index for Gather(axis=0, batch_dims=0).
+    class batch_gather_index_map {
+    private:
       const int32_t* _offsets;
-      int32_t _stride;
-      map_id(const int32_t* offsets, int32_t stride)
+      const int32_t _stride;
+    public:
+      batch_gather_index_map(const int32_t* offsets, const int32_t stride)
         : _offsets(offsets)
         , _stride(stride) {
       }
       __host__ __device__
-      int32_t operator()(const int32_t& i) const {
-        int32_t row = i / _stride;
-        int32_t col = i % _stride;
+      int32_t operator()(const int32_t i) const {
+        const int32_t row = i / _stride;
+        const int32_t col = i % _stride;
         return _offsets[row] * _stride + col;
       }
     };
 
+    // Functor mapping output index to data index for Gather(axis=rank - 1, batch_dims=rank - 1).
+    class depth_gather_index_map {
+    private:
+      const int32_t* _offsets;
+      const int32_t _total_depth;
+      const int32_t _gather_depth;
+    public:
+      depth_gather_index_map(const int32_t* offsets,
+                             const int32_t total_depth,
+                             const int32_t gather_depth)
+        : _offsets(offsets)
+        , _total_depth(total_depth)
+        , _gather_depth(gather_depth) {
+      }
+      __host__ __device__
+      int32_t operator()(const int32_t i) const {
+        const int32_t row = i / _gather_depth;
+        return row * _total_depth + _offsets[i];
+      }
+    };
+
+    template <typename T, typename IndexMap>
+    void run_gather(const IndexMap& index_map,
+                    const T* src,
+                    T* dst,
+                    const dim_t dst_size) {
+      auto gather_ids = thrust::make_transform_iterator(thrust::counting_iterator<int32_t>(0),
+                                                        index_map);
+      THRUST_CALL(thrust::gather, gather_ids, gather_ids + dst_size, src, dst);
+    }
+
     template <Device D, typename T>
     void Gather::compute(const StorageView& data,
                          const StorageView& input,
+                         const dim_t axis,
+                         const dim_t batch_dims,
                          StorageView& output) const {
-      auto gather_ids = thrust::make_transform_iterator(
-        thrust::counting_iterator<int32_t>(0),
-        map_id(input.data<int32_t>(), data.stride(0)));
-      THRUST_CALL(thrust::gather,
-                  gather_ids, gather_ids + output.size(), data.data<T>(), output.data<T>());
+      const dim_t dst_size = output.size();
+      const int32_t* indices = input.data<int32_t>();
+      const T* src = data.data<T>();
+      T* dst = output.data<T>();
+
+      if (axis == 0 && batch_dims == 0) {
+        run_gather(batch_gather_index_map(indices, data.stride(0)),
+                   src, dst, dst_size);
+
+      } else if (axis == data.rank() - 1 && batch_dims == data.rank() - 1) {
+        run_gather(depth_gather_index_map(indices, data.dim(-1), input.dim(-1)),
+                   src, dst, dst_size);
+
+      } else {
+        throw std::invalid_argument("unsupported gather configuration");
+      }
     }
 
 #define DECLARE_IMPL(T)                                                 \
     template void                                                       \
     Gather::compute<Device::CUDA, T>(const StorageView& data,           \
                                      const StorageView& input,          \
+                                     const dim_t axis,                  \
+                                     const dim_t batch_dims,            \
                                      StorageView& output) const;
 
     DECLARE_ALL_TYPES(DECLARE_IMPL)

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -382,6 +382,16 @@ TEST_P(OpDeviceTest, GatherData2DIndex2D) {
   expect_storage_eq(output, expected);
 }
 
+TEST_P(OpDeviceTest, GatherDepthDim) {
+  Device device = GetParam();
+  StorageView data({2, 4}, std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8}, device);
+  StorageView ids({2, 2}, std::vector<int32_t>{1, 2, 0, 3}, device);
+  StorageView expected({2, 2}, std::vector<float>{2, 3, 5, 8}, device);
+  StorageView output(device);
+  ops::Gather(-1, 1)(data, ids, output);
+  expect_storage_eq(output, expected);
+}
+
 TEST_P(OpDeviceTest, Transpose2D) {
   Device device = GetParam();
   StorageView x({4, 2}, std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8}, device);

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -382,7 +382,17 @@ TEST_P(OpDeviceTest, GatherData2DIndex2D) {
   expect_storage_eq(output, expected);
 }
 
-TEST_P(OpDeviceTest, GatherDepthDim) {
+TEST_P(OpDeviceTest, GatherInDepthWith1DInput) {
+  Device device = GetParam();
+  StorageView data({2, 4}, std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8}, device);
+  StorageView ids({2}, std::vector<int32_t>{1, 3}, device);
+  StorageView expected({2}, std::vector<float>{2, 8}, device);
+  StorageView output(device);
+  ops::Gather(-1, 1)(data, ids, output);
+  expect_storage_eq(output, expected);
+}
+
+TEST_P(OpDeviceTest, GatherInDepthWith2DInput) {
   Device device = GetParam();
   StorageView data({2, 4}, std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8}, device);
   StorageView ids({2, 2}, std::vector<int32_t>{1, 2, 0, 3}, device);


### PR DESCRIPTION
This is mostly useful to select scores from the model output distribution. For reference, it is the same as:

```python
tf.gather(x, ids, axis=x.shape.rank - 1, batch_dims=x.shape.rank - 1)
```