### PR TITLE
Fix int8 quantization when a row contains only zeros

### DIFF
--- a/python/ctranslate2/specs/model_spec.py
+++ b/python/ctranslate2/specs/model_spec.py
@@ -134,7 +134,9 @@ class LayerSpec(object):
                     )
                     value = value.astype(np.int16)
                 elif quantization == "int8":
-                    scale = 127.0 / np.amax(np.absolute(value), axis=1)
+                    amax = np.amax(np.absolute(value), axis=1)
+                    amax[amax == 0] = 127.0
+                    scale = 127.0 / amax
                     value *= np.expand_dims(scale, 1)
                     value = value.astype(np.int8)
                 setattr(spec, "weight_scale", scale)

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -587,6 +587,19 @@ def test_layer_spec_optimize():
     assert spec.sub.a.dtype == np.float16
 
 
+def test_int8_quantization():
+    class Spec(ctranslate2.specs.LayerSpec):
+        def __init__(self):
+            self.weight = np.array([[-10, -3, 5, 2], [0, 0, 0, 0]], dtype=np.float32)
+
+    spec = Spec()
+    spec.optimize(quantization="int8")
+    assert np.array_equal(
+        spec.weight, np.array([[-127, -38, 63, 25], [0, 0, 0, 0]], dtype=np.int8)
+    )
+    assert np.array_equal(spec.weight_scale, np.array([12.7, 1], dtype=np.float32))
+
+
 def test_index_spec():
     spec = ctranslate2.specs.TransformerBase()
     assert isinstance(

--- a/src/ops/quantize_cpu.cc
+++ b/src/ops/quantize_cpu.cc
@@ -65,7 +65,8 @@ namespace ctranslate2 {
               std::min(v * scale_value,
                        static_cast<float>(std::numeric_limits<int16_t>::max())),
               static_cast<float>(std::numeric_limits<int16_t>::lowest())));
-        }
+        });
+    }
 
   }
 }

