### PR TITLE
Switch to cibuildwheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,29 +152,17 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
-
       - name: Build wheels
         run: |
-          docker run -v $PWD:/root -w /root quay.io/pypa/manylinux2014_x86_64 bash /root/python/tools/build_wheel.sh
-
-      - name: Install dependencies
-        run: |
-          python -m pip install -r python/tests/requirements.txt
-          python -m pip uninstall -y ctranslate2
-          python -m pip install python/wheelhouse/*cp36*.whl
-
-      - name: Download test data
-        run: |
-          wget https://opennmt-models.s3.amazonaws.com/transliteration-aren-all.tar.gz
-          tar xf transliteration-aren-all.tar.gz -C tests/data/models/
-
-      - name: Test with pytest
-        run: |
-          python -m pytest python/tests/test.py
+          python -m pip install cibuildwheel==1.7.4
+          python -m cibuildwheel python --output-dir python/wheelhouse
+        env:
+          CIBW_BEFORE_ALL: python/tools/prepare_build_environment.sh
+          CIBW_BEFORE_BUILD: pip install -r python/install_requirements.txt
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_BEFORE_TEST: python/tools/prepare_test_environment.sh
+          CIBW_TEST_COMMAND: {project}/python/tools/run_test.sh {project}
+          CIBW_SKIP: cp27-* pp* *i686
 
       - name: Upload Python wheels
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,8 +154,8 @@ jobs:
 
       - name: Build wheels
         run: |
-          python -m pip install cibuildwheel==1.7.4
-          python -m cibuildwheel python --output-dir python/wheelhouse
+          python3 -m pip install cibuildwheel==1.7.4
+          python3 -m cibuildwheel python --output-dir python/wheelhouse
         env:
           CIBW_BEFORE_ALL: python/tools/prepare_build_environment.sh
           CIBW_BEFORE_BUILD: pip install -r python/install_requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,10 +152,15 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+
       - name: Build wheels
         run: |
-          python3 -m pip install cibuildwheel==1.7.4
-          python3 -m cibuildwheel python --output-dir python/wheelhouse
+          python -m pip install cibuildwheel==1.7.4
+          python -m cibuildwheel python --output-dir python/wheelhouse
         env:
           CIBW_BEFORE_ALL: python/tools/prepare_build_environment.sh
           CIBW_BEFORE_BUILD: pip install -r python/install_requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           CIBW_BEFORE_BUILD: pip install -r python/install_requirements.txt
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BEFORE_TEST: python/tools/prepare_test_environment.sh
-          CIBW_TEST_COMMAND: {project}/python/tools/run_test.sh {project}
+          CIBW_TEST_COMMAND: '{project}/python/tools/run_test.sh {project}'
           CIBW_SKIP: cp27-* pp* *i686
 
       - name: Upload Python wheels

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/python/setup.py
+++ b/python/setup.py
@@ -9,7 +9,7 @@ include_dirs = [pybind11.get_include()]
 library_dirs = []
 
 def _get_long_description():
-    readme_path = os.path.join(os.path.dirname(__file__), "..", "README.md")
+    readme_path = os.path.join(os.path.dirname(__file__), "README.md")
     with io.open(readme_path, encoding="utf-8") as readme_file:
         return readme_file.read()
 

--- a/python/tools/prepare_test_environment.sh
+++ b/python/tools/prepare_test_environment.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+set -e
+set -x
+
+# Skip tests on Python 3.8 or greater for now
+if python -c "import sys; assert sys.version_info >= (3, 8)"; then
+    exit
+fi
+
+# Install test rquirements
+pip install -r python/tests/requirements.txt
+
+# Download test data
+curl -o transliteration-aren-all.tar.gz https://opennmt-models.s3.amazonaws.com/transliteration-aren-all.tar.gz
+tar xf transliteration-aren-all.tar.gz -C tests/data/models/

--- a/python/tools/run_test.sh
+++ b/python/tools/run_test.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+set -e
+set -x
+
+ROOT_DIR=$1
+
+# Skip tests on Python 3.8 or greater for now
+if python -c "import sys; assert sys.version_info >= (3, 8)"; then
+    exit
+fi
+
+pytest $ROOT_DIR/python/tests/test.py


### PR DESCRIPTION
In preparation for building wheels for macOS (#133), this PR attempts to use [cibuildwheel](https://github.com/joerick/cibuildwheel) to build wheels. I am however facing two issues here:

1. Test dependencies cannot be installed on Python 3.9 since TensorFlow hasn't released wheels for Python 3.9 yet.
2. `pip wheel` does not allow reading files outside the directory where `setup.py` is located. As a result, I am manually copying `README.md` from the root directory to `python/`before building wheels.

Any advice is welcome.