### PR TITLE
Remove ctranslate2 package installed from test dependencies

### DIFF
--- a/python/tools/prepare_test_environment.sh
+++ b/python/tools/prepare_test_environment.sh
@@ -10,6 +10,7 @@ fi
 
 # Install test rquirements
 pip install -r python/tests/requirements.txt
+pip uninstall -y ctranslate2
 
 # Download test data
 curl -o transliteration-aren-all.tar.gz https://opennmt-models.s3.amazonaws.com/transliteration-aren-all.tar.gz


### PR DESCRIPTION
Before this change, tests were run on the latest wheel pushed to PyPI and not the wheel that is built in the CI.