### PR TITLE
Fix CUDA code path of Multinomial op

### DIFF
--- a/include/ctranslate2/ops/multinomial.h
+++ b/include/ctranslate2/ops/multinomial.h
@@ -13,6 +13,8 @@ namespace ctranslate2 {
     private:
       dim_t _sample_size;
 
+      void dispatch(const StorageView& input, StorageView& output) const;
+
       template <Device D, typename T>
       void compute(const StorageView& input, StorageView& output) const;
     };

--- a/src/ops/multinomial.cc
+++ b/src/ops/multinomial.cc
@@ -17,6 +17,10 @@ namespace ctranslate2 {
       output_shape.back() = _sample_size;
       output.resize(output_shape);
 
+      dispatch(input, output);
+    }
+
+    void Multinomial::dispatch(const StorageView& input, StorageView& output) const {
       switch (input.dtype()) {
       case DataType::FLOAT:
         DEVICE_DISPATCH(input.device(), (compute<D, float>(input, output)));

--- a/src/ops/multinomial_gpu.cu
+++ b/src/ops/multinomial_gpu.cu
@@ -9,7 +9,7 @@ namespace ctranslate2 {
     void Multinomial::compute(const StorageView& input, StorageView& output) const {
       // TODO: CUDA implementation.
       StorageView output_host(output.shape(), output.dtype());
-      compute<Device::CPU, T>(input.to(Device::CPU), output_host);
+      dispatch(input.to(Device::CPU), output_host);
       output.copy_from(output_host);
     }
 


### PR DESCRIPTION
For some reasons the CPU fallback was called with an incorrect template type. We can redo the type dispatch to workaround this error.