### PR TITLE
Fix issue where macOS wheel fails to load bundled OpenMP runtime

### DIFF
--- a/python/tools/prepare_build_environment_macos.sh
+++ b/python/tools/prepare_build_environment_macos.sh
@@ -9,8 +9,8 @@ ONEAPI_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas
 wget -q $ONEAPI_INSTALLER_URL
 hdiutil attach -noverify -noautofsck $(basename $ONEAPI_INSTALLER_URL)
 sudo /Volumes/$(basename $ONEAPI_INSTALLER_URL .dmg)/bootstrapper.app/Contents/MacOS/bootstrapper --silent --eula accept --components intel.oneapi.mac.mkl.devel:intel.oneapi.mac.dnnl
-# Prefix the install name of libdnnl with @rpath
-sudo install_name_tool -id @rpath/libdnnl.2.dylib /opt/intel/oneapi/dnnl/latest/cpu_iomp/lib/libdnnl.2.0.dylib
+# Fix install name and rpath of libdnnl so that delocate works correctly.
+sudo install_name_tool -id @rpath/libdnnl.2.dylib -add_rpath /opt/intel/oneapi/compiler/latest/mac/compiler/lib /opt/intel/oneapi/dnnl/latest/cpu_iomp/lib/libdnnl.2.0.dylib
 
 # Install LLVM's libomp because Intel's OpenMP runtime included in MKL does
 # not ship with the header file.


### PR DESCRIPTION
I found out that the currently published macOS wheels fail to load the bundled OpenMP runtime due to an issue related to RPATH and delocate. This PR fixes it.

```
>>> import ctranslate2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/site-packages/ctranslate2/__init__.py", line 2, in <module>
    from ctranslate2.translator import Translator
ImportError: dlopen(/usr/local/lib/python3.8/site-packages/ctranslate2/translator.cpython-38-darwin.so, 2): Library not loaded: @rpath/libiomp5.dylib
  Referenced from: /usr/local/lib/python3.8/site-packages/ctranslate2/.dylibs/libdnnl.2.0.dylib
  Reason: image not found
```

