### PR TITLE
Create a separate CUDA allocator for each host thread

### DIFF
--- a/src/translator_pool.cc
+++ b/src/translator_pool.cc
@@ -169,6 +169,9 @@ namespace ctranslate2 {
 
       if (_request_end) {
         lock.unlock();
+        // The CUDA context is destroyed when the thread exits, so we clear the translation
+        // resources now when the CUDA context is still active.
+        translator.detach_model();
         break;
       }
 


### PR DESCRIPTION
The methods in `cub::CachingDeviceAllocator` use a mutex so we should prefer creating a new allocator for each host thread. Otherwise, this synchronization can degrade performance when creating multiple `Translator` instances on different GPU that are then used in parallel.

Related to #374.