### PR TITLE
Improve thread safety when loading/unloading models from Python

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -145,8 +145,6 @@ Note: parallelization with Python threads is made possible because the `Translat
 * `translator.model_is_loaded`<br/>Property set to `True` when the model is loaded on the initial device and ready to be used.
 * `del translator`<br/>Release the translator resources.
 
-When using multiple Python threads, the application should ensure that no translations are running before calling these functions.
-
 ## Utility API
 
 * `ctranslate2.contains_model(path: str)`<br/>Helper function to check if a directory seems to contain a CTranslate2 model.

--- a/docs/python.md
+++ b/docs/python.md
@@ -140,9 +140,7 @@ Note: parallelization with Python threads is made possible because the `Translat
 
 ## Memory management API
 
-* `translator.unload_model(to_cpu: bool = False, timeout: int = 10)`<br/>Unload the model attached to this translator but keep enough runtime context to quickly resume translation on the initial device. Returns `True` if the model was actually unloaded.
-  * `to_cpu`: If `True`, the model is moved to the CPU memory and not fully unloaded.
-  * `timeout`: The method will block as long as the translator is being used in other threads. If after this many seconds the model can't be unloaded, the operation is aborted.
+* `translator.unload_model(to_cpu: bool = False)`<br/>Unload the model attached to this translator but keep enough runtime context to quickly resume translation on the initial device. When `to_cpu` is `True`, the model is moved to the CPU memory and not fully unloaded.
 * `translator.load_model()`<br/>Load the model back to the initial device.
 * `translator.model_is_loaded`<br/>Property set to `True` when the model is loaded on the initial device and ready to be used.
 * `del translator`<br/>Release the translator resources.

--- a/docs/python.md
+++ b/docs/python.md
@@ -140,7 +140,9 @@ Note: parallelization with Python threads is made possible because the `Translat
 
 ## Memory management API
 
-* `translator.unload_model(to_cpu: bool = False)`<br/>Unload the model attached to this translator but keep enough runtime context to quickly resume translation on the initial device. When `to_cpu` is `True`, the model is moved to the CPU memory and not fully unloaded.
+* `translator.unload_model(to_cpu: bool = False, timeout: int = 10)`<br/>Unload the model attached to this translator but keep enough runtime context to quickly resume translation on the initial device. Returns `True` if the model was actually unloaded.
+  * `to_cpu`: If `True`, the model is moved to the CPU memory and not fully unloaded.
+  * `timeout`: The method will block as long as the translator is being used in other threads. If after this many seconds the model can't be unloaded, the operation is aborted.
 * `translator.load_model()`<br/>Load the model back to the initial device.
 * `translator.model_is_loaded`<br/>Property set to `True` when the model is loaded on the initial device and ready to be used.
 * `del translator`<br/>Release the translator resources.

--- a/docs/python.md
+++ b/docs/python.md
@@ -140,7 +140,8 @@ Note: parallelization with Python threads is made possible because the `Translat
 
 ## Memory management API
 