--- a/src/ops/quantize_cpu.cc
+++ b/src/ops/quantize_cpu.cc
@@ -10,6 +10,8 @@ namespace ctranslate2 {
                                                  StorageView& output,
                                                  StorageView& scale) const {
       // INT8 quantization rescales based on the per batch absolute maximum.
+      constexpr float int8_max = std::numeric_limits<int8_t>::max();
+      constexpr float int8_min = std::numeric_limits<int8_t>::min();
 
       const dim_t batch_size = scale.size();
       const dim_t depth = input.dim(-1);
@@ -18,17 +20,15 @@ namespace ctranslate2 {
       auto* output_data = output.data<int8_t>();
       auto* scale_data = scale.data<float>();
 
-      const float shift = (_shift_to_uint8
-                           ? -static_cast<float>(std::numeric_limits<int8_t>::min())
-                           : 0);
+      const float shift = (_shift_to_uint8 ? -int8_min : 0);
 
       #pragma omp parallel for
       for (dim_t i = 0; i < batch_size; ++i) {
         const dim_t offset = i * depth;
         const auto* row = input_data + offset;
         auto* qrow = output_data + offset;
-        const auto row_scale = (static_cast<float>(std::numeric_limits<int8_t>::max())
-                                / primitives<Device::CPU>::amax(row, depth));
+        const auto amax = primitives<Device::CPU>::amax(row, depth);
+        const auto row_scale = (amax != 0.f ? int8_max / amax : 1.f);
         cpu::unary_transform(row, qrow, depth,
                              [row_scale, shift](float v) {
                                return static_cast<int8_t>(v * row_scale + shift);
@@ -42,6 +42,8 @@ namespace ctranslate2 {
                                                   StorageView& output,
                                                   StorageView& scale) const {
       // INT16 quantization simply rescales by a constant.
+      constexpr float int16_max = std::numeric_limits<int16_t>::max();
+      constexpr float int16_min = std::numeric_limits<int16_t>::min();
 
       const dim_t size = input.size();
       const auto* input_data = input.data<float>();
@@ -60,11 +62,7 @@ namespace ctranslate2 {
       cpu::parallel_unary_transform(
         input_data, output_data, size, /*work_size=*/5,
         [scale_value](float v) {
-          return static_cast<int16_t>(
-            std::max(
-              std::min(v * scale_value,
-                       static_cast<float>(std::numeric_limits<int16_t>::max())),
-              static_cast<float>(std::numeric_limits<int16_t>::lowest())));
+          return static_cast<int16_t>(std::max(std::min(v * scale_value, int16_max), int16_min));
         });
     }
 

--- a/src/ops/quantize_cpu.cc
+++ b/src/ops/quantize_cpu.cc
@@ -61,7 +61,7 @@ namespace ctranslate2 {
 
       cpu::parallel_unary_transform(
         input_data, output_data, size, /*work_size=*/5,
-        [scale_value](float v) {
+        [scale_value, int16_max, int16_min](float v) {
           return static_cast<int16_t>(std::max(std::min(v * scale_value, int16_max), int16_min));
         });
     }

--- a/src/ops/quantize_cpu.cc
+++ b/src/ops/quantize_cpu.cc
@@ -42,8 +42,6 @@ namespace ctranslate2 {
                                                   StorageView& output,
                                                   StorageView& scale) const {
       // INT16 quantization simply rescales by a constant.
-      constexpr float int16_max = std::numeric_limits<int16_t>::max();
-      constexpr float int16_min = std::numeric_limits<int16_t>::min();
 
       const dim_t size = input.size();
       const auto* input_data = input.data<float>();
@@ -61,10 +59,13 @@ namespace ctranslate2 {
 
       cpu::parallel_unary_transform(
         input_data, output_data, size, /*work_size=*/5,
-        [scale_value, int16_max, int16_min](float v) {
-          return static_cast<int16_t>(std::max(std::min(v * scale_value, int16_max), int16_min));
-        });
-    }
+        [scale_value](float v) {
+          return static_cast<int16_t>(
+            std::max(
+              std::min(v * scale_value,
+                       static_cast<float>(std::numeric_limits<int16_t>::max())),
+              static_cast<float>(std::numeric_limits<int16_t>::lowest())));
+        }
 
   }
 }

--- a/src/ops/quantize_gpu.cu
+++ b/src/ops/quantize_gpu.cu
@@ -42,7 +42,7 @@ namespace ctranslate2 {
 
       float thread_max = cuda::ilp_reduce(input, depth, absolute_maximum_func(), 0.f);
       float max = cuda::block_reduce(sdata, thread_max, maximum_func(), 0.f);
-      float scale = 127.f / max;
+      float scale = max != 0.f ? 127.f / max : 1.f;
 
       scales[blockIdx.x] = scale;
 

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -630,6 +630,18 @@ TEST_P(OpDeviceTest, QuantizeINT8) {
   expect_storage_eq(qa, expected_qa);
 }
 
+TEST_P(OpDeviceTest, QuantizeINT8ZeroRow) {
+  Device device = GetParam();
+  StorageView a({2, 4}, std::vector<float>{-10, -3, 5, 2, 0, 0, 0, 0}, device);
+  StorageView scale(DataType::FLOAT, device);
+  StorageView qa(DataType::INT8, device);
+  StorageView expected_scale({2}, std::vector<float>{12.7, 1}, device);
+  StorageView expected_qa(a.shape(), std::vector<int8_t>{-127, -38, 63, 25, 0, 0, 0, 0});
+  ops::Quantize()(a, qa, scale);
+  expect_storage_eq(scale, expected_scale);
+  expect_storage_eq(qa, expected_qa);
+}
+
 TEST_P(OpDeviceFPTest, Multinomial) {
   const Device device = GetParam().first;
   const DataType dtype = GetParam().second;


### PR DESCRIPTION
OpenNMT-tf "update_vocab" feature initializes new embeddings with a zero vector. If they are not updated during the training it can lead to unexpected quantization values or warnings for these rows.