### PR TITLE
Disable translators core pinning in OpenMP builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Some environment variables can be configured to customize the execution:
 * `CT2_CUDA_ALLOW_FP16`: Allow using FP16 computation on GPU even if the device does not have efficient FP16 support.
 * `CT2_CUDA_CACHING_ALLOCATOR_CONFIG`: Tune the CUDA caching allocator (see [Performance](docs/performance.md)).
 * `CT2_FORCE_CPU_ISA`: Force CTranslate2 to select a specific instruction set architecture (ISA). Possible values are: `GENERIC`, `AVX`, `AVX2`. Note: this does not impact backend libraries (such as Intel MKL) which usually have their own environment variables to configure ISA dispatching.
-* `CT2_TRANSLATORS_CORE_OFFSET`: If set to a non negative value, parallel translators are pinned to cores in the range `[offset, offset + inter_threads]`. Requires `intra_threads` to 1.
+* `CT2_TRANSLATORS_CORE_OFFSET`: If set to a non negative value, parallel translators are pinned to cores in the range `[offset, offset + inter_threads]`. Requires compilation with `-DOPENMP_RUNTIME=NONE`.
 * `CT2_USE_EXPERIMENTAL_PACKED_GEMM`: Enable the packed GEMM API for Intel MKL (see [Performance](docs/performance.md)).
 * `CT2_USE_MKL`: Force CTranslate2 to use (or not) Intel MKL. By default, the runtime automatically decides whether to use Intel MKL or not based on the CPU vendor.
 * `CT2_VERBOSE`: Enable some verbose logs to help debugging the run configuration.

--- a/include/ctranslate2/utils.h
+++ b/include/ctranslate2/utils.h
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <random>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "devices.h"
@@ -26,6 +27,7 @@ namespace ctranslate2 {
                                     int device_index = 0);
 
   void set_num_threads(size_t num_threads);
+  void set_thread_affinity(std::thread& thread, int index);
 
   bool ends_with(const std::string& str, const std::string& suffix);
   bool starts_with(const std::string& str, const std::string& prefix);

--- a/src/translator_pool.cc
+++ b/src/translator_pool.cc
@@ -123,15 +123,6 @@ namespace ctranslate2 {
     }
 
     static const int core_offset = read_int_from_env("CT2_TRANSLATORS_CORE_OFFSET", -1);
-    if (core_offset >= 0) {
-#ifdef __linux__
-      if (num_threads_per_translator > 1) {
-        throw std::invalid_argument("Pinning translators to CPU cores requires intra_threads = 1");
-      }
-#else
-      throw std::invalid_argument("Pinning translators to CPU cores is only supported on Linux");
-#endif
-    }
 
     _translators.reserve(num_translators);
     _workers.reserve(num_translators);
@@ -141,20 +132,8 @@ namespace ctranslate2 {
                             this,
                             std::ref(_translators.back()),
                             num_threads_per_translator);
-#ifdef __linux__
-      if (core_offset >= 0) {
-        cpu_set_t cpuset;
-        CPU_ZERO(&cpuset);
-        CPU_SET(core_offset + i, &cpuset);
-        const int status = pthread_setaffinity_np(_workers.back().native_handle(),
-                                                  sizeof (cpu_set_t),
-                                                  &cpuset);
-        if (status != 0) {
-          throw std::runtime_error("Error calling pthread_setaffinity_np: "
-                                   + std::to_string(status));
-        }
-      }
-#endif
+      if (core_offset >= 0)
+        set_thread_affinity(_workers.back(), core_offset + i);
     }
   }
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -163,6 +163,24 @@ namespace ctranslate2 {
 #endif
   }
 
+  void set_thread_affinity(std::thread& thread, int index) {
+#if !defined(__linux__) || defined(_OPENMP)
+    (void)thread;
+    (void)index;
+    throw std::runtime_error("Setting thread affinity is only supported in Linux binaries built "
+                             "with -DOPENMP_RUNTIME=NONE");
+#else
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(index, &cpuset);
+    const int status = pthread_setaffinity_np(thread.native_handle(), sizeof (cpu_set_t), &cpuset);
+    if (status != 0) {
+      throw std::runtime_error("Error calling pthread_setaffinity_np: "
+                               + std::to_string(status));
+    }
+#endif
+  }
+
   bool ends_with(const std::string& str, const std::string& suffix) {
     return (str.size() >= suffix.size() &&
             str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0);


### PR DESCRIPTION
Setting thread affinity does not work when OpenMP is enabled. An error is now raised if the environment variable `CT2_TRANSLATORS_CORE_OFFSET` is set in an OpenMP build.