### PR TITLE
Add an experimental CUDA asynchronous allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ int main() {
 Some environment variables can be configured to customize the execution:
 
 * `CT2_CUDA_ALLOW_FP16`: Allow using FP16 computation on GPU even if the device does not have efficient FP16 support.
-* `CT2_CUDA_CACHING_ALLOCATOR_CONFIG`: Tune the CUDA caching allocator (see [Performance](docs/performance.md)).
+* `CT2_CUDA_CACHING_ALLOCATOR_CONFIG`: Tune the default CUDA caching allocator (see [Performance](docs/performance.md)).
+* `CT2_CUDA_USE_ASYNC_ALLOCATOR`: Replace the default CUDA caching allocator by an [asynchronous allocator](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html#group__CUDART__MEMORY__POOLS). Requires CUDA 11.2 or above and a compatible GPU.
 * `CT2_FORCE_CPU_ISA`: Force CTranslate2 to select a specific instruction set architecture (ISA). Possible values are: `GENERIC`, `AVX`, `AVX2`. Note: this does not impact backend libraries (such as Intel MKL) which usually have their own environment variables to configure ISA dispatching.
 * `CT2_TRANSLATORS_CORE_OFFSET`: If set to a non negative value, parallel translators are pinned to cores in the range `[offset, offset + inter_threads]`. Requires compilation with `-DOPENMP_RUNTIME=NONE`.
 * `CT2_USE_EXPERIMENTAL_PACKED_GEMM`: Enable the packed GEMM API for Intel MKL (see [Performance](docs/performance.md)).

--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ int main() {
 Some environment variables can be configured to customize the execution:
 
 * `CT2_CUDA_ALLOW_FP16`: Allow using FP16 computation on GPU even if the device does not have efficient FP16 support.
-* `CT2_CUDA_CACHING_ALLOCATOR_CONFIG`: Tune the default CUDA caching allocator (see [Performance](docs/performance.md)).
-* `CT2_CUDA_USE_ASYNC_ALLOCATOR`: Replace the default CUDA caching allocator by an [asynchronous allocator](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html#group__CUDART__MEMORY__POOLS). Requires CUDA 11.2 or above and a compatible GPU.
+* `CT2_CUDA_ALLOCATOR`: Select the CUDA memory allocator. Possible values are: `cub_caching` (default), `cuda_malloc_async` (requires CUDA >= 11.2).
+* `CT2_CUDA_CACHING_ALLOCATOR_CONFIG`: Tune the CUDA caching allocator (see [Performance](docs/performance.md)).
 * `CT2_FORCE_CPU_ISA`: Force CTranslate2 to select a specific instruction set architecture (ISA). Possible values are: `GENERIC`, `AVX`, `AVX2`. Note: this does not impact backend libraries (such as Intel MKL) which usually have their own environment variables to configure ISA dispatching.
 * `CT2_TRANSLATORS_CORE_OFFSET`: If set to a non negative value, parallel translators are pinned to cores in the range `[offset, offset + inter_threads]`. Requires compilation with `-DOPENMP_RUNTIME=NONE`.
 * `CT2_USE_EXPERIMENTAL_PACKED_GEMM`: Enable the packed GEMM API for Intel MKL (see [Performance](docs/performance.md)).

--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ int main() {
 
 Some environment variables can be configured to customize the execution:
 
-* `CT2_CUDA_ALLOW_FP16`: Allow using FP16 computation on GPU even if the device does not have efficient FP16 support.
 * `CT2_CUDA_ALLOCATOR`: Select the CUDA memory allocator. Possible values are: `cub_caching` (default), `cuda_malloc_async` (requires CUDA >= 11.2).
+* `CT2_CUDA_ALLOW_FP16`: Allow using FP16 computation on GPU even if the device does not have efficient FP16 support.
 * `CT2_CUDA_CACHING_ALLOCATOR_CONFIG`: Tune the CUDA caching allocator (see [Performance](docs/performance.md)).
 * `CT2_FORCE_CPU_ISA`: Force CTranslate2 to select a specific instruction set architecture (ISA). Possible values are: `GENERIC`, `AVX`, `AVX2`. Note: this does not impact backend libraries (such as Intel MKL) which usually have their own environment variables to configure ISA dispatching.
 * `CT2_TRANSLATORS_CORE_OFFSET`: If set to a non negative value, parallel translators are pinned to cores in the range `[offset, offset + inter_threads]`. Requires compilation with `-DOPENMP_RUNTIME=NONE`.

--- a/src/cuda/allocator.cc
+++ b/src/cuda/allocator.cc
@@ -5,6 +5,7 @@
 #include "ctranslate2/utils.h"
 #include "cuda/utils.h"
 
+#include <cuda.h>
 #include <cub/util_allocator.cuh>
 
 namespace ctranslate2 {
@@ -56,13 +57,71 @@ namespace ctranslate2 {
       std::unique_ptr<cub::CachingDeviceAllocator> _allocator;
     };
 
+#if CUDA_VERSION >= 11020
+    class CudaAsyncAllocator : public Allocator {
+    public:
+      void* allocate(size_t size, int device_index) override {
+        int prev_device_index = -1;
+        if (device_index >= 0) {
+          CUDA_CHECK(cudaGetDevice(&prev_device_index));
+          CUDA_CHECK(cudaSetDevice(device_index));
+        }
+
+        void* ptr = nullptr;
+        CUDA_CHECK(cudaMallocAsync(&ptr, size, get_cuda_stream()));
+
+        if (prev_device_index >= 0) {
+          CUDA_CHECK(cudaSetDevice(prev_device_index));
+        }
+
+        return ptr;
+      }
+
+      void free(void* ptr, int device_index) override {
+        int prev_device_index = -1;
+        if (device_index >= 0) {
+          CUDA_CHECK(cudaGetDevice(&prev_device_index));
+          CUDA_CHECK(cudaSetDevice(device_index));
+        }
+
+        CUDA_CHECK(cudaFreeAsync(ptr, get_cuda_stream()));
+
+        if (prev_device_index >= 0) {
+          CUDA_CHECK(cudaSetDevice(prev_device_index));
+        }
+      }
+    };
+
+#endif
+
+    static std::unique_ptr<Allocator> create_allocator() {
+      const bool async_alloc = read_bool_from_env("CT2_CUDA_USE_ASYNC_ALLOCATOR");
+
+      if (async_alloc) {
+#if CUDA_VERSION < 11020
+        throw std::runtime_error("Using the asynchronous CUDA allocator requires CUDA 11.2 or above");
+#else
+        for (int i = 0; i < get_gpu_count(); ++i) {
+          int supported = 0;
+          CUDA_CHECK(cudaDeviceGetAttribute(&supported, cudaDevAttrMemoryPoolsSupported, i));
+          if (!supported)
+            throw std::runtime_error("Asynchronous allocation is not supported by the current GPU");
+        }
+
+        return std::make_unique<CudaAsyncAllocator>();
+#endif
+      }
+
+      return std::make_unique<CubCachingAllocator>();
+    }
+
   }
 
   template<>
   Allocator& get_allocator<Device::CUDA>() {
     // Use 1 allocator per thread for performance.
-    static thread_local cuda::CubCachingAllocator allocator;
-    return allocator;
+    static thread_local std::unique_ptr<Allocator> allocator(cuda::create_allocator());
+    return *allocator;
   }
 
 }

--- a/src/cuda/allocator.cc
+++ b/src/cuda/allocator.cc
@@ -91,7 +91,6 @@ namespace ctranslate2 {
         }
       }
     };
-
 #endif
 
     static std::unique_ptr<Allocator> create_allocator() {


### PR DESCRIPTION
Can be enabled with the environment variable `CT2_CUDA_ALLOCATOR=cuda_malloc_async`.