### PR TITLE
Add asynchronous flag in Python translation API

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -64,7 +64,7 @@ translator.num_queued_batches  # Number of batches waiting to be translated.
 # * scores (empty if return_scores is set to False)
 # * attention (empty if return_attention is set to False)
 # With asynchronous=True, the function returns a list of AsyncTranslationResult instances.
-# The actual result can retrieved by calling .result() on these instances.
+# The actual TranslationResult instance can be retrieved by calling .result() on the async wrapper.
 results = translator.translate_batch(
     source: list,                      # A list of list of string.
     target_prefix: list = None,        # An optional list of list of string.

--- a/docs/python.md
+++ b/docs/python.md
@@ -63,12 +63,15 @@ translator.num_queued_batches  # Number of batches waiting to be translated.
 # * hypotheses
 # * scores (empty if return_scores is set to False)
 # * attention (empty if return_attention is set to False)
+# With asynchronous=True, the function returns a list of AsyncTranslationResult instances.
+# The actual result can retrieved by calling .result() on these instances.
 results = translator.translate_batch(
     source: list,                      # A list of list of string.
     target_prefix: list = None,        # An optional list of list of string.
     *,
     max_batch_size: int = 0,           # Maximum batch size to run the model on.
     batch_type: str = "examples",      # Whether max_batch_size is the number of examples or tokens.
+    asynchronous: bool = False,        # Run the translation asynchronously.
     beam_size: int = 2,                # Beam size (set 1 to run greedy search).
     num_hypotheses: int = 1,           # Number of hypotheses to return (should be <= beam_size
                                        # unless return_alternatives is set).
@@ -174,21 +177,17 @@ Parallel translations are enabled in the following cases:
 
 * When calling `translate_file` (or `score_file`).
 * When calling `translate_batch` (or `score_batch`) and setting `max_batch_size`: the input will be split according to `max_batch_size` and each sub-batch will be translated in parallel.
-* When calling `translate_batch` (or `score_batch`) from multiple Python threads. If you are using a multithreaded HTTP server, this may already be the case. For other cases, you could use a [`ThreadPoolExecutor`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor) to submit multiple concurrent translations:
+* When calling `translate_batch` (or `score_batch`) from multiple Python threads: parallelization with Python threads is made possible because the `Translator` methods release the [Python GIL](https://wiki.python.org/moin/GlobalInterpreterLock).
+* When calling `translate_batch` multiple times with `asynchronous=True`:
 
 ```python
-import concurrent.futures
+async_results = []
+for batch in batch_generator():
+    async_results.extend(translator.translate_batch(batch, asynchronous=True))
 
-with concurrent.futures.ThreadPoolExecutor(max_workers=inter_threads) as executor:
-    futures = [
-        executor.submit(translator.translate_batch, batch)
-        for batch in batch_generator()
-    ]
-    for future in futures:
-        translation_result = future.result()
+for async_result in async_results:
+    print(async_result.result())  # This method blocks until the result is available.
 ```
-
-Note: parallelization with Python threads is made possible because the `Translator` methods release the [Python GIL](https://wiki.python.org/moin/GlobalInterpreterLock).
 
 ## Memory management API
 

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -99,6 +99,18 @@ def test_batch_translation(max_batch_size):
     assert output[1][0]["tokens"] == ["a", "c", "h", "i", "s", "o", "n"]
 
 
+def test_batch_translation_async():
+    translator = _get_transliterator()
+    output = translator.translate_batch(
+        [["آ", "ت", "ز", "م", "و", "ن"], ["آ", "ت", "ش", "ي", "س", "و", "ن"]],
+        asynchronous=True,
+    )
+    assert output[0].result().hypotheses == [["a", "t", "z", "m", "o", "n"]]
+    assert output[1].result().hypotheses == [["a", "c", "h", "i", "s", "o", "n"]]
+    assert output[0].done()
+    assert output[1].done()
+
+
 def test_file_translation(tmpdir):
     input_path = str(tmpdir.join("input.txt"))
     output_path = str(tmpdir.join("output.txt"))

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -91,6 +91,29 @@ get_translators_location(const std::vector<ctranslate2::Translator>& translators
 }
 
 
+template <typename T>
+class AsyncResult {
+public:
+  AsyncResult(std::future<T> future)
+    : _future(std::move(future))
+  {
+  }
+
+  T result() {
+    py::gil_scoped_release release;
+    return _future.get();
+  }
+
+  bool done() {
+    constexpr std::chrono::seconds zero_sec(0);
+    return _future.wait_for(zero_sec) == std::future_status::ready;
+  }
+
+private:
+  std::future<T> _future;
+};
+
+
 class TranslatorWrapper
 {
 public:
@@ -222,11 +245,13 @@ public:
     return stats;
   }
 
-  std::vector<ctranslate2::TranslationResult>
+  std::variant<std::vector<ctranslate2::TranslationResult>,
+               std::vector<AsyncResult<ctranslate2::TranslationResult>>>
   translate_batch(const BatchTokens& source,
                   const BatchTokensOptional& target_prefix,
                   size_t max_batch_size,
                   const std::string& batch_type_str,
+                  bool asynchronous,
                   size_t beam_size,
                   size_t num_hypotheses,
                   float length_penalty,
@@ -270,11 +295,25 @@ public:
     options.return_alternatives = return_alternatives;
     options.replace_unknowns = replace_unknowns;
 
-    return _translator_pool.translate_batch(source,
-                                            finalize_optional_batch(target_prefix),
-                                            options,
-                                            max_batch_size,
-                                            batch_type);
+    auto futures = _translator_pool.translate_batch_async(source,
+                                                          finalize_optional_batch(target_prefix),
+                                                          options,
+                                                          max_batch_size,
+                                                          batch_type);
+
+    if (asynchronous) {
+      std::vector<AsyncResult<ctranslate2::TranslationResult>> results;
+      results.reserve(futures.size());
+      for (auto& future : futures)
+        results.emplace_back(std::move(future));
+      return std::move(results);
+    } else {
+      std::vector<ctranslate2::TranslationResult> results;
+      results.reserve(futures.size());
+      for (auto& future : futures)
+        results.emplace_back(future.get());
+      return std::move(results);
+    }
   }
 
   std::vector<std::vector<float>>
@@ -447,6 +486,14 @@ static py::set get_supported_compute_types(const std::string& device_str, const 
   return compute_types;
 }
 
+template <typename T>
+static void declare_async_wrapper(py::module& m, const char* name) {
+  py::class_<AsyncResult<T>>(m, name)
+    .def("result", &AsyncResult<T>::result)
+    .def("done", &AsyncResult<T>::done)
+    ;
+}
+
 PYBIND11_MODULE(translator, m)
 {
   m.def("contains_model", &ctranslate2::models::contains_model, py::arg("path"));
@@ -481,6 +528,8 @@ PYBIND11_MODULE(translator, m)
     })
     ;
 
+  declare_async_wrapper<ctranslate2::TranslationResult>(m, "AsyncTranslationResult");
+
   py::class_<TranslatorWrapper>(m, "Translator")
     .def(py::init<const std::string&, const std::string&, const std::variant<int, std::vector<int>>&, const StringOrMap&, size_t, size_t>(),
          py::arg("model_path"),
@@ -500,6 +549,7 @@ PYBIND11_MODULE(translator, m)
          py::kw_only(),
          py::arg("max_batch_size")=0,
          py::arg("batch_type")="examples",
+         py::arg("asynchronous")=false,
          py::arg("beam_size")=2,
          py::arg("num_hypotheses")=1,
          py::arg("length_penalty")=0,


### PR DESCRIPTION
When set, the `translate_batch` method returns a list of future-like objects (one per example in the batch). Calling the method `.result()` on these objects returns the actual translation result.