### PR TITLE
Return one future per example instead of a single future for the batch

### DIFF
--- a/include/ctranslate2/generation_result.h
+++ b/include/ctranslate2/generation_result.h
@@ -18,6 +18,9 @@ namespace ctranslate2 {
                      const bool with_attention,
                      const bool with_score);
 
+    // Construct an uninitialized result.
+    GenerationResult() = default;
+
     size_t num_hypotheses() const;
 
     const std::vector<T>& output() const;

--- a/include/ctranslate2/translator_pool.h
+++ b/include/ctranslate2/translator_pool.h
@@ -293,8 +293,8 @@ namespace ctranslate2 {
     public:
       JobResultConsumer(size_t num_results);
       std::vector<std::future<Result>> get_futures();
-      virtual void set_result(size_t index, Result result);
-      virtual void set_exception(size_t index, std::exception_ptr exception);
+      void set_result(size_t index, Result result);
+      void set_exception(size_t index, std::exception_ptr exception);
 
     private:
       std::vector<std::promise<Result>> _promises;

--- a/include/ctranslate2/translator_pool.h
+++ b/include/ctranslate2/translator_pool.h
@@ -88,7 +88,7 @@ namespace ctranslate2 {
       std::queue<std::future<TranslationResult>> results;
 
       auto pop_results = [&results, &output, &target_writer](bool blocking) {
-        constexpr std::chrono::seconds zero_sec(0);
+        static const auto zero_sec = std::chrono::seconds(0);
         while (!results.empty()
                && (blocking
                    || results.front().wait_for(zero_sec) == std::future_status::ready)) {

--- a/src/translator_pool.cc
+++ b/src/translator_pool.cc
@@ -258,32 +258,6 @@ namespace ctranslate2 {
     }
   }
 
-  template <typename Result>
-  TranslatorPool::JobResultConsumer<Result>::JobResultConsumer(size_t num_results)
-    : _promises(num_results)
-  {
-  }
-
-  template <typename Result>
-  std::vector<std::future<Result>> TranslatorPool::JobResultConsumer<Result>::get_futures() {
-    std::vector<std::future<Result>> futures;
-    futures.reserve(_promises.size());
-    for (auto& promise : _promises)
-      futures.emplace_back(promise.get_future());
-    return futures;
-  }
-
-  template <typename Result>
-  void TranslatorPool::JobResultConsumer<Result>::set_result(size_t index, Result result) {
-    _promises[index].set_value(std::move(result));
-  }
-
-  template <typename Result>
-  void TranslatorPool::JobResultConsumer<Result>::set_exception(size_t index,
-                                                                std::exception_ptr exception) {
-    _promises[index].set_exception(exception);
-  }
-
   TranslatorPool::TranslationJob::TranslationJob(Batch batch,
                                                  TranslationOptions options,
                                                  std::shared_ptr<TranslationResultConsumer> consumer)

--- a/src/translator_pool.cc
+++ b/src/translator_pool.cc
@@ -106,6 +106,10 @@ namespace ctranslate2 {
     if (source.empty())
       return {};
 
+    // Rebatch the input and post each sub-batch in the translation queue.
+    auto batches = rebatch_input(source, target_prefix, options);
+    options.rebatch_input = false;
+
     auto consumer = std::make_shared<TranslationResultConsumer>(source.size());
     auto futures = consumer->get_futures();
 
@@ -117,10 +121,6 @@ namespace ctranslate2 {
                                                   options.return_scores));
       }
     }
-
-    // Rebatch the input and post each sub-batch in the translation queue.
-    auto batches = rebatch_input(source, target_prefix, options);
-    options.rebatch_input = false;
 
     for (auto& batch : batches)
       post_job(std::make_unique<TranslationJob>(std::move(batch), options, consumer), throttle);


### PR DESCRIPTION
This will facilitate the support of #457 and allow early return from decoding functions in the future. 