### PR TITLE
Add "auto" compute type

### DIFF
--- a/cli/translate.cc
+++ b/cli/translate.cc
@@ -13,7 +13,7 @@ int main(int argc, char* argv[]) {
   cmd_options.add_options()
     ("h,help", "Display available options.")
     ("model", "Path to the CTranslate2 model directory.", cxxopts::value<std::string>())
-    ("compute_type", "The type used for computation: default, float, float16, int16, or int8",
+    ("compute_type", "The type used for computation: default, auto, float, float16, int16, or int8",
      cxxopts::value<std::string>()->default_value("default"))
     ("cuda_compute_type", "Computation type on CUDA devices (overrides compute_type)",
      cxxopts::value<std::string>())

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -6,6 +6,7 @@ Below are some recommendations to further improve translation performance. Many 
 
 ### General
 
+* Set the compute type to "auto" to automatically select the fastest execution path on the current system
 * Reduce the beam size to the minimum value that meets your quality requirement
 * When using a beam size of 1, disable `return_scores` if you are not using prediction scores: the final softmax layer can be skipped
 * Set `max_batch_size` and pass a larger batch to `translate_batch`: the input sentences will be sorted by length and split by chunk of `max_batch_size` elements for improved efficiency
@@ -13,14 +14,12 @@ Below are some recommendations to further improve translation performance. Many 
 
 ### CPU
 
-* Set the compute type to "int8"
 * Use an Intel CPU supporting AVX512
 * If you are translating a large volume of data, prefer increasing `inter_threads` over `intra_threads` to improve scalability
 * Avoid setting `intra_threads` to a value that is greater than the number of physical cores
 
 ### GPU
 
-* Set the compute type to "float16" if you have a NVIDIA GPU with Compute Capability >= 7.0
 * Pass multiple GPU IDs to `device_index` to run translations on multiple GPUs
 
 ## Measuring performance

--- a/docs/python.md
+++ b/docs/python.md
@@ -37,7 +37,7 @@ translator = ctranslate2.Translator(
     # The device ID, or list of device IDs, where to place this translator on.
     device_index: Union[int, List[int]] = 0,
 
-    # The computation type: "default", "int8", "int16", "float16", or "float",
+    # The computation type: "default", "auto", "int8", "int16", "float16", or "float",
     # or a dict mapping a device to a computation type.
     compute_type: Union[str, Dict[str, str]] = "default",
 

--- a/include/ctranslate2/types.h
+++ b/include/ctranslate2/types.h
@@ -23,6 +23,7 @@ namespace ctranslate2 {
 
   enum class ComputeType {
     DEFAULT,
+    AUTO,
     FLOAT,
     INT8,
     INT16,

--- a/src/types.cc
+++ b/src/types.cc
@@ -34,6 +34,8 @@ namespace ctranslate2 {
       return ComputeType::FLOAT16;
     if (compute_type == "default")
       return ComputeType::DEFAULT;
+    if (compute_type == "auto")
+      return ComputeType::AUTO;
     throw std::invalid_argument("Invalid compute type: " + compute_type);
   }
 
@@ -82,6 +84,21 @@ namespace ctranslate2 {
         return ComputeType::INT16;
       if (device == Device::CUDA && mayiuse_float16(device, device_index))
         return ComputeType::FLOAT16;
+      return ComputeType::FLOAT;
+    }
+
+    case ComputeType::AUTO: {
+      if (device == Device::CUDA) {
+        if (mayiuse_float16(device, device_index))
+          return ComputeType::FLOAT16;
+        if (mayiuse_int8(device, device_index))
+          return ComputeType::INT8;
+      } else {
+        if (mayiuse_int8(device, device_index))
+          return ComputeType::INT8;
+        if (mayiuse_int16(device, device_index))
+          return ComputeType::INT16;
+      }
       return ComputeType::FLOAT;
     }
 

--- a/tests/translator_test.cc
+++ b/tests/translator_test.cc
@@ -62,8 +62,14 @@ TEST_P(ModelVariantTest, Transliteration) {
   type_params.emplace_back(ComputeType::FLOAT, DataType::FLOAT);
   if (mayiuse_int16(device))
     type_params.emplace_back(ComputeType::INT16, DataType::INT16);
-  if (mayiuse_int8(device))
+  if (mayiuse_int8(device)) {
     type_params.emplace_back(ComputeType::INT8, DataType::INT8);
+    type_params.emplace_back(ComputeType::AUTO, DataType::INT8);
+  } else if (mayiuse_int16(device)) {
+    type_params.emplace_back(ComputeType::AUTO, DataType::INT16);
+  } else {
+    type_params.emplace_back(ComputeType::AUTO, DataType::FLOAT);
+  }
 
   for (const auto& types : type_params) {
     const ComputeType compute_type = types.first;


### PR DESCRIPTION
This makes it easier to always use the fastest compute type on any device type and system.