-* `translator.unload_model(to_cpu: bool = False)`<br/>Unload the model attached to this translator but keep enough runtime context to quickly resume translation on the initial device. When `to_cpu` is `True`, the model is moved to the CPU memory and not fully unloaded.
+* `translator.unload_model(to_cpu: bool = False)`<br/>Unload the model attached to this translator but keep enough runtime context to quickly resume translation on the initial device. The model is not guaranteed to be unloaded if the translator is used simultaneously in another thread.
+  * `to_cpu`: If `True`, the model is moved to the CPU memory and not fully unloaded.
 * `translator.load_model()`<br/>Load the model back to the initial device.
 * `translator.model_is_loaded`<br/>Property set to `True` when the model is loaded on the initial device and ready to be used.
 * `del translator`<br/>Release the translator resources.

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -282,15 +282,17 @@ public:
   }
 
   void unload_model(const bool to_cpu) {
+    if (to_cpu && _device == ctranslate2::Device::CPU)
+      return;
+
     py::gil_scoped_release release;
 
-    {
-      std::shared_lock lock(_mutex);
-      if (!_model_is_loaded || (to_cpu && _device == ctranslate2::Device::CPU))
-        return;
-    }
+    // If the lock is not acquired immediately it means the model is being used
+    // in another thread and we can't unload it at this time.
+    std::unique_lock lock(_mutex, std::try_to_lock);
+    if (!lock || !_model_is_loaded)
+      return;
 
-    std::unique_lock lock(_mutex);
     const auto& translators = _translator_pool.get_translators();
     if (to_cpu)
       _cached_models.reserve(translators.size());
@@ -311,13 +313,10 @@ public:
   void load_model() {
     py::gil_scoped_release release;
 
-    {
-      std::shared_lock lock(_mutex);
-      if (_model_is_loaded)
-        return;
-    }
-
     std::unique_lock lock(_mutex);
+    if (_model_is_loaded)
+      return;
+
     if (_cached_models.empty()) {
       _cached_models = ctranslate2::models::load_replicas(_model_path,
                                                           _device,
@@ -354,7 +353,7 @@ private:
   std::vector<std::shared_ptr<const ctranslate2::models::Model>> _cached_models;
   bool _model_is_loaded;
 
-  // Use a shared_mutex to protect the model state (loaded/unloaded).
+  // Use a shared mutex to protect the model state (loaded/unloaded).
   // Multiple threads can read the model at the same time, but a single thread can change
   // the model state (e.g. load or unload the model).
   std::shared_mutex _mutex;

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -358,7 +358,7 @@ private:
   // the model state (e.g. load or unload the model).
   std::shared_mutex _mutex;
 
-  void assert_model_is_ready() {
+  void assert_model_is_ready() const {
     if (!_model_is_loaded)
       throw std::runtime_error("The model for this translator was unloaded");
   }

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -281,18 +281,16 @@ public:
     return py_results;
   }
 
-  bool unload_model(const bool to_cpu, const int timeout) {
-    if (to_cpu && _device == ctranslate2::Device::CPU)
-      return false;
-
+  void unload_model(const bool to_cpu) {
     py::gil_scoped_release release;
 
-    // If the mutex is not locked after timeout seconds, it means new translation requests
-    // keep coming in other threads and the model can't be unloaded at this time.
-    std::unique_lock lock(_mutex, std::chrono::seconds(timeout));
-    if (!_model_is_loaded || !lock)
-      return false;
+    {
+      std::shared_lock lock(_mutex);
+      if (!_model_is_loaded || (to_cpu && _device == ctranslate2::Device::CPU))
+        return;
+    }
 
+    std::unique_lock lock(_mutex);
     const auto& translators = _translator_pool.get_translators();
     if (to_cpu)
       _cached_models.reserve(translators.size());
@@ -308,16 +306,18 @@ public:
     }
 
     _model_is_loaded = false;
-    return true;
   }
 
   void load_model() {
     py::gil_scoped_release release;
 
-    std::unique_lock lock(_mutex);
-    if (_model_is_loaded)
-      return;
+    {
+      std::shared_lock lock(_mutex);
+      if (_model_is_loaded)
+        return;
+    }
 
+    std::unique_lock lock(_mutex);
     if (_cached_models.empty()) {
       _cached_models = ctranslate2::models::load_replicas(_model_path,
                                                           _device,
@@ -354,10 +354,10 @@ private:
   std::vector<std::shared_ptr<const ctranslate2::models::Model>> _cached_models;
   bool _model_is_loaded;
 
-  // Use a shared mutex to protect the model state (loaded/unloaded).
+  // Use a shared_mutex to protect the model state (loaded/unloaded).
   // Multiple threads can read the model at the same time, but a single thread can change
   // the model state (e.g. load or unload the model).
-  std::shared_timed_mutex _mutex;
+  std::shared_mutex _mutex;
 
   void assert_model_is_ready() {
     if (!_model_is_loaded)
@@ -421,8 +421,7 @@ PYBIND11_MODULE(translator, m)
          py::arg("target_tokenize_fn")=nullptr,
          py::arg("replace_unknowns")=false)
     .def("unload_model", &TranslatorWrapper::unload_model,
-         py::arg("to_cpu")=false,
-         py::arg("timeout")=10)
+         py::arg("to_cpu")=false)
     .def("load_model", &TranslatorWrapper::load_model)
     .def_property_readonly("model_is_loaded", &TranslatorWrapper::model_is_loaded)
     ;

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -1,3 +1,4 @@
+#include <mutex>
 #include <optional>
 #include <shared_mutex>
 #include <unordered_map>


### PR DESCRIPTION
Changing the model state (unloading, loading) is now thread safe.