### PR TITLE
Prepare the length mask before calling SoftMax op

### DIFF
--- a/include/ctranslate2/layers/attention.h
+++ b/include/ctranslate2/layers/attention.h
@@ -28,6 +28,12 @@ namespace ctranslate2 {
                       StorageView* cached_values = nullptr,
                       StorageView* attention = nullptr,
                       const Padder* padder = nullptr) const;
+
+      static StorageView prepare_length_mask(const StorageView& lengths,
+                                             const dim_t num_heads,
+                                             const dim_t num_queries,
+                                             const bool mask_future = false);
+
     private:
       const dim_t _num_heads;
       const bool _self_attention;

--- a/include/ctranslate2/layers/transformer.h
+++ b/include/ctranslate2/layers/transformer.h
@@ -121,6 +121,7 @@ namespace ctranslate2 {
 
     private:
       const Embeddings _embeddings;
+      const dim_t _num_heads;
       const ComputeType _compute_type;
       const std::unique_ptr<PositionEncoder> _position_encoder;
       const std::unique_ptr<LayerNorm> _output_norm;
@@ -161,6 +162,7 @@ namespace ctranslate2 {
 
     private:
       const bool _with_encoder_attention;
+      const dim_t _num_heads;
       const ComputeType _compute_type;
       const Embeddings _embeddings;
       const std::unique_ptr<PositionEncoder> _position_encoder;

--- a/src/cpu/kernels.cc
+++ b/src/cpu/kernels.cc
@@ -264,7 +264,6 @@ namespace ctranslate2 {
     void softmax<TARGET_ISA>(const float* input,
                              const int32_t* lengths,
                              float* output,
-                             dim_t lengths_size,
                              dim_t batch_size,
                              dim_t depth,
                              bool log,
@@ -279,12 +278,7 @@ namespace ctranslate2 {
 
         dim_t size = depth;
         if (lengths) {
-          if (lengths_size == batch_size) {
-            size = lengths[i];
-          } else {
-            // Broadcast length vector.
-            size = lengths[i * lengths_size / batch_size];
-          }
+          size = lengths[i];
 
           // Directly set 0 in output for out of range positions.
           for (dim_t j = size; j < depth; ++j) {

--- a/src/cpu/kernels.h
+++ b/src/cpu/kernels.h
@@ -52,7 +52,6 @@ namespace ctranslate2 {
     void softmax(const float* input,
                  const int32_t* lengths,
                  float* output,
-                 dim_t lengths_size,
                  dim_t batch_size,
                  dim_t depth,
                  bool log,

--- a/src/ops/softmax.cc
+++ b/src/ops/softmax.cc
@@ -23,6 +23,15 @@ namespace ctranslate2 {
     }
 
     void SoftMax::operator()(const StorageView& x, const StorageView* lengths, StorageView& y) const {
+      if (lengths) {
+        const dim_t batch_size = x.size() / x.dim(-1);
+        if (lengths->size() != batch_size)
+          throw std::invalid_argument("Length mask has size "
+                                      + std::to_string(lengths->size())
+                                      + " which is different than the current batch size "
+                                      + std::to_string(batch_size));
+      }
+
       PROFILE(_log ? "LogSoftMax" : "SoftMax");
       y.resize_as(x);
       switch (x.dtype()) {

--- a/src/ops/softmax_cpu.cc
+++ b/src/ops/softmax_cpu.cc
@@ -16,7 +16,6 @@ namespace ctranslate2 {
       CPU_ISA_DISPATCH((cpu::softmax<ISA>(input.data<T>(),
                                           lengths ? lengths->data<int32_t>() : nullptr,
                                           output.data<T>(),
-                                          lengths ? lengths->dim(0) : 0,
                                           batch_size,
                                           depth,
                                           _log,


### PR DESCRIPTION
The SoftMax op should not assume how to broadcast the length vector.