### PR TITLE
Update Intel oneAPI to 2021.2

### DIFF
--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -18,15 +18,14 @@ RUN wget -q https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/c
     rm *.tar.gz
 ENV PATH=$PATH:/root/cmake-$CMAKE_VERSION-Linux-x86_64/bin
 
-ENV ONEAPI_VERSION=2021.1.1
-ENV MKL_BUILD=52
-ENV DNNL_BUILD=55
+ENV ONEAPI_VERSION=2021.2.0
+ENV MKL_BUILD=296
+ENV DNNL_BUILD=228
 RUN yum-config-manager --add-repo https://yum.repos.intel.com/oneapi && \
     rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && \
     yum install -y \
         intel-oneapi-mkl-devel-$ONEAPI_VERSION-$MKL_BUILD \
         intel-oneapi-dnnl-devel-$ONEAPI_VERSION-$DNNL_BUILD \
-        intel-oneapi-common-vars-$ONEAPI_VERSION-60 \
         && \
     rm -rf /var/cache/yum/*
 

--- a/docker/Dockerfile.centos7-gpu
+++ b/docker/Dockerfile.centos7-gpu
@@ -21,15 +21,14 @@ RUN wget -q https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/c
     rm *.tar.gz
 ENV PATH=$PATH:/root/cmake-$CMAKE_VERSION-Linux-x86_64/bin
 
-ENV ONEAPI_VERSION=2021.1.1
-ENV MKL_BUILD=52
-ENV DNNL_BUILD=55
+ENV ONEAPI_VERSION=2021.2.0
+ENV MKL_BUILD=296
+ENV DNNL_BUILD=228
 RUN yum-config-manager --add-repo https://yum.repos.intel.com/oneapi && \
     rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && \
     yum install -y \
         intel-oneapi-mkl-devel-$ONEAPI_VERSION-$MKL_BUILD \
         intel-oneapi-dnnl-devel-$ONEAPI_VERSION-$DNNL_BUILD \
-        intel-oneapi-common-vars-$ONEAPI_VERSION-60 \
         && \
     rm -rf /var/cache/yum/*
 

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -20,9 +20,9 @@ RUN wget -q https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/c
     rm *.tar.gz
 ENV PATH=$PATH:/root/cmake-$CMAKE_VERSION-Linux-x86_64/bin
 
-ENV ONEAPI_VERSION=2021.1.1
-ENV MKL_BUILD=52
-ENV DNNL_BUILD=55
+ENV ONEAPI_VERSION=2021.2.0
+ENV MKL_BUILD=296
+ENV DNNL_BUILD=228
 RUN wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && \
     apt-key add *.PUB && \
     rm *.PUB && \

--- a/docker/Dockerfile.ubuntu-gpu
+++ b/docker/Dockerfile.ubuntu-gpu
@@ -21,9 +21,9 @@ RUN wget -q https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/c
     rm *.tar.gz
 ENV PATH=$PATH:/root/cmake-$CMAKE_VERSION-Linux-x86_64/bin
 
-ENV ONEAPI_VERSION=2021.1.1
-ENV MKL_BUILD=52
-ENV DNNL_BUILD=55
+ENV ONEAPI_VERSION=2021.2.0
+ENV MKL_BUILD=296
+ENV DNNL_BUILD=228
 RUN wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && \
     apt-key add *.PUB && \
     rm *.PUB && \

--- a/python/tools/prepare_build_environment_linux.sh
+++ b/python/tools/prepare_build_environment_linux.sh
@@ -19,13 +19,13 @@ ln -s cuda-10.1 /usr/local/cuda
 yum install -y devtoolset-8
 source /opt/rh/devtoolset-8/enable
 
-ONEAPI_VERSION=2021.1.1
-MKL_BUILD=52
-DNNL_BUILD=55
+ONEAPI_VERSION=2021.2.0
+MKL_BUILD=296
+DNNL_BUILD=228
 yum install -y yum-utils
 yum-config-manager --add-repo https://yum.repos.intel.com/oneapi
 rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-yum install -y intel-oneapi-mkl-devel-$ONEAPI_VERSION-$MKL_BUILD intel-oneapi-dnnl-devel-$ONEAPI_VERSION-$DNNL_BUILD intel-oneapi-common-vars-$ONEAPI_VERSION-60
+yum install -y intel-oneapi-mkl-devel-$ONEAPI_VERSION-$MKL_BUILD intel-oneapi-dnnl-devel-$ONEAPI_VERSION-$DNNL_BUILD
 echo "/opt/intel/oneapi/dnnl/latest/cpu_gomp/lib" > /etc/ld.so.conf.d/intel-dnnl.conf
 ldconfig
 


### PR DESCRIPTION
This is mostly to resolve version conflicts since Intel uploaded the 2021.2 packages to their repositories.