### PR TITLE
Ensure the same allocator is used to allocate and release CUDA storages

### DIFF
--- a/include/ctranslate2/primitives/primitives.h
+++ b/include/ctranslate2/primitives/primitives.h
@@ -13,9 +13,9 @@ namespace ctranslate2 {
     static void set_device(int index);
     static int get_device();
 
-    static void* alloc_data(dim_t size, int device_index = -1);
-    static void free_data(void* data, int device_index = -1);
-    static void clear_cache();
+    static void* alloc_data(dim_t size, int device_index = -1, void** allocator_handle = nullptr);
+    static void free_data(void* data, int device_index = -1, void* allocator_handle = nullptr);
+    static void clear_cache(void* allocator_handle = nullptr);
 
     template <typename T>
     static T deref(const T* x, dim_t index);

--- a/include/ctranslate2/storage_view.h
+++ b/include/ctranslate2/storage_view.h
@@ -230,6 +230,7 @@ namespace ctranslate2 {
     DataType _dtype = DataType::FLOAT;
     Device _device = Device::CPU;
     int _device_index = 0;
+    void* _allocator = nullptr;
     void* _data = nullptr;
     bool _own_data = true;
     dim_t _allocated_size = 0;

--- a/src/primitives/cpu.cc
+++ b/src/primitives/cpu.cc
@@ -41,17 +41,17 @@ namespace ctranslate2 {
   }
 
   template<>
-  void* primitives<Device::CPU>::alloc_data(dim_t size, int) {
+  void* primitives<Device::CPU>::alloc_data(dim_t size, int, void**) {
     return aligned_alloc(size, ALIGNMENT);
   }
 
   template<>
-  void primitives<Device::CPU>::free_data(void* data, int) {
+  void primitives<Device::CPU>::free_data(void* data, int, void*) {
     aligned_free(data);
   }
 
   template<>
-  void primitives<Device::CPU>::clear_cache() {
+  void primitives<Device::CPU>::clear_cache(void*) {
 #ifdef CT2_WITH_MKL
     mkl_free_buffers();
 #endif

--- a/src/storage_view.cc
+++ b/src/storage_view.cc
@@ -130,9 +130,10 @@ namespace ctranslate2 {
 
   StorageView& StorageView::release() {
     if (_own_data && _data != nullptr) {
-      DEVICE_DISPATCH(_device, primitives<D>::free_data(_data, _device_index));
+      DEVICE_DISPATCH(_device, primitives<D>::free_data(_data, _device_index, _allocator));
     }
     _data = nullptr;
+    _allocator = nullptr;
     _allocated_size = 0;
     return clear();
   }
@@ -143,7 +144,9 @@ namespace ctranslate2 {
     release();
     dim_t required_bytes = 0;
     TYPE_DISPATCH(_dtype, required_bytes = size * sizeof (T));
-    DEVICE_DISPATCH(_device, _data = primitives<D>::alloc_data(required_bytes, _device_index));
+    DEVICE_DISPATCH(_device, _data = primitives<D>::alloc_data(required_bytes,
+                                                               _device_index,
+                                                               &_allocator));
     if (_data == nullptr)
       THROW_RUNTIME_ERROR("failed to allocated memory");
     _own_data = true;
@@ -430,6 +433,7 @@ namespace ctranslate2 {
     std::swap(a._dtype, b._dtype);
     std::swap(a._device, b._device);
     std::swap(a._device_index, b._device_index);
+    std::swap(a._allocator, b._allocator);
     std::swap(a._data, b._data);
     std::swap(a._own_data, b._own_data);
     std::swap(a._allocated_size, b._allocated_size);


### PR DESCRIPTION
Each thread has its own CUDA allocator since commit 13a0dddc. However, the Python method `unload_model()` clears some resources that were possibly allocated by another thread using another CUDA allocator. In that case, the memory should be released with this initial allocator and not the allocator of the current thread.