### PR TITLE
Respect return_scores value when building results for empty inputs

### DIFF
--- a/include/ctranslate2/generation_result.h
+++ b/include/ctranslate2/generation_result.h
@@ -8,11 +8,15 @@ namespace ctranslate2 {
   template <typename T>
   class GenerationResult {
   public:
-    GenerationResult(const size_t num_hypotheses, const bool with_attention);  // Empty result.
     GenerationResult(std::vector<std::vector<T>> hypotheses);
     GenerationResult(std::vector<std::vector<T>> hypotheses,
                      std::vector<float> scores,
                      std::vector<std::vector<std::vector<float>>> attention);
+
+    // Construct an empty result.
+    GenerationResult(const size_t num_hypotheses,
+                     const bool with_attention,
+                     const bool with_score);
 
     size_t num_hypotheses() const;
 

--- a/src/generation_result.cc
+++ b/src/generation_result.cc
@@ -1,11 +1,15 @@
 #include "ctranslate2/generation_result.h"
 
+#include <stdexcept>
+
 namespace ctranslate2 {
 
   template <typename T>
-  GenerationResult<T>::GenerationResult(const size_t num_hypotheses, const bool with_attention)
+  GenerationResult<T>::GenerationResult(const size_t num_hypotheses,
+                                        const bool with_attention,
+                                        const bool with_score)
     : _hypotheses(num_hypotheses)
-    , _scores(num_hypotheses, static_cast<float>(0))
+    , _scores(with_score ? num_hypotheses : 0, static_cast<float>(0))
     , _attention(with_attention ? num_hypotheses : 0) {
   }
 
@@ -30,6 +34,8 @@ namespace ctranslate2 {
 
   template <typename T>
   float GenerationResult<T>::score() const {
+    if (_scores.empty())
+      throw std::runtime_error("This result has no scores");
     return _scores[0];
   }
 

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -101,7 +101,9 @@ namespace ctranslate2 {
     if (!options.rebatch_input)
       return run_batch_translation(source, target_prefix, options);
 
-    const TranslationResult empty_result(options.num_hypotheses, options.return_attention);
+    const TranslationResult empty_result(options.num_hypotheses,
+                                         options.return_attention,
+                                         options.return_scores);
     std::vector<TranslationResult> results(source.size(), empty_result);
 
     for (const auto& batch : rebatch_input(source, target_prefix, options)) {

--- a/src/translator_pool.cc
+++ b/src/translator_pool.cc
@@ -127,7 +127,9 @@ namespace ctranslate2 {
                                 options));
     }
 
-    const TranslationResult empty_result(options.num_hypotheses, options.return_attention);
+    const TranslationResult empty_result(options.num_hypotheses,
+                                         options.return_attention,
+                                         options.return_scores);
     std::vector<TranslationResult> results(source.size(), empty_result);
 
     // Wait for the result of each sub-batch.

--- a/tests/translator_test.cc
+++ b/tests/translator_test.cc
@@ -247,12 +247,19 @@ TEST(TranslatorTest, TranslateEmptyBatch) {
 
 static void check_empty_result(const TranslationResult& result,
                                size_t num_hypotheses = 1,
-                               bool with_attention = false) {
+                               bool with_attention = false,
+                               bool with_score = true) {
   EXPECT_TRUE(result.output().empty());
-  EXPECT_EQ(result.score(), static_cast<float>(0));
   EXPECT_EQ(result.num_hypotheses(), num_hypotheses);
   EXPECT_EQ(result.hypotheses().size(), num_hypotheses);
-  EXPECT_EQ(result.scores().size(), num_hypotheses);
+  EXPECT_EQ(result.has_scores(), with_score);
+  if (with_score) {
+    EXPECT_EQ(result.scores().size(), num_hypotheses);
+    EXPECT_EQ(result.score(), 0);
+    for (const auto score : result.scores()) {
+      EXPECT_EQ(score, 0);
+    }
+  }
   EXPECT_EQ(result.has_attention(), with_attention);
   if (with_attention) {
     const auto& attention = result.attention();
@@ -281,6 +288,13 @@ TEST(TranslatorTest, TranslateBatchWithOnlyEmptySource) {
   EXPECT_EQ(results.size(), 2);
   check_empty_result(results[0]);
   check_empty_result(results[1]);
+}
+
+TEST(TranslatorTest, TranslateEmptySourceWithoutScore) {
+  Translator translator = default_translator();
+  TranslationOptions options;
+  options.return_scores = false;
+  EXPECT_FALSE(translator.translate(std::vector<std::string>{}, options).has_scores());
 }
 
 TEST(TranslatorTest, TranslateBatchWithPrefixAndEmpty) {


### PR DESCRIPTION
The code assumed return_scores=True when building the results for empty inputs.