### PR TITLE
Explicitly set CUDA_VISIBLE_DEVICES to "" in CPU CT2 benchmark

### DIFF
--- a/tools/benchmark/run.sh
+++ b/tools/benchmark/run.sh
@@ -33,13 +33,13 @@ then
             --command "-src %s -output %s -beam_size $BEAM_SIZE -batch_size $BATCH_SIZE -int8"
 
     $PREFIX --image opennmt/ctranslate2-benchmark --name cpu-ctranslate2-float \
-            --command "--src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE"
+            --command "--device cpu --src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE"
     $PREFIX --image opennmt/ctranslate2-benchmark --name cpu-ctranslate2-int16 \
-            --command "--src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE --compute_type int16"
+            --command "--device cpu --src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE --compute_type int16"
     $PREFIX --image opennmt/ctranslate2-benchmark --name cpu-ctranslate2-int8 \
-            --command "--src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE --compute_type int8"
+            --command "--device cpu --src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE --compute_type int8"
     $PREFIX --image opennmt/ctranslate2-benchmark --name cpu-ctranslate2-int8-vmap \
-            --command "--src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE --compute_type int8 --use_vmap"
+            --command "--device cpu --src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE --compute_type int8 --use_vmap"
 
 else
 

--- a/tools/benchmark/run.sh
+++ b/tools/benchmark/run.sh
@@ -33,13 +33,13 @@ then
             --command "-src %s -output %s -beam_size $BEAM_SIZE -batch_size $BATCH_SIZE -int8"
 
     $PREFIX --image opennmt/ctranslate2-benchmark --name cpu-ctranslate2-float \
-            --command "--device cpu --src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE"
+            --command "--src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE"
     $PREFIX --image opennmt/ctranslate2-benchmark --name cpu-ctranslate2-int16 \
-            --command "--device cpu --src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE --compute_type int16"
+            --command "--src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE --compute_type int16"
     $PREFIX --image opennmt/ctranslate2-benchmark --name cpu-ctranslate2-int8 \
-            --command "--device cpu --src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE --compute_type int8"
+            --command "--src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE --compute_type int8"
     $PREFIX --image opennmt/ctranslate2-benchmark --name cpu-ctranslate2-int8-vmap \
-            --command "--device cpu --src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE --compute_type int8 --use_vmap"
+            --command "--src %s --out %s --beam_size $BEAM_SIZE --batch_size $BATCH_SIZE --compute_type int8 --use_vmap"
 
 else
 


### PR DESCRIPTION
Hey @guillaumekln
Looks like in some cases the CPU benchmark still runs on GPU (when available) -- probably linked to the fact that the default docker runtime is set to `nvidia` on the machine(s) in question. To prevent any unwanted behavior, I propose to explicitly set the cpu device in the command.
(Maybe we could make this change in the `benchmark.py` script, but at least in the `run.sh` it's quite explicit to the user.)
What do you think?