### PR TITLE
Clear memory allocator cache when unloading model

### DIFF
--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -120,6 +120,12 @@ namespace ctranslate2 {
     // Detach the model from this translator, which becomes unusable until set_model is called.
     void detach_model();
 
+    // Return the memory allocator associated with this translator.
+    // The allocator is registered on the first translation.
+    Allocator* get_allocator() const {
+      return _allocator;
+    }
+
   private:
     void assert_has_model() const;
 
@@ -132,6 +138,7 @@ namespace ctranslate2 {
     std::unique_ptr<layers::Encoder> _encoder;
     std::unique_ptr<layers::Decoder> _decoder;
     const models::SequenceToSequenceModel* _seq2seq_model = nullptr;
+    Allocator* _allocator = nullptr;
   };
 
   struct Batch {

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -293,6 +293,11 @@ public:
       }
 
       const_cast<ctranslate2::Translator&>(translator).detach_model();
+
+      // Clear cache of memory allocator associated with this translator.
+      auto* allocator = translator.get_allocator();
+      if (allocator && _device == ctranslate2::Device::CUDA)
+        allocator->clear_cache();
     }
 
     _model_is_loaded = false;

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -142,6 +142,10 @@ namespace ctranslate2 {
     PROFILE("run_batch_translation");
     assert_has_model();
     auto scoped_device_setter = _model->get_scoped_device_setter();
+    const Device device = _model->device();
+
+    if (!_allocator)
+      _allocator = &ctranslate2::get_allocator(device);
 
     const auto& source_vocabulary = _seq2seq_model->get_source_vocabulary();
     const auto& target_vocabulary = _seq2seq_model->get_target_vocabulary();
@@ -150,7 +154,6 @@ namespace ctranslate2 {
                                                      _seq2seq_model->with_source_eos());
     const auto target_prefix_ids = target_vocabulary.to_ids(target_prefix);
 
-    const Device device = _model->device();
     const dim_t preferred_size_multiple = get_preferred_size_multiple(
       _model->effective_compute_type(),
       device,


### PR DESCRIPTION
Each translator instance has its own memory allocator and associated cache. This cache should be cleared when `unload_model` is called. 

Fixes #426.