### PR TITLE
Implement mixed INT8 and FP16 computation

### DIFF
--- a/cli/translate.cc
+++ b/cli/translate.cc
@@ -13,7 +13,7 @@ int main(int argc, char* argv[]) {
   cmd_options.add_options()
     ("h,help", "Display available options.")
     ("model", "Path to the CTranslate2 model directory.", cxxopts::value<std::string>())
-    ("compute_type", "The type used for computation: default, auto, float, float16, int16, or int8",
+    ("compute_type", "The type used for computation: default, auto, float, float16, int16, int8, or int8_float16",
      cxxopts::value<std::string>()->default_value("default"))
     ("cuda_compute_type", "Computation type on CUDA devices (overrides compute_type)",
      cxxopts::value<std::string>())

--- a/docs/python.md
+++ b/docs/python.md
@@ -22,7 +22,7 @@ converter = ctranslate2.converters.OpenNMTPyConverter(
 output_dir = converter.convert(
     output_dir: str,          # Path to the output directory.
     vmap: str = None,         # Path to a vocabulary mapping file.
-    quantization: str = None, # Weights quantization: "int8", "int16", or "float16".
+    quantization: str = None, # Weights quantization: "int8", "int8_float16", "int16", or "float16".
     force: bool = False,      # Override output_dir if it exists.
 )
 ```
@@ -38,7 +38,7 @@ translator = ctranslate2.Translator(
     # The device ID, or list of device IDs, where to place this translator on.
     device_index: Union[int, List[int]] = 0,
 
-    # The computation type: "default", "auto", "int8", "int16", "float16", or "float",
+    # The computation type: "default", "auto", "int8", "int8_float16", "int16", "float16", or "float",
     # or a dict mapping a device to a computation type.
     compute_type: Union[str, Dict[str, str]] = "default",
 

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -17,6 +17,7 @@ Quantization can be enabled when converting the model or when loading the model.
 Enabling the quantization during conversion is helpful to reduce the model size on disk. The converters expose the option `quantization` that accepts the following values:
 
 * `int8`
+* `int8_float16`
 * `int16`
 * `float16`
 
@@ -35,6 +36,7 @@ Quantization can also be enabled or changed when loading the model. The translat
 * `default`: see description below
 * `auto`: selects the fastest computation type
 * `int8`
+* `int8_float16`
 * `int16`
 * `float16`
 * `float`
@@ -47,24 +49,24 @@ By default, the runtime tries to use the type that is saved in the converted mod
 
 **On CPU:**
 
-| CPU vendor | int8 | int16 | float16 |
+| CPU vendor | int8 | int8_float16 | int16 | float16 |
 | --- | --- | --- | --- |
-| Intel | int8 | int16 | float |
-| other | int8 | int8 | float |
+| Intel | int8 | int8 | int16 | float |
+| other | int8 | int8 | int8 | float |
 
 **On GPU:**
 
-| GPU Compute Capability | int8 | int16 | float16 |
+| GPU Compute Capability | int8 | int8_float16 | int16 | float16 |
 | --- | --- | --- | --- |
-| >= 7.0 | int8 | float16 | float16 |
-| 6.1 | int8 | float | float |
-| <= 6.0 | float | float | float |
+| >= 7.0 | int8 | int8_float16 | float16 | float16 |
+| 6.1 | int8 | int8 | float | float |
+| <= 6.0 | float | float | float | float |
 
 You can get more information about the detected capabilities of your system by setting the environment variable `CT2_VERBOSE=1`.
 
 ## Quantized types
 
-### 8-bit integers (INT8)
+### 8-bit integers (`int8`)
 
 **Supported on:**
 
@@ -77,7 +79,7 @@ The implementation applies the equation from [Wu et al. 2016](https://arxiv.org/
 
 Note that this corresponds to a symmetric quantization (absolute maximum of the input range instead of separate min/max values). We only quantize the weights of the embedding and linear layers.
 
-### 16-bit integers (INT16)
+### 16-bit integers (`int16`)
 
 **Supported on:**
 
@@ -91,10 +93,18 @@ scale = 2^10 / max(abs(W))
 
 As suggested by the author, the idea is to use 10 bits for the input so that the multiplication is 20 bits which gives 12 bits left for accumulation. We only quantize the weights of the embedding and linear layers.
 
-### 16-bit floating points (FP16)
+### 16-bit floating points (`float16`)
 
 **Supported on:**
 
 * NVIDIA GPU with Compute Capability >= 7.0
 
 In this mode, all model weights are stored in half precision and all layers are run in half precision.
+
+### Mixed 8-bit integers and 16-bit floating points (`int8_float16`)
+
+**Supported on:**
+
+* NVIDIA GPU with Compute Capability >= 7.0
+
+This mode is the same as `int8`, but all non quantized layers are run in FP16 instead of FP32.

--- a/include/ctranslate2/layers/common.h
+++ b/include/ctranslate2/layers/common.h
@@ -31,7 +31,7 @@ namespace ctranslate2 {
       const StorageView& _embeddings;
       const DataType _output_type;
       const StorageView* _qscale;
-      const std::unique_ptr<const StorageView> _scale;
+      std::unique_ptr<const StorageView> _scale;
     };
 
     // Base class for position encoders.

--- a/include/ctranslate2/layers/common.h
+++ b/include/ctranslate2/layers/common.h
@@ -29,6 +29,7 @@ namespace ctranslate2 {
     private:
       const ops::Gather _gather_op;
       const StorageView& _embeddings;
+      const DataType _output_type;
       const StorageView* _qscale;
       const std::unique_ptr<const StorageView> _scale;
     };
@@ -89,6 +90,7 @@ namespace ctranslate2 {
       StorageView _partial_bias;
       StorageView _partial_qscale;
       StorageView _partial_u8_shift_compensation;
+      const DataType _output_type;
       const bool _quantized_gemm;
       const ops::Gemm _gemm_op;
       const ops::Quantize _quantize_op;

--- a/include/ctranslate2/models/model.h
+++ b/include/ctranslate2/models/model.h
@@ -53,10 +53,6 @@ namespace ctranslate2 {
         return _effective_compute_type;
       }
 
-      DataType default_float_type() const {
-        return ::ctranslate2::default_float_type(_effective_compute_type);
-      }
-
       dim_t preferred_size_multiple() const {
         return _preferred_size_multiple;
       }

--- a/include/ctranslate2/models/model.h
+++ b/include/ctranslate2/models/model.h
@@ -53,6 +53,10 @@ namespace ctranslate2 {
         return _effective_compute_type;
       }
 
+      DataType default_float_type() const {
+        return ::ctranslate2::default_float_type(_effective_compute_type);
+      }
+
       dim_t preferred_size_multiple() const {
         return _preferred_size_multiple;
       }
@@ -92,6 +96,9 @@ namespace ctranslate2 {
       // Returns true if the variable can be pre-packed.
       virtual bool is_packable(const std::string& variable_name) const;
 
+      // Returns true if the variable can be converted to another type.
+      virtual bool is_convertible(const StorageView& variable, const std::string& name) const;
+
       // Models can override these methods to execute some transformations if needed
       // (e.g. a variable name changed in a newer spec revision).
       virtual void register_variable(const std::string& name, StorageView& variable);
@@ -115,6 +122,7 @@ namespace ctranslate2 {
                         const DataType target_dtype,
                         std::unordered_map<std::string, StorageView>& variables_to_add,
                         std::vector<std::string>& variables_to_remove);
+      ComputeType infer_compute_type() const;
     };
 
     // The ModelReader interface allows user code to customize how and where to read model files.

--- a/include/ctranslate2/ops/dequantize.h
+++ b/include/ctranslate2/ops/dequantize.h
@@ -24,12 +24,12 @@ namespace ctranslate2 {
                       const StorageView* bias = nullptr) const;
 
     private:
-      template <Device D, typename T>
+      template <Device D, typename InT, typename OutT>
       void dequantize(const StorageView& input,
                       const StorageView& scale,
                       StorageView& output) const;
 
-      template <Device D>
+      template <Device D, typename T>
       void dequantize_gemm_output(const StorageView& c,
                                   const StorageView& a_scale,
                                   const StorageView& b_scale,

--- a/include/ctranslate2/ops/quantize.h
+++ b/include/ctranslate2/ops/quantize.h
@@ -23,7 +23,7 @@ namespace ctranslate2 {
                       StorageView& scale) const;
 
     private:
-      template <Device D, typename T>
+      template <Device D, typename InT, typename OutT>
       void quantize(const StorageView& input,
                     StorageView& output,
                     StorageView& scale) const;

--- a/include/ctranslate2/types.h
+++ b/include/ctranslate2/types.h
@@ -42,6 +42,6 @@ namespace ctranslate2 {
   DataType compute_type_to_data_type(const ComputeType compute_type);
 
   // Gets the default floating point type for the given compute type.
-  DataType default_float_type(const ComputeType compute_type);
+  DataType get_default_float_type(const ComputeType compute_type);
 
 }

--- a/include/ctranslate2/types.h
+++ b/include/ctranslate2/types.h
@@ -24,6 +24,7 @@ namespace ctranslate2 {
     AUTO,
     FLOAT,
     INT8,
+    INT8_FLOAT16,
     INT16,
     FLOAT16
   };
@@ -31,13 +32,16 @@ namespace ctranslate2 {
   ComputeType str_to_compute_type(const std::string& compute_type);
 
   // Returns the final compute type based on model weights and device information.
-  ComputeType resolve_compute_type(const ComputeType compute_type,
-                                   const DataType weights_type,
+  ComputeType resolve_compute_type(const ComputeType requested_compute_type,
+                                   const ComputeType model_compute_type,
                                    const Device device,
                                    const int device_index,
                                    const bool enable_fallback = false);
 
   // Gets the weights data type for the given compute type.
   DataType compute_type_to_data_type(const ComputeType compute_type);
+
+  // Gets the default floating point type for the given compute type.
+  DataType default_float_type(const ComputeType compute_type);
 
 }

--- a/python/ctranslate2/converters/converter.py
+++ b/python/ctranslate2/converters/converter.py
@@ -17,7 +17,7 @@ class Converter(abc.ABC):
         parser.add_argument(
             "--quantization",
             default=None,
-            choices=["int8", "int16", "float16"],
+            choices=["int8", "int8_float16", "int16", "float16"],
             help="Weight quantization type.",
         )
         parser.add_argument(

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -407,7 +407,7 @@ def test_opennmt_tf_model_conversion(
 
 
 @pytest.mark.skipif(not _FRAMEWORK_DATA_EXIST, reason="Data files are not available")
-@pytest.mark.parametrize("quantization", ["float16", "int16", "int8"])
+@pytest.mark.parametrize("quantization", ["float16", "int16", "int8", "int8_float16"])
 def test_opennmt_tf_model_quantization(tmpdir, quantization):
     model_path = os.path.join(
         _TEST_DATA_DIR,

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -388,8 +388,10 @@ static py::set get_supported_compute_types(const std::string& device_str, const 
 
   py::set compute_types;
   compute_types.add("float");
-  if (ctranslate2::mayiuse_float16(device, device_index))
+  if (ctranslate2::mayiuse_float16(device, device_index)) {
+    compute_types.add("int8_float16");
     compute_types.add("float16");
+  }
   if (ctranslate2::mayiuse_int16(device, device_index))
     compute_types.add("int16");
   if (ctranslate2::mayiuse_int8(device, device_index))

--- a/src/layers/common.cc
+++ b/src/layers/common.cc
@@ -42,7 +42,7 @@ namespace ctranslate2 {
 
     Embeddings::Embeddings(const models::Model& model, const std::string& scope)
       : _embeddings(model.get_variable(scope + "/weight"))
-      , _output_type(model.default_float_type())
+      , _output_type(get_default_float_type(model.effective_compute_type()))
       , _qscale(model.get_variable_if_exists(scope + "/weight_scale"))
     {
       if (model.get_flag_with_default(scope + "/multiply_by_sqrt_depth", true)) {
@@ -201,7 +201,7 @@ namespace ctranslate2 {
       , _partial_bias(_weight.device(), _bias ? _bias->dtype() : DataType::FLOAT)
       , _partial_qscale(_weight.device(), DataType::FLOAT)
       , _partial_u8_shift_compensation(_weight.device(), DataType::INT32)
-      , _output_type(model.default_float_type())
+      , _output_type(get_default_float_type(model.effective_compute_type()))
       , _quantized_gemm(_weight.dtype() == DataType::INT16 || _weight.dtype() == DataType::INT8)
       , _gemm_op(/*alpha=*/1,
                  /*beta=*/0,

--- a/src/layers/common.cc
+++ b/src/layers/common.cc
@@ -40,9 +40,10 @@ namespace ctranslate2 {
     }
 
 
-    static inline StorageView get_sqrt_depth_scale(const StorageView& embeddings) {
-      const auto scale = std::sqrt(static_cast<float>(embeddings.dim(-1)));
-      if (embeddings.dtype() == DataType::FLOAT16) {
+    static inline StorageView get_sqrt_depth_scale(const dim_t embedding_size,
+                                                   const DataType dtype) {
+      const auto scale = std::sqrt(static_cast<float>(embedding_size));
+      if (dtype == DataType::FLOAT16) {
         return StorageView(float16_t(scale));
       } else {
         return StorageView(scale);
@@ -51,14 +52,15 @@ namespace ctranslate2 {
 
     Embeddings::Embeddings(const models::Model& model, const std::string& scope)
       : _embeddings(model.get_variable(scope + "/weight"))
+      , _output_type(model.default_float_type())
       , _qscale(model.get_variable_if_exists(scope + "/weight_scale"))
       , _scale(model.get_flag_with_default(scope + "/multiply_by_sqrt_depth", true)
-               ? std::make_unique<StorageView>(get_sqrt_depth_scale(_embeddings))
+               ? std::make_unique<StorageView>(get_sqrt_depth_scale(_embeddings.dim(1), _output_type))
                : nullptr) {
     }
 
     DataType Embeddings::output_type() const {
-      return _embeddings.dtype() == DataType::FLOAT16 ? DataType::FLOAT16 : DataType::FLOAT;
+      return _output_type;
     }
 
     dim_t Embeddings::output_size() const {
@@ -207,6 +209,7 @@ namespace ctranslate2 {
       , _partial_bias(_weight.device(), _bias ? _bias->dtype() : DataType::FLOAT)
       , _partial_qscale(_weight.device(), DataType::FLOAT)
       , _partial_u8_shift_compensation(_weight.device(), DataType::INT32)
+      , _output_type(model.default_float_type())
       , _quantized_gemm(_weight.dtype() == DataType::INT16 || _weight.dtype() == DataType::INT8)
       , _gemm_op(/*alpha=*/1,
                  /*beta=*/0,
@@ -222,7 +225,7 @@ namespace ctranslate2 {
     }
 
     DataType Dense::output_type() const {
-      return _weight.dtype() == DataType::FLOAT16 ? DataType::FLOAT16 : DataType::FLOAT;
+      return _output_type;
     }
 
     dim_t Dense::output_size() const {

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -200,6 +200,10 @@ namespace ctranslate2 {
       return false;
     }
 
+    bool Model::is_convertible(const StorageView& variable, const std::string& name) const {
+      return !variable.is_scalar() && name.find("_scale") == std::string::npos;
+    }
+
     void
     Model::ensure_dtype(const std::string& name,
                         StorageView& variable,
@@ -272,24 +276,40 @@ namespace ctranslate2 {
       variable = std::move(target_variable);
     }
 
+    ComputeType Model::infer_compute_type() const {
+      DataType weight_type = DataType::FLOAT;
+      DataType other_type = DataType::FLOAT;
+
+      for (const auto& variable_pair : _variable_index) {
+        const std::string& name = variable_pair.first;
+        const StorageView& variable = variable_pair.second;
+        if (is_quantizable(name)) {
+          weight_type = variable.dtype();
+        } else if (is_convertible(variable, name)) {
+          other_type = variable.dtype();
+        }
+      }
+
+      switch (weight_type) {
+      case DataType::INT8:
+        return other_type == DataType::FLOAT16 ? ComputeType::INT8_FLOAT16 : ComputeType::INT8;
+      case DataType::INT16:
+        return ComputeType::INT16;
+      case DataType::FLOAT16:
+        return ComputeType::FLOAT16;
+      default:
+        return ComputeType::FLOAT;
+      }
+    }
+
     void Model::finalize() {
       auto scoped_device_setter = get_scoped_device_setter();
 
       std::vector<std::string> variables_to_remove;
       std::unordered_map<std::string, StorageView> variables_to_add;
 
-      DataType model_dtype = DataType::FLOAT;
-      for (const auto& variable_pair : _variable_index) {
-        const std::string& name = variable_pair.first;
-        const StorageView& variable = variable_pair.second;
-        if (is_quantizable(name)) {
-          model_dtype = variable.dtype();
-          break;
-        }
-      }
-
       _effective_compute_type = resolve_compute_type(_compute_type,
-                                                     model_dtype,
+                                                     infer_compute_type(),
                                                      _device,
                                                      _device_index);
       _preferred_size_multiple = get_preferred_size_multiple(_effective_compute_type,
@@ -308,9 +328,9 @@ namespace ctranslate2 {
                        target_dtype,
                        variables_to_add,
                        variables_to_remove);
-        } else if (!variable.is_scalar() && name.find("_scale") == std::string::npos) {
+        } else if (is_convertible(variable, name)) {
           // Other parameters may be converted from or to float16 (e.g. bias).
-          if (target_dtype == DataType::FLOAT16) {
+          if (default_float_type() == DataType::FLOAT16) {
             if (variable.dtype() == DataType::FLOAT) {
               variable = variable.to_float16();
             }

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -316,6 +316,7 @@ namespace ctranslate2 {
                                                              _device,
                                                              _device_index);
       const DataType target_dtype = compute_type_to_data_type(_effective_compute_type);
+      const DataType float_dtype = get_default_float_type(_effective_compute_type);
 
       for (auto& variable_pair : _variable_index) {
         const auto& name = variable_pair.first;
@@ -330,7 +331,7 @@ namespace ctranslate2 {
                        variables_to_remove);
         } else if (is_convertible(variable, name)) {
           // Other parameters may be converted from or to float16 (e.g. bias).
-          if (default_float_type() == DataType::FLOAT16) {
+          if (float_dtype == DataType::FLOAT16) {
             if (variable.dtype() == DataType::FLOAT) {
               variable = variable.to_float16();
             }

--- a/src/ops/dequantize.cc
+++ b/src/ops/dequantize.cc
@@ -1,6 +1,7 @@
 #include "ctranslate2/ops/dequantize.h"
 
-#include "../device_dispatch.h"
+#include "device_dispatch.h"
+#include "type_dispatch.h"
 
 namespace ctranslate2 {
   namespace ops {
@@ -22,7 +23,7 @@ namespace ctranslate2 {
           throw std::invalid_argument("INT16 dequantization is only supported on CPU");
         if (!scale.is_scalar())
           throw std::invalid_argument("INT16 quantization scale should be a scalar value");
-        dequantize<Device::CPU, int16_t>(input, scale, output);
+        dequantize<Device::CPU, int16_t, float>(input, scale, output);
         break;
       }
 
@@ -30,7 +31,22 @@ namespace ctranslate2 {
         const dim_t batch_size = input.size() / input.dim(-1);
         if (scale.size() != batch_size)
           throw std::invalid_argument("INT8 dequantization expects per-batch scales");
-        DEVICE_DISPATCH(input.device(), (dequantize<D, int8_t>(input, scale, output)));
+
+        switch (output.dtype()) {
+        case DataType::FLOAT: {
+          DEVICE_DISPATCH(input.device(), (dequantize<D, int8_t, float>(input, scale, output)));
+          break;
+        }
+        case DataType::FLOAT16: {
+          if (output.device() != Device::CUDA)
+            throw std::invalid_argument("Dequantize: float16 ouput is only supported on CUDA");
+          dequantize<Device::CUDA, int8_t, float16_t>(input, scale, output);
+          break;
+        }
+        default:
+          throw std::invalid_argument("Dequantize: output should have a float type");
+        }
+
         break;
       }
 
@@ -49,13 +65,35 @@ namespace ctranslate2 {
                                 const StorageView* bias) const {
       PROFILE("DequantizeGemmOutput");
       y.resize_as(c);
-      DEVICE_DISPATCH(c.device(), dequantize_gemm_output<D>(c,
-                                                            a_scale,
-                                                            b_scale,
-                                                            transpose_a,
-                                                            transpose_b,
-                                                            bias,
-                                                            y));
+
+      switch (y.dtype()) {
+      case DataType::FLOAT: {
+        DEVICE_DISPATCH(c.device(), (dequantize_gemm_output<D, float>(c,
+                                                                      a_scale,
+                                                                      b_scale,
+                                                                      transpose_a,
+                                                                      transpose_b,
+                                                                      bias,
+                                                                      y)));
+        break;
+      }
+
+      case DataType::FLOAT16: {
+        if (y.device() != Device::CUDA)
+          throw std::invalid_argument("DequantizeGemmOutput: float16 ouput is only supported on CUDA");
+        dequantize_gemm_output<Device::CUDA, float16_t>(c,
+                                                        a_scale,
+                                                        b_scale,
+                                                        transpose_a,
+                                                        transpose_b,
+                                                        bias,
+                                                        y);
+        break;
+      }
+
+      default:
+        throw std::invalid_argument("DequantizeGemmOutput: output should have a float type");
+      }
     }
 
   }

--- a/src/ops/dequantize.cc
+++ b/src/ops/dequantize.cc
@@ -37,12 +37,16 @@ namespace ctranslate2 {
           DEVICE_DISPATCH(input.device(), (dequantize<D, int8_t, float>(input, scale, output)));
           break;
         }
+
+#ifdef CT2_WITH_CUDA
         case DataType::FLOAT16: {
           if (output.device() != Device::CUDA)
             throw std::invalid_argument("Dequantize: float16 ouput is only supported on CUDA");
           dequantize<Device::CUDA, int8_t, float16_t>(input, scale, output);
           break;
         }
+#endif
+
         default:
           throw std::invalid_argument("Dequantize: output should have a float type");
         }
@@ -78,6 +82,7 @@ namespace ctranslate2 {
         break;
       }
 
+#ifdef CT2_WITH_CUDA
       case DataType::FLOAT16: {
         if (y.device() != Device::CUDA)
           throw std::invalid_argument("DequantizeGemmOutput: float16 ouput is only supported on CUDA");
@@ -90,6 +95,7 @@ namespace ctranslate2 {
                                                         y);
         break;
       }
+#endif
 
       default:
         throw std::invalid_argument("DequantizeGemmOutput: output should have a float type");

--- a/src/ops/dequantize_cpu.cc
+++ b/src/ops/dequantize_cpu.cc
@@ -21,9 +21,9 @@ namespace ctranslate2 {
     }
 
     template<>
-    void Dequantize::dequantize<Device::CPU, int16_t>(const StorageView& input,
-                                                      const StorageView& scale,
-                                                      StorageView& output) const {
+    void Dequantize::dequantize<Device::CPU, int16_t, float>(const StorageView& input,
+                                                             const StorageView& scale,
+                                                             StorageView& output) const {
       dequantize_kernel(input.data<int16_t>(),
                         scale.as_scalar<float>(),
                         input.size(),
@@ -31,9 +31,9 @@ namespace ctranslate2 {
     }
 
     template<>
-    void Dequantize::dequantize<Device::CPU, int8_t>(const StorageView& input,
-                                                     const StorageView& scale,
-                                                     StorageView& output) const {
+    void Dequantize::dequantize<Device::CPU, int8_t, float>(const StorageView& input,
+                                                            const StorageView& scale,
+                                                            StorageView& output) const {
       const dim_t batch_size = scale.size();
       const dim_t depth = input.dim(-1);
 
@@ -49,13 +49,13 @@ namespace ctranslate2 {
     }
 
     template<>
-    void Dequantize::dequantize_gemm_output<Device::CPU>(const StorageView& c,
-                                                         const StorageView& a_scale,
-                                                         const StorageView& b_scale,
-                                                         const bool transpose_a,
-                                                         const bool transpose_b,
-                                                         const StorageView* bias,
-                                                         StorageView& y) const {
+    void Dequantize::dequantize_gemm_output<Device::CPU, float>(const StorageView& c,
+                                                                const StorageView& a_scale,
+                                                                const StorageView& b_scale,
+                                                                const bool transpose_a,
+                                                                const bool transpose_b,
+                                                                const StorageView* bias,
+                                                                StorageView& y) const {
       const auto* c_data = c.data<int32_t>();
       auto* y_data = y.data<float>();
 

--- a/src/ops/dequantize_gpu.cu
+++ b/src/ops/dequantize_gpu.cu
@@ -5,26 +5,35 @@
 namespace ctranslate2 {
   namespace ops {
 
-    template <typename T>
+    template <typename InT, typename OutT>
     struct dequantize_func {
       __device__
-      float operator()(float scale, T x) {
+      OutT operator()(float scale, InT x) {
         return __fdividef(static_cast<float>(x), scale);
       }
     };
 
-    template<>
-    void Dequantize::dequantize<Device::CUDA, int8_t>(const StorageView& input,
-                                                      const StorageView& scale,
-                                                      StorageView& output) const {
+    template <Device D, typename InT, typename OutT>
+    void Dequantize::dequantize(const StorageView& input,
+                                const StorageView& scale,
+                                StorageView& output) const {
       const dim_t depth = input.dim(-1);
       cuda::binary_transform(scale.data<float>(),
-                             input.data<int8_t>(),
-                             output.data<float>(),
+                             input.data<InT>(),
+                             output.data<OutT>(),
                              input.size(),
-                             dequantize_func<int8_t>(),
+                             dequantize_func<InT, cuda::device_type<OutT>>(),
                              cuda::repeat_vec_depth<dim_t>(depth));
     }
+
+    template void
+    Dequantize::dequantize<Device::CUDA, int8_t, float>(const StorageView&,
+                                                        const StorageView&,
+                                                        StorageView&) const;
+    template void
+    Dequantize::dequantize<Device::CUDA, int8_t, float16_t>(const StorageView&,
+                                                            const StorageView&,
+                                                            StorageView&) const;
 
 
     __device__ __forceinline__ float rescale(const int32_t c,
@@ -33,36 +42,39 @@ namespace ctranslate2 {
       return __fdividef(__int2float_rn(c), a_scale * b_scale);
     }
 
-    template <typename Epilogue>
+    template <typename Epilogue, typename T>
     __global__ void dequantize_gemm_output_kernel(const int32_t* c,
                                                   const float* a_scales,
                                                   const float* b_scales,
                                                   const bool transpose_a,
                                                   const bool transpose_b,
-                                                  const float* bias,
+                                                  const T* bias,
                                                   const Epilogue& epilogue,
-                                                  float* y,
+                                                  T* y,
                                                   dim_t depth) {
       // y = c / (expand_dims(a_scales, trans_a ? 0 : 1) * expand_dims(b_scales, trans_b ? 0 : 1)
       // if bias: y += expand_dims(bias, 0)
       // y = epilogue(y)
+      const auto add_op = cuda::plus<T>();
       const dim_t i = blockIdx.x;
       for (dim_t j = threadIdx.x; j < depth; j += blockDim.x) {
         const dim_t index = i * depth + j;
-        y[index] = epilogue(rescale(c[index],
-                                    a_scales[transpose_a ? j : i],
-                                    b_scales[transpose_b ? j : i]) + (bias ? bias[j] : 0));
+        T v = rescale(c[index], a_scales[transpose_a ? j : i], b_scales[transpose_b ? j : i]);
+        if (bias)
+          v = add_op(v, bias[j]);
+        y[index] = epilogue(v);
       }
     }
 
+    template <typename T>
     static void dequantize_gemm_output_kernel_wrapper(const int32_t* c,
                                                       const float* a_scales,
                                                       const float* b_scales,
                                                       const bool transpose_a,
                                                       const bool transpose_b,
-                                                      const float* bias,
+                                                      const T* bias,
                                                       const ActivationType* activation_type,
-                                                      float* y,
+                                                      T* y,
                                                       dim_t batch_size,
                                                       dim_t depth) {
       const dim_t blocks = std::min(batch_size, cuda::max_blocks);
@@ -70,20 +82,20 @@ namespace ctranslate2 {
 
       if (!activation_type) {
         dequantize_gemm_output_kernel<<<blocks, threads, 0, cuda::get_cuda_stream()>>>(
-          c, a_scales, b_scales, transpose_a, transpose_b, bias, thrust::identity<float>(), y, depth);
+          c, a_scales, b_scales, transpose_a, transpose_b, bias, thrust::identity<T>(), y, depth);
 
       } else {
         switch (*activation_type) {
 
         case ActivationType::ReLU: {
           dequantize_gemm_output_kernel<<<blocks, threads, 0, cuda::get_cuda_stream()>>>(
-            c, a_scales, b_scales, transpose_a, transpose_b, bias, cuda::relu_func<float>(), y, depth);
+            c, a_scales, b_scales, transpose_a, transpose_b, bias, cuda::relu_func<T>(), y, depth);
           break;
         }
 
         case ActivationType::GELU: {
           dequantize_gemm_output_kernel<<<blocks, threads, 0, cuda::get_cuda_stream()>>>(
-            c, a_scales, b_scales, transpose_a, transpose_b, bias, cuda::gelu_func<float>(), y, depth);
+            c, a_scales, b_scales, transpose_a, transpose_b, bias, cuda::gelu_func<T>(), y, depth);
           break;
         }
 
@@ -91,14 +103,14 @@ namespace ctranslate2 {
       }
     }
 
-    template<>
-    void Dequantize::dequantize_gemm_output<Device::CUDA>(const StorageView& c,
-                                                          const StorageView& a_scale,
-                                                          const StorageView& b_scale,
-                                                          const bool transpose_a,
-                                                          const bool transpose_b,
-                                                          const StorageView* bias,
-                                                          StorageView& y) const {
+    template <Device D, typename T>
+    void Dequantize::dequantize_gemm_output(const StorageView& c,
+                                            const StorageView& a_scale,
+                                            const StorageView& b_scale,
+                                            const bool transpose_a,
+                                            const bool transpose_b,
+                                            const StorageView* bias,
+                                            StorageView& y) const {
       const dim_t batch_size = a_scale.size();
       const dim_t depth = c.dim(-1);
       dequantize_gemm_output_kernel_wrapper(
@@ -107,12 +119,29 @@ namespace ctranslate2 {
         b_scale.data<float>(),
         transpose_a,
         transpose_b,
-        bias ? bias->data<float>() : nullptr,
+        bias ? cuda::device_cast<T>(bias->data<T>()) : nullptr,
         _activation_type,
-        y.data<float>(),
+        cuda::device_cast<T>(y.data<T>()),
         batch_size,
         depth);
     }
+
+    template void
+    Dequantize::dequantize_gemm_output<Device::CUDA, float>(const StorageView&,
+                                                            const StorageView&,
+                                                            const StorageView&,
+                                                            const bool,
+                                                            const bool,
+                                                            const StorageView*,
+                                                            StorageView&) const;
+    template void
+    Dequantize::dequantize_gemm_output<Device::CUDA, float16_t>(const StorageView&,
+                                                                const StorageView&,
+                                                                const StorageView&,
+                                                                const bool,
+                                                                const bool,
+                                                                const StorageView*,
+                                                                StorageView&) const;
 
   }
 }

--- a/src/ops/dequantize_gpu.cu
+++ b/src/ops/dequantize_gpu.cu
@@ -5,21 +5,11 @@
 namespace ctranslate2 {
   namespace ops {
 
-    template <typename T>
-    __device__ __forceinline__ float cast_to_float(T x) {
-      return static_cast<float>(x);
-    }
-
-    template<>
-    __device__ __forceinline__ float cast_to_float(int32_t x) {
-      return __int2float_rn(x);
-    }
-
     template <typename InT, typename OutT>
     struct dequantize_func {
       __device__ __forceinline__
       OutT operator()(float scale, InT x) const {
-        return __fdividef(cast_to_float<InT>(x), scale);
+        return __fdividef(static_cast<float>(x), scale);
       }
     };
 

--- a/src/ops/quantize.cc
+++ b/src/ops/quantize.cc
@@ -39,12 +39,16 @@ namespace ctranslate2 {
           DEVICE_DISPATCH(input.device(), (quantize<D, float, int8_t>(input, output, scale)));
           break;
         }
+
+#ifdef CT2_WITH_CUDA
         case DataType::FLOAT16: {
           if (input.device() != Device::CUDA)
             throw std::invalid_argument("Quantize: float16 input is only supported on CUDA");
           quantize<Device::CUDA, float16_t, int8_t>(input, output, scale);
           break;
         }
+#endif
+
         default:
           throw std::invalid_argument("Quantize: input should have a float type");
         }

--- a/src/ops/quantize.cc
+++ b/src/ops/quantize.cc
@@ -1,6 +1,7 @@
 #include "ctranslate2/ops/quantize.h"
 
-#include "../device_dispatch.h"
+#include "device_dispatch.h"
+#include "type_dispatch.h"
 
 namespace ctranslate2 {
   namespace ops {
@@ -24,7 +25,7 @@ namespace ctranslate2 {
       case DataType::INT16: {
         if (input.device() != Device::CPU)
           throw std::invalid_argument("INT16 quantization is only supported on CPU");
-        quantize<Device::CPU, int16_t>(input, output, scale);
+        quantize<Device::CPU, float, int16_t>(input, output, scale);
         break;
       }
 
@@ -32,7 +33,22 @@ namespace ctranslate2 {
         const dim_t depth = input.dim(-1);
         const dim_t batch_size = input.size() / depth;
         scale.resize({batch_size});
-        DEVICE_DISPATCH(input.device(), (quantize<D, int8_t>(input, output, scale)));
+
+        switch (input.dtype()) {
+        case DataType::FLOAT: {
+          DEVICE_DISPATCH(input.device(), (quantize<D, float, int8_t>(input, output, scale)));
+          break;
+        }
+        case DataType::FLOAT16: {
+          if (input.device() != Device::CUDA)
+            throw std::invalid_argument("Quantize: float16 input is only supported on CUDA");
+          quantize<Device::CUDA, float16_t, int8_t>(input, output, scale);
+          break;
+        }
+        default:
+          throw std::invalid_argument("Quantize: input should have a float type");
+        }
+
         break;
       }
 

--- a/src/ops/quantize_cpu.cc
+++ b/src/ops/quantize_cpu.cc
@@ -6,9 +6,9 @@ namespace ctranslate2 {
   namespace ops {
 
     template<>
-    void Quantize::quantize<Device::CPU, int8_t>(const StorageView& input,
-                                                 StorageView& output,
-                                                 StorageView& scale) const {
+    void Quantize::quantize<Device::CPU, float, int8_t>(const StorageView& input,
+                                                        StorageView& output,
+                                                        StorageView& scale) const {
       // INT8 quantization rescales based on the per batch absolute maximum.
       constexpr float int8_max = std::numeric_limits<int8_t>::max();
       constexpr float int8_min = std::numeric_limits<int8_t>::min();
@@ -38,9 +38,9 @@ namespace ctranslate2 {
     }
 
     template<>
-    void Quantize::quantize<Device::CPU, int16_t>(const StorageView& input,
-                                                  StorageView& output,
-                                                  StorageView& scale) const {
+    void Quantize::quantize<Device::CPU, float, int16_t>(const StorageView& input,
+                                                         StorageView& output,
+                                                         StorageView& scale) const {
       // INT16 quantization simply rescales by a constant.
 
       const dim_t size = input.size();

--- a/src/ops/quantize_gpu.cu
+++ b/src/ops/quantize_gpu.cu
@@ -55,8 +55,8 @@ namespace ctranslate2 {
       output += blockIdx.x * depth;
 
       T thread_max = cuda::ilp_reduce(input, depth, absolute_maximum_func<T>(), T(0));
-      T max_t = cuda::block_reduce(sdata, thread_max, cuda::maximum<T>(), T(0));
-      float max = max_t;
+      T global_max = cuda::block_reduce(sdata, thread_max, cuda::maximum<T>(), T(0));
+      float max = global_max;
       float scale = max != 0.f ? 127.f / max : 1.f;
 
       scales[blockIdx.x] = scale;

--- a/src/ops/quantize_gpu.cu
+++ b/src/ops/quantize_gpu.cu
@@ -30,14 +30,13 @@ namespace ctranslate2 {
       }
     };
 
-    template <typename T>
     struct quantize_func {
       __device__ __forceinline__ quantize_func(float scale)
         : _scale(scale) {
       }
 
-      __device__ __forceinline__ int8_t operator()(T v) const {
-        return static_cast<int8_t>(float(v) * _scale);
+      __device__ __forceinline__ int8_t operator()(float v) const {
+        return static_cast<int8_t>(v * _scale);
       }
 
     private:
@@ -62,7 +61,7 @@ namespace ctranslate2 {
 
       scales[blockIdx.x] = scale;
 
-      cuda::apply_epilogue(input, depth, quantize_func<T>(scale), output);
+      cuda::apply_epilogue(input, depth, quantize_func(scale), output);
     }
 
     template <Device D, typename InT, typename OutT>

--- a/src/ops/quantize_gpu.cu
+++ b/src/ops/quantize_gpu.cu
@@ -5,54 +5,70 @@
 namespace ctranslate2 {
   namespace ops {
 
+    template <typename T>
     struct absolute_maximum_func {
+      __device__ __forceinline__ T operator()(T a, T b) const;
+    };
+
+    template<>
+    struct absolute_maximum_func<float> {
       __device__ __forceinline__ float operator()(float a, float b) const {
         return fmaxf(fabsf(a), fabsf(b));
       }
     };
 
-    struct maximum_func {
-      __device__ __forceinline__ float operator()(float a, float b) const {
-        return fmaxf(a, b);
+    template<>
+    struct absolute_maximum_func<__half> {
+      __device__ __forceinline__ __half operator()(__half a, __half b) const {
+#if CUDA_CAN_USE_HALF
+        a = __habs(a);
+        b = __habs(b);
+        return a > b ? a : b;
+#else
+        return fmaxf(fabsf(a), fabsf(b));
+#endif
       }
     };
 
+    template <typename T>
     struct quantize_func {
       __device__ __forceinline__ quantize_func(float scale)
         : _scale(scale) {
       }
 
-      __device__ __forceinline__ int8_t operator()(float v) const {
-        return static_cast<int8_t>(v * _scale);
+      __device__ __forceinline__ int8_t operator()(T v) const {
+        return static_cast<int8_t>(float(v) * _scale);
       }
 
     private:
       const float _scale;
     };
 
-    __global__ void quantize_kernel(const float* input,
+    template <typename T>
+    __global__ void quantize_kernel(const T* input,
                                     dim_t depth,
                                     float* scales,
                                     int8_t* output) {
       extern __shared__ unsigned char smem[];
-      auto sdata = reinterpret_cast<float*>(smem);
+      auto* sdata = reinterpret_cast<T*>(smem);
 
       input += blockIdx.x * depth;
       output += blockIdx.x * depth;
 
-      float thread_max = cuda::ilp_reduce(input, depth, absolute_maximum_func(), 0.f);
-      float max = cuda::block_reduce(sdata, thread_max, maximum_func(), 0.f);
+      T thread_max = cuda::ilp_reduce(input, depth, absolute_maximum_func<T>(), T(0));
+      T max_t = cuda::block_reduce(sdata, thread_max, cuda::maximum<T>(), T(0));
+      float max = max_t;
       float scale = max != 0.f ? 127.f / max : 1.f;
 
       scales[blockIdx.x] = scale;
 
-      cuda::apply_epilogue(input, depth, quantize_func(scale), output);
+      cuda::apply_epilogue(input, depth, quantize_func<T>(scale), output);
     }
 
-    template<>
-    void Quantize::quantize<Device::CUDA, int8_t>(const StorageView& input,
-                                                  StorageView& output,
-                                                  StorageView& scale) const {
+    template <Device D, typename InT, typename OutT>
+    void Quantize::quantize(const StorageView& input,
+                            StorageView& output,
+                            StorageView& scale) const {
       if (_shift_to_uint8)
         throw std::invalid_argument("Shift to uin8_t is not defined on CUDA");
 
@@ -61,12 +77,21 @@ namespace ctranslate2 {
 
       const dim3 grid(batch_size);
       const dim3 block(cuda::get_block_size(depth));
-      quantize_kernel<<<grid, block, block.x * sizeof (float), cuda::get_cuda_stream()>>>(
-        input.data<float>(),
+      quantize_kernel<<<grid, block, block.x * sizeof (InT), cuda::get_cuda_stream()>>>(
+        cuda::device_cast<InT>(input.data<InT>()),
         depth,
         scale.data<float>(),
-        output.data<int8_t>());
+        cuda::device_cast<OutT>(output.data<OutT>()));
     }
+
+    template void
+    Quantize::quantize<Device::CUDA, float, int8_t>(const StorageView&,
+                                                    StorageView&,
+                                                    StorageView&) const;
+    template void
+    Quantize::quantize<Device::CUDA, float16_t, int8_t>(const StorageView&,
+                                                        StorageView&,
+                                                        StorageView&) const;
 
   }
 }

--- a/src/types.cc
+++ b/src/types.cc
@@ -26,6 +26,8 @@ namespace ctranslate2 {
   ComputeType str_to_compute_type(const std::string& compute_type) {
     if (compute_type == "int8")
       return ComputeType::INT8;
+    if (compute_type == "int8_float16")
+      return ComputeType::INT8_FLOAT16;
     if (compute_type == "int16")
       return ComputeType::INT16;
     if (compute_type == "float")
@@ -44,12 +46,12 @@ namespace ctranslate2 {
                                 "or backend do not support efficient " + name + " computation.");
   }
 
-  ComputeType resolve_compute_type(const ComputeType compute_type,
-                                   const DataType weights_type,
+  ComputeType resolve_compute_type(const ComputeType requested_compute_type,
+                                   const ComputeType model_compute_type,
                                    const Device device,
                                    const int device_index,
                                    const bool enable_fallback) {
-    switch (compute_type) {
+    switch (requested_compute_type) {
 
     case ComputeType::FLOAT: {
       return ComputeType::FLOAT;
@@ -87,10 +89,24 @@ namespace ctranslate2 {
       return ComputeType::FLOAT;
     }
 
+    case ComputeType::INT8_FLOAT16: {
+      if (mayiuse_float16(device, device_index))
+        return ComputeType::INT8_FLOAT16;
+      if (!enable_fallback)
+        unsupported_compute_type("int8_float16");
+      if (device == Device::CPU) {
+        if (mayiuse_int8(device, device_index))
+          return ComputeType::INT8;
+        if (mayiuse_int16(device, device_index))
+          return ComputeType::INT16;
+      }
+      return ComputeType::FLOAT;
+    }
+
     case ComputeType::AUTO: {
       if (device == Device::CUDA) {
         if (mayiuse_float16(device, device_index))
-          return ComputeType::FLOAT16;
+          return ComputeType::INT8_FLOAT16;
         if (mayiuse_int8(device, device_index))
           return ComputeType::INT8;
       } else {
@@ -105,25 +121,8 @@ namespace ctranslate2 {
     default: {
       // By default, the compute type is the type of the saved model weights.
       // To ensure that any models can be loaded, we enable the fallback.
-
-      ComputeType inferred_compute_type = ComputeType::FLOAT;
-      switch (weights_type) {
-      case DataType::INT16:
-        inferred_compute_type = ComputeType::INT16;
-        break;
-      case DataType::INT8:
-        inferred_compute_type = ComputeType::INT8;
-        break;
-      case DataType::FLOAT16:
-        inferred_compute_type = ComputeType::FLOAT16;
-        break;
-      default:
-        inferred_compute_type = ComputeType::FLOAT;
-        break;
-      }
-
-      return resolve_compute_type(inferred_compute_type,
-                                  weights_type,
+      return resolve_compute_type(model_compute_type,
+                                  model_compute_type,
                                   device,
                                   device_index,
                                   /*enable_fallback=*/true);
@@ -137,9 +136,24 @@ namespace ctranslate2 {
     case ComputeType::FLOAT:
       return DataType::FLOAT;
     case ComputeType::INT8:
+    case ComputeType::INT8_FLOAT16:
       return DataType::INT8;
     case ComputeType::INT16:
       return DataType::INT16;
+    case ComputeType::FLOAT16:
+      return DataType::FLOAT16;
+    default:
+      throw std::invalid_argument("resolve_compute_type should be called first");
+    }
+  }
+
+  DataType default_float_type(const ComputeType compute_type) {
+    switch (compute_type) {
+    case ComputeType::FLOAT:
+    case ComputeType::INT8:
+    case ComputeType::INT16:
+      return DataType::FLOAT;
+    case ComputeType::INT8_FLOAT16:
     case ComputeType::FLOAT16:
       return DataType::FLOAT16;
     default:

--- a/src/types.cc
+++ b/src/types.cc
@@ -147,7 +147,7 @@ namespace ctranslate2 {
     }
   }
 
-  DataType default_float_type(const ComputeType compute_type) {
+  DataType get_default_float_type(const ComputeType compute_type) {
     switch (compute_type) {
     case ComputeType::FLOAT:
     case ComputeType::INT8:


### PR DESCRIPTION
This PR adds the compute type `int8_float16`. In this mode, layers that are not quantized to INT8 are run in FP16 instead of FP32.