### PR TITLE
Delegate bias and activation application to operators

### DIFF
--- a/include/ctranslate2/layers/common.h
+++ b/include/ctranslate2/layers/common.h
@@ -89,7 +89,7 @@ namespace ctranslate2 {
       StorageView _partial_bias;
       StorageView _partial_qscale;
       StorageView _partial_u8_shift_compensation;
-      const ops::UnaryOp* _activation;
+      const bool _quantized_gemm;
       const ops::Gemm _gemm_op;
       const ops::Quantize _quantize_op;
       const ops::Dequantize _dequantize_op;

--- a/include/ctranslate2/layers/transformer.h
+++ b/include/ctranslate2/layers/transformer.h
@@ -30,6 +30,7 @@ namespace ctranslate2 {
     private:
       const LayerNorm _layer_norm;
       const bool _pre_norm;
+      const ops::ActivationType _activation_type;
       const Dense _ff1;
       const Dense _ff2;
     };

--- a/include/ctranslate2/ops/activation.h
+++ b/include/ctranslate2/ops/activation.h
@@ -11,7 +11,7 @@ namespace ctranslate2 {
       GELU,
     };
 
-    const UnaryOp* get_activation(ActivationType type);
+    const UnaryOp& get_activation_op(ActivationType type);
 
   }
 }

--- a/include/ctranslate2/ops/dequantize.h
+++ b/include/ctranslate2/ops/dequantize.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "activation.h"
 #include "op.h"
 
 namespace ctranslate2 {
@@ -7,6 +8,8 @@ namespace ctranslate2 {
 
     class Dequantize : public Op {
     public:
+      Dequantize(const ActivationType* activation_type = nullptr);
+
       void operator()(const StorageView& input,
                       const StorageView& scale,
                       StorageView& output) const;
@@ -35,6 +38,7 @@ namespace ctranslate2 {
                                   const StorageView* bias,
                                   StorageView& y) const;
 
+      const ActivationType* _activation_type;
     };
 
   }

--- a/include/ctranslate2/ops/gemm.h
+++ b/include/ctranslate2/ops/gemm.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include "activation.h"
 #include "op.h"
 
 namespace ctranslate2 {
   namespace ops {
+
+    void add_bias(StorageView& x, const StorageView& bias);
 
     class Gemm : public Op {
     public:
@@ -12,30 +15,23 @@ namespace ctranslate2 {
            bool trans_a = false,
            bool trans_b = false,
            bool a_is_packed = false,
-           bool b_is_packed = false);
+           bool b_is_packed = false,
+           const ActivationType* activation_type = nullptr);
 
       void operator()(const StorageView& a,
                       const StorageView& b,
                       StorageView& c,
-                      const StorageView* a_shift_compensation = nullptr) const;
-      void operator()(const StorageView& a,
-                      const StorageView& b,
-                      const StorageView& c,
-                      StorageView& y) const;
+                      const StorageView* a_shift_compensation = nullptr,
+                      const StorageView* bias = nullptr) const;
 
     private:
-      void compute(const StorageView& a,
-                   const StorageView& b,
-                   const StorageView* c,
-                   StorageView& y,
-                   const StorageView* a_shift_compensation) const;
-
       float _alpha;
       float _beta;
       bool _trans_a;
       bool _trans_b;
       bool _a_is_packed;
       bool _b_is_packed;
+      const ActivationType* _activation_type;
     };
 
   }

--- a/src/layers/transformer.cc
+++ b/src/layers/transformer.cc
@@ -9,7 +9,8 @@ namespace ctranslate2 {
                                            const ops::ActivationType activation_type)
       : _layer_norm(model, scope + "/layer_norm")
       , _pre_norm(pre_norm)
-      , _ff1(model, scope + "/linear_0", &activation_type)
+      , _activation_type(activation_type)
+      , _ff1(model, scope + "/linear_0", &_activation_type)
       , _ff2(model, scope + "/linear_1") {
     }
 

