### PR TITLE
Relax GPU driver requirement for the Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The library is installed in `/opt/ctranslate2` and a Python package is installed
 **Requirements:**
 
 * Docker
-* (optional) GPU driver version: >= 460.32.03
+* (optional) GPU driver version: >= 450.80.02
 
 ### Manual compilation
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,6 +72,7 @@ RUN apt-get update && \
         libcublas-11-2 \
         python3-pip \
         && \
+    apt-get remove -y cuda-compat-11-2 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN apt-get update && \
         libcublas-11-2 \
         python3-pip \
         && \
-    apt-get remove -y cuda-compat-11-2 && \
+    apt-get purge -y cuda-compat-11-2 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
All CUDA 11.x versions should be compatible with driver version >= 450.80.02. This is known as the CUDA Enhanced Compatibility which was introduced in CUDA 11.

However, the package `cuda-compat-11-2` prevented this compatibility mode to work correctly.