### PR TITLE
Use the default cuBLAS GEMM algorithm

### DIFF
--- a/src/cuda/primitives.cu
+++ b/src/cuda/primitives.cu
@@ -375,7 +375,7 @@ namespace ctranslate2 {
                               &beta_h,
                               c, CUDA_R_16F, ldc,
                               CUDA_R_16F,
-                              CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+                              CUBLAS_GEMM_DEFAULT));
   }
 
   template<>
@@ -407,7 +407,7 @@ namespace ctranslate2 {
                               &beta_i,
                               c, CUDA_R_32I, ldc,
                               CUDA_R_32I,
-                              CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+                              CUBLAS_GEMM_DEFAULT));
   }
 
   template<>
@@ -475,7 +475,7 @@ namespace ctranslate2 {
                                             c, CUDA_R_16F, ldc, stridec,
                                             batch_size,
                                             CUDA_R_16F,
-                                            CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+                                            CUBLAS_GEMM_DEFAULT));
   }
 
   struct exp_func {


### PR DESCRIPTION
`CUBLAS_GEMM_DEFAULT_TENSOR_OP` is deprecated and has currently no impact in how it is used.

Possibly related to #414.