--- a/src/ops/activation.cc
+++ b/src/ops/activation.cc
@@ -6,18 +6,18 @@
 namespace ctranslate2 {
   namespace ops {
 
-    const UnaryOp* get_activation(ActivationType type) {
+    const UnaryOp& get_activation_op(ActivationType type) {
       switch (type) {
       case ActivationType::ReLU: {
         static const ReLU relu;
-        return &relu;
+        return relu;
       }
       case ActivationType::GELU: {
         static const GELU gelu;
-        return &gelu;
+        return gelu;
       }
       }
-      return nullptr;
+      throw std::invalid_argument("invalid activation type");
     }
 
   }

--- a/src/ops/dequantize.cc
+++ b/src/ops/dequantize.cc
@@ -5,6 +5,11 @@
 namespace ctranslate2 {
   namespace ops {
 
+    Dequantize::Dequantize(const ActivationType* activation_type)
+      : _activation_type(activation_type)
+    {
+    }
+
     void Dequantize::operator()(const StorageView& input,
                                 const StorageView& scale,
                                 StorageView& output) const {

--- a/src/ops/dequantize_cpu.cc
+++ b/src/ops/dequantize_cpu.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/dequantize.h"
 
+#include "ctranslate2/ops/gemm.h"
+
 #include "cpu/kernels.h"
 #include "cpu/parallel.h"
 
@@ -54,9 +56,6 @@ namespace ctranslate2 {
                                                          const bool transpose_b,
                                                          const StorageView* bias,
                                                          StorageView& y) const {
-      if (bias)
-        throw std::runtime_error("Fused dequantize and bias add is not implemented on CPU");
-
       const auto* c_data = c.data<int32_t>();
       auto* y_data = y.data<float>();
 
@@ -102,6 +101,11 @@ namespace ctranslate2 {
           }
         }
       }
+
+      if (bias)
+        add_bias(y, *bias);
+      if (_activation_type)
+        get_activation_op(*_activation_type)(y, y);
     }
 
   }

--- a/src/ops/dequantize_gpu.cu
+++ b/src/ops/dequantize_gpu.cu
@@ -73,6 +73,8 @@ namespace ctranslate2 {
         bias ? bias->data<float>() : nullptr,
         y.data<float>(),
         depth);
+      if (_activation_type)
+        get_activation_op(*_activation_type)(y, y);
     }
 
   }

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -98,11 +98,10 @@ TEST(OpTest, GemmInt16) {
     return;
   StorageView a({64, 64}, static_cast<int16_t>(1));
   StorageView b(a);
-  StorageView c({64, 64}, static_cast<int32_t>(2));
-  StorageView y(c.dtype());
+  StorageView y({64, 64}, static_cast<int32_t>(2));
   StorageView expected({64, 64}, static_cast<int32_t>(130));
   ops::Gemm op(2.0, 1.0, false, true);
-  op(a, b, c, y);
+  op(a, b, y);
   expect_storage_eq(y, expected);
 };
 
@@ -454,12 +453,12 @@ TEST_P(OpDeviceFPTest, Gemm) {
   StorageView a(
     {4, 4}, std::vector<float>{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, device);
   StorageView b(a);
-  StorageView c({4, 4}, 2.f, device);
-  StorageView y(dtype, device);
+  StorageView y({4, 4}, 2.f, device);
   StorageView expected(
     {4, 4}, std::vector<float>{3, 2, 2, 2, 2, 3, 2, 2, 2, 2, 3, 2, 2, 2, 2, 3}, device);
   ops::Gemm op(1.0, 1.0, false, false);
-  op(a.to(dtype), b.to(dtype), c.to(dtype), y);
+  y = y.to(dtype);
+  op(a.to(dtype), b.to(dtype), y);
   expect_storage_eq(y.to_float(), expected);
 };
 


### PR DESCRIPTION
This change is required to fuse bias and activation in operators `Dequantize` and `Gemm`.

Related to #350, #375.