### PR TITLE
Support float16 as an input for ops::Log()

### DIFF
--- a/include/ctranslate2/primitives.h
+++ b/include/ctranslate2/primitives.h
@@ -139,7 +139,8 @@ namespace ctranslate2 {
     static void transpose_4d(const T* a, const dim_t* dims, const dim_t* perm, T* b);
 
     static void exp(const float* x, float* y, dim_t size);
-    static void log(const float* x, float* y, dim_t size);
+    template <typename T>
+    static void log(const T* x, T* y, dim_t size);
     static void cos(const float* x, float* y, dim_t size);
     static void sin(const float* x, float* y, dim_t size);
     static void gelu(const float* x, float* y, dim_t size);

--- a/src/cpu/primitives.cc
+++ b/src/cpu/primitives.cc
@@ -310,6 +310,7 @@ namespace ctranslate2 {
   }
 
   template<>
+  template<>
   void primitives<Device::CPU>::log(const float* x, float* y, dim_t size) {
 #ifdef CT2_WITH_MKL
     if (cpu::mayiuse_mkl())

--- a/src/cuda/primitives.cu
+++ b/src/cuda/primitives.cu
@@ -494,10 +494,21 @@ namespace ctranslate2 {
   };
 
   template<>
+  template<>
   void primitives<Device::CUDA>::log(const float* x, float* y, dim_t size) {
     cuda::unary_transform(x, y, size, log_func());
   }
 
+  struct hlog_func {
+    __device__
+    __half operator()(__half x) { return hlog(x); }
+  };
+
+  template<>
+  template<>
+  void primitives<Device::CUDA>::log(const float16_t* x, float16_t* y, dim_t size) {
+    cuda::unary_transform(x, y, size, hlog_func());
+  }
 
   template<>
   template <typename T>

--- a/src/cuda/primitives.cu
+++ b/src/cuda/primitives.cu
@@ -499,10 +499,17 @@ namespace ctranslate2 {
     cuda::unary_transform(x, y, size, log_func());
   }
 
+#if CUDA_CAN_USE_HALF
   struct hlog_func {
     __device__
     __half operator()(__half x) { return hlog(x); }
   };
+#else 
+  struct hlog_func {
+    __host__ __device__
+    __half operator()(__half x) { return __half(logf(float(x))); }
+  };
+#endif
 
   template<>
   template<>

--- a/src/ops/log.cc
+++ b/src/ops/log.cc
@@ -1,13 +1,29 @@
 #include "ctranslate2/ops/log.h"
 
 #include "../device_dispatch.h"
+#include "../type_dispatch.h"
 
 namespace ctranslate2 {
   namespace ops {
 
     void Log::operator()(const StorageView& x, StorageView& y) const {
       PROFILE("Log");
-      DEVICE_DISPATCH(x.device(), (compute<D, float>(x.to_float(), y)));
+      switch (x.dtype()) {
+      case DataType::FLOAT: {
+        DEVICE_DISPATCH(x.device(), (compute<D, float>(x, y)));
+        break;
+      }
+#ifdef CT2_WITH_CUDA
+      case DataType::FLOAT16: {
+        if (x.device() != Device::CUDA)
+          throw std::invalid_argument("FP16 Log is only supported on GPU");
+        compute<Device::CUDA, float16_t>(x, y);
+        break;
+      }
+#endif
+      default:
+        throw std::invalid_argument("Log only supports float (or float16 on GPU)");
+      }
     }
 
   }

--- a/src/ops/log.cc
+++ b/src/ops/log.cc
@@ -7,7 +7,7 @@ namespace ctranslate2 {
 
     void Log::operator()(const StorageView& x, StorageView& y) const {
       PROFILE("Log");
-      DEVICE_DISPATCH(x.device(), (compute<D, float>(x, y)));
+      DEVICE_DISPATCH(x.device(), (compute<D, float>(x.to_float(), y)));
     }
 
   }

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -662,22 +662,19 @@ TEST_P(OpDeviceFPTest, ReLU) {
   expect_storage_eq(output.to_float(), expected);
 }
 
-TEST_P(OpDeviceTest, Log) {
-  Device device = GetParam();
+TEST_P(OpDeviceFPTest, Log) {
+  const Device device = GetParam().first;
+  const DataType dtype = GetParam().second;
   std::vector<float > input_vec({0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4});
-  std::vector<float > output_vec;
-  output_vec.reserve(input_vec.size());
-  std::transform(input_vec.begin(), input_vec.end(), std::back_inserter(output_vec),
+  std::vector<float > expected_vec;
+  expected_vec.reserve(input_vec.size());
+  std::transform(input_vec.begin(), input_vec.end(), std::back_inserter(expected_vec),
           [](const float& i){return std::log(i);});
   StorageView input({2, 4}, input_vec, device);
-  StorageView expected({2, 4}, output_vec, device);
-  StorageView output(device);
-  ops::Log()(input, output);
-  expect_storage_eq(output, expected, 1e-4);
-
-  // Test float16
-  ops::Log()(input.to_float16(), output);
-  expect_storage_eq(output, expected, 1e-4);
+  StorageView expected({2, 4}, expected_vec, device);
+  StorageView output(dtype, device);
+  ops::Log()(input.to(dtype), output);
+  expect_storage_eq(output.to_float(), expected, 1e-3);
 }
 
 template <typename T, typename Ops, typename Func>

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -674,6 +674,10 @@ TEST_P(OpDeviceTest, Log) {
   StorageView output(device);
   ops::Log()(input, output);
   expect_storage_eq(output, expected, 1e-4);
+
+  // Test float16
+  ops::Log()(input.to_float16(), output);
+  expect_storage_eq(output, expected, 1e-4);
 }
 
 template <typename T, typename Ops, typename Func>


### PR DESCRIPTION
Hi, 

As discussed in https://github.com/OpenNMT/CTranslate2/issues/473, here is a small PR that extends ops::Log() to support float16 as an input datatype.  

This change is somewhat trivial because it simply performs a conversion from FLOAT16 to FLOAT prior to calling log() primitives.  I couldn't find FLOAT16 log primitives supported by CPU or [CUDA](https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__SINGLE.html#group__CUDA__MATH__SINGLE_1gcdaf041c4071f63cba0e51658b89ffa4).  

I'm not sure if this is what you were looking for, please advise, thanks!