### PR TITLE
Add a translation wrapper that buffers and batches incoming inputs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ set(PRIVATE_INCLUDE_DIRECTORIES
 set(SOURCES
   src/allocator.cc
   src/batch_reader.cc
+  src/buffered_translation_wrapper.cc
   src/cpu/allocator.cc
   src/cpu/backend.cc
   src/cpu/cpu_info.cc

--- a/include/ctranslate2/buffered_translation_wrapper.h
+++ b/include/ctranslate2/buffered_translation_wrapper.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "translator_pool.h"
+
+namespace ctranslate2 {
+
+  // This class wraps a TranslatorPool instance and bufferizes incoming translation requests.
+  // The buffer is flushed when one of the following conditions is met:
+  //
+  //  * buffer_timeout_in_micros microseconds have passed
+  //  * max_buffer_size examples are ready to be translated
+  //
+  // By default, max_buffer_size is set to max_batch_size, but it can be set to a larger value
+  // in which case the buffer content is sorted by length and rebatched according to max_batch_size.
+  class BufferedTranslationWrapper {
+  public:
+    BufferedTranslationWrapper(std::shared_ptr<TranslatorPool> translator_pool,
+                               size_t max_batch_size,
+                               size_t buffer_timeout_in_micros,
+                               TranslationOptions options = TranslationOptions(),
+                               size_t max_buffer_size = 0);
+    ~BufferedTranslationWrapper();
+
+    std::future<TranslationResult>
+    translate_async(std::vector<std::string> source, std::vector<std::string> target = {});
+
+    std::vector<std::future<TranslationResult>>
+    translate_batch_async(std::vector<std::vector<std::string>> source,
+                          std::vector<std::vector<std::string>> target = {});
+
+  private:
+    std::shared_ptr<TranslatorPool> _translator_pool;
+    TranslationOptions _options;
+    const size_t _max_batch_size;
+    const size_t _max_buffer_size;
+    const std::chrono::microseconds _buffer_timeout;
+    std::thread _background_thread;
+    bool _stop = false;
+
+    std::mutex _mutex;
+    std::condition_variable _cv;
+    std::queue<std::vector<std::string>> _source;
+    std::queue<std::vector<std::string>> _target;
+    std::queue<std::promise<TranslationResult>> _promises;
+
+    void buffer_loop();
+  };
+
+}

--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -13,6 +13,7 @@ namespace ctranslate2 {
 
   class Translator;
   class TranslatorPool;
+  class BufferedTranslationWrapper;
 
   struct TranslationOptions {
     // Beam size to use for beam search (set 1 to run greedy search).
@@ -74,6 +75,7 @@ namespace ctranslate2 {
 
     friend class Translator;
     friend class TranslatorPool;
+    friend class BufferedTranslationWrapper;
   };
 
   // This class holds all information required to translate from a model. Copying

--- a/include/ctranslate2/translator_pool.h
+++ b/include/ctranslate2/translator_pool.h
@@ -18,6 +18,8 @@ namespace ctranslate2 {
     double total_time_in_ms = 0;
   };
 
+  class BufferedTranslationWrapper;
+
   // A pool of Translators running in parallel.
   class TranslatorPool {
   public:
@@ -312,6 +314,8 @@ namespace ctranslate2 {
     const std::vector<Translator>& get_translators() const;
 
   private:
+    friend class BufferedTranslationWrapper;
+
     class Job {
     public:
       virtual ~Job() = default;

--- a/src/buffered_translation_wrapper.cc
+++ b/src/buffered_translation_wrapper.cc
@@ -1,0 +1,121 @@
+#include "ctranslate2/buffered_translation_wrapper.h"
+
+namespace ctranslate2 {
+
+  BufferedTranslationWrapper::BufferedTranslationWrapper(std::shared_ptr<TranslatorPool> translator_pool,
+                                                         size_t max_batch_size,
+                                                         size_t buffer_timeout_in_micros,
+                                                         TranslationOptions options,
+                                                         size_t max_buffer_size)
+    : _translator_pool(std::move(translator_pool))
+    , _options(std::move(options))
+    , _max_batch_size(max_batch_size)
+    , _max_buffer_size(max_buffer_size == 0 ? max_batch_size : max_buffer_size)
+    , _buffer_timeout(buffer_timeout_in_micros)
+    , _background_thread(&BufferedTranslationWrapper::buffer_loop, this)
+  {
+    _options.validate();
+    _options.validated = true;
+    _options.rebatch_input = false;
+  }
+
+  BufferedTranslationWrapper::~BufferedTranslationWrapper() {
+    {
+      const std::lock_guard<std::mutex> lock(_mutex);
+      _stop = true;
+    }
+    _background_thread.join();
+  }
+
+  std::future<TranslationResult>
+  BufferedTranslationWrapper::translate_async(std::vector<std::string> source,
+                                              std::vector<std::string> target) {
+    std::promise<TranslationResult> promise;
+    auto future = promise.get_future();
+
+    if (source.empty()) {
+      promise.set_value(TranslationResult(_options.num_hypotheses,
+                                          _options.return_attention,
+                                          _options.return_scores));
+    } else {
+      const std::lock_guard<std::mutex> lock(_mutex);
+
+      _promises.emplace(std::move(promise));
+      _source.emplace(std::move(source));
+      _target.emplace(std::move(target));
+
+      if (_source.size() >= _max_buffer_size)
+        _cv.notify_one();
+    }
+
+    return future;
+  }
+
+  std::vector<std::future<TranslationResult>>
+  BufferedTranslationWrapper::translate_batch_async(std::vector<std::vector<std::string>> source,
+                                                    std::vector<std::vector<std::string>> target) {
+    std::vector<std::future<TranslationResult>> futures;
+    futures.reserve(source.size());
+
+    for (size_t i = 0; i < source.size(); ++i) {
+      futures.emplace_back(translate_async(std::move(source[i]),
+                                           target.empty()
+                                           ? std::vector<std::string>()
+                                           : std::move(target[i])));
+    }
+
+    return futures;
+  }
+
+  void BufferedTranslationWrapper::buffer_loop() {
+    while (true) {
+      std::unique_lock<std::mutex> lock(_mutex);
+      _cv.wait_for(lock, _buffer_timeout,
+                   [this]{ return _source.size() >= _max_buffer_size || _stop; });
+
+      // Get the stop flag value when we hold the lock.
+      const bool stop = _stop;
+
+      if (!_source.empty()) {
+        // Build full batches unless the timeout is reached or we are stopping the process.
+        size_t flush_size = _source.size();
+        if (!stop && flush_size > _max_batch_size)
+          flush_size -= flush_size % _max_batch_size;
+
+        std::vector<std::vector<std::string>> source;
+        std::vector<std::vector<std::string>> target;
+        std::vector<std::promise<TranslationResult>> promises;
+        source.reserve(flush_size);
+        target.reserve(flush_size);
+        promises.reserve(flush_size);
+
+        for (size_t i = 0; i < flush_size; ++i) {
+          source.emplace_back(std::move(_source.front()));
+          target.emplace_back(std::move(_target.front()));
+          promises.emplace_back(std::move(_promises.front()));
+          _source.pop();
+          _target.pop();
+          _promises.pop();
+        }
+
+        // Release the lock as soon as the buffer is flushed.
+        lock.unlock();
+
+        auto consumer = std::make_shared<TranslatorPool::JobResultConsumer<TranslationResult>>(
+          std::move(promises));
+
+        // Rebatch buffered examples and post jobs in the pool.
+        for (auto& batch : rebatch_input(source, target, _max_batch_size)) {
+          auto job = std::make_unique<TranslatorPool::TranslateJob>(std::move(batch),
+                                                                    _options,
+                                                                    consumer);
+          _translator_pool->post_job(std::move(job), /*throttle=*/false);
+        }
+      }
+
+      if (stop)
+        break;
+    }
+  }
+
+}

--- a/src/buffered_translation_wrapper.cc
+++ b/src/buffered_translation_wrapper.cc
@@ -33,6 +33,7 @@ namespace ctranslate2 {
     std::promise<TranslationResult> promise;
     auto future = promise.get_future();
 
+    bool notify = false;
     if (source.empty()) {
       promise.set_value(TranslationResult(_options.num_hypotheses,
                                           _options.return_attention,
@@ -44,9 +45,11 @@ namespace ctranslate2 {
       _source.emplace(std::move(source));
       _target.emplace(std::move(target));
 
-      if (_source.size() >= _max_buffer_size)
-        _cv.notify_one();
+      notify = (_source.size() >= _max_buffer_size);
     }
+
+    if (notify)
+      _cv.notify_one();
 
     return future;
   }


### PR DESCRIPTION
It is only implemented as a C++ class for now. I'm not sure it can be effectively added to the Python API. The wrapper only makes sense when requests are coming in parallel but Python has limited support for threading. In that case the buffer timeout would probably need to be much longer.

Closes #457.