### PR TITLE
Fix bugs when converting fairseq models.

### DIFF
--- a/python/ctranslate2/converters/fairseq.py
+++ b/python/ctranslate2/converters/fairseq.py
@@ -75,7 +75,14 @@ def _get_vocab(dictionary):
 class FairseqConverter(Converter):
     """Converts models trained with Fairseq."""
 
-    def __init__(self, model_path, data_dir, source_lang=None, target_lang=None, fixed_dictionary=None):
+    def __init__(
+        self,
+        model_path,
+        data_dir,
+        source_lang=None,
+        target_lang=None,
+        fixed_dictionary=None,
+    ):
         self._model_path = model_path
         self._data_dir = data_dir
         self._fixed_dictionary = fixed_dictionary
@@ -97,7 +104,7 @@ class FairseqConverter(Converter):
 
             if self._source_lang is not None:
                 args.source_lang = self._source_lang
-            
+
             if self._target_lang is not None:
                 args.target_lang = self._target_lang
 
@@ -222,11 +229,11 @@ def main():
     )
     parser.add_argument(
         "--source_lang",
-        help="Source language. This argument is used to find dictionary file from `data_dir`."
+        help="Source language. This argument is used to find dictionary file from `data_dir`.",
     )
     parser.add_argument(
         "--target_lang",
-        help="Target language. This argument is used to find dictionary file from `data_dir`."
+        help="Target language. This argument is used to find dictionary file from `data_dir`.",
     )
     Converter.declare_arguments(parser)
     args = parser.parse_args()

--- a/python/ctranslate2/converters/fairseq.py
+++ b/python/ctranslate2/converters/fairseq.py
@@ -75,10 +75,12 @@ def _get_vocab(dictionary):
 class FairseqConverter(Converter):
     """Converts models trained with Fairseq."""
 
-    def __init__(self, model_path, data_dir, fixed_dictionary=None):
+    def __init__(self, model_path, data_dir, source_lang=None, target_lang=None, fixed_dictionary=None):
         self._model_path = model_path
         self._data_dir = data_dir
         self._fixed_dictionary = fixed_dictionary
+        self.source_lang = source_lang
+        self.target_lang = target_lang
 
     def _load(self):
         import torch
@@ -87,10 +89,20 @@ class FairseqConverter(Converter):
 
         with torch.no_grad():
             checkpoint = checkpoint_utils.load_checkpoint_to_cpu(self._model_path)
-            args = checkpoint["args"]
+            if checkpoint["args"]:
+                args = checkpoint["args"]
+            else:
+                args = checkpoint["cfg"]["model"]
+
             args.data = self._data_dir
             if self._fixed_dictionary is not None:
                 args.fixed_dictionary = self._fixed_dictionary
+
+            if self.source_lang is not None:
+                args.source_lang = self.source_lang
+            
+            if self.target_lang is not None:
+                args.target_lang = self.target_lang
 
             model_spec = _get_model_spec(args)
             model_spec.with_source_eos = True
@@ -211,11 +223,21 @@ def main():
         "--fixed_dictionary",
         help="Fixed dictionary for multilingual models.",
     )
+    parser.add_argument(
+        "--source_lang",
+        help="Source language. This argument is used to find dictionary file from `data_dir`."
+    )
+    parser.add_argument(
+        "--target_lang",
+        help="Target language. This argument is used to find dictionary file from `data_dir`."
+    )
     Converter.declare_arguments(parser)
     args = parser.parse_args()
     converter = FairseqConverter(
         args.model_path,
         args.data_dir,
+        source_lang=args.source_lang,
+        target_lang=args.target_lang,
         fixed_dictionary=args.fixed_dictionary,
     )
     converter.convert_from_args(args)

--- a/python/ctranslate2/converters/fairseq.py
+++ b/python/ctranslate2/converters/fairseq.py
@@ -79,8 +79,8 @@ class FairseqConverter(Converter):
         self._model_path = model_path
         self._data_dir = data_dir
         self._fixed_dictionary = fixed_dictionary
-        self.source_lang = source_lang
-        self.target_lang = target_lang
+        self._source_lang = source_lang
+        self._target_lang = target_lang
 
     def _load(self):
         import torch
@@ -95,11 +95,11 @@ class FairseqConverter(Converter):
             if self._fixed_dictionary is not None:
                 args.fixed_dictionary = self._fixed_dictionary
 
-            if self.source_lang is not None:
-                args.source_lang = self.source_lang
+            if self._source_lang is not None:
+                args.source_lang = self._source_lang
             
-            if self.target_lang is not None:
-                args.target_lang = self.target_lang
+            if self._target_lang is not None:
+                args.target_lang = self._target_lang
 
             model_spec = _get_model_spec(args)
             model_spec.with_source_eos = True

--- a/python/ctranslate2/converters/fairseq.py
+++ b/python/ctranslate2/converters/fairseq.py
@@ -89,10 +89,7 @@ class FairseqConverter(Converter):
 
         with torch.no_grad():
             checkpoint = checkpoint_utils.load_checkpoint_to_cpu(self._model_path)
-            if checkpoint["args"]:
-                args = checkpoint["args"]
-            else:
-                args = checkpoint["cfg"]["model"]
+            args = checkpoint["args"] or checkpoint["cfg"]["model"]
 
             args.data = self._data_dir
             if self._fixed_dictionary is not None:


### PR DESCRIPTION
I want to convert my fairseq（v0.10.2） model trained by this command:
```
python $RUN_PATH/preprocess.py --source-lang $SOURCE_LANG --target-lang $TARGET_LANG \
      --trainpref $DATASET_DIR/train --validpref $DATASET_DIR/dev \
      --srcdict $SOURCE_VOCAB \
      --tgtdict $TARGET_VOCAB \
      --destdir $DATA_BIN_PATH \
      --workers 20

python -u $RUN_PATH/train.py  \
      $DATA_BIN_PATH \
      --arch transformer_vaswani_wmt_en_de_big --share-all-embeddings \
      --optimizer adam --adam-betas '(0.9, 0.98)' --clip-norm 0.0 \
      --lr 5e-4 --lr-scheduler inverse_sqrt --warmup-updates 4000 --warmup-init-lr 1e-07 \
      --dropout 0.3 --weight-decay 0.0001 \
      --criterion label_smoothed_cross_entropy --label-smoothing 0.1 \
      --max-update 600000 --max-epoch 50 \
      --patience 5 \
      --attention-dropout 0.1 \
      --max-tokens 8192 \
      --update-freq 1 \
      --eval-bleu \
      --eval-bleu-args '{"beam": 1, "max_len_a": 1.2, "max_len_b": 10}' \
      --eval-bleu-detok moses \
      --eval-bleu-remove-bpe \
      --eval-bleu-print-samples \
      --best-checkpoint-metric bleu --maximize-best-checkpoint-metric \
      --keep-best-checkpoints 10 \
      --ddp-backend=no_c10d \
      --fp16 \
      --save-dir $MODEL_PATH
```
When I convert checkpoints by this command:
```
ct2-fairseq-converter --model_path checkpoint_best.pt --data_dir ./ --output_dir ct2_convert
```
Error raised
```
Traceback (most recent call last):
  File "/home/hanbing/miniconda3/bin/ct2-fairseq-converter", line 8, in <module>
    sys.exit(main())
  File "/home/hanbing/miniconda3/lib/python3.7/site-packages/ctranslate2/converters/fairseq.py", line 221, in main
    converter.convert_from_args(args)
  File "/home/hanbing/miniconda3/lib/python3.7/site-packages/ctranslate2/converters/converter.py", line 35, in convert_from_args
    force=args.force,
  File "/home/hanbing/miniconda3/lib/python3.7/site-packages/ctranslate2/converters/converter.py", line 45, in convert
    model_spec = self._load()
  File "/home/hanbing/miniconda3/lib/python3.7/site-packages/ctranslate2/converters/fairseq.py", line 91, in _load
    args.data = self._data_dir
AttributeError: 'NoneType' object has no attribute 'data'
```
It because in some cases the args stored in `model["cfg"]["model"]` instead of `model["args"]`. After I fix this, there is another error:
```
Traceback (most recent call last):
  File "/home/hanbing/miniconda3/bin/ct2-fairseq-converter", line 8, in <module>
    sys.exit(main())
  File "/home/hanbing/miniconda3/lib/python3.7/site-packages/ctranslate2/converters/fairseq.py", line 224, in main
    converter.convert_from_args(args)
  File "/home/hanbing/miniconda3/lib/python3.7/site-packages/ctranslate2/converters/converter.py", line 35, in convert_from_args
    force=args.force,
  File "/home/hanbing/miniconda3/lib/python3.7/site-packages/ctranslate2/converters/converter.py", line 45, in convert
    model_spec = self._load()
  File "/home/hanbing/miniconda3/lib/python3.7/site-packages/ctranslate2/converters/fairseq.py", line 102, in _load
    task = fairseq.tasks.setup_task(args)
  File "/home/hanbing/projects/mtmodeltrainer/.fairseq/fairseq/tasks/__init__.py", line 44, in setup_task
    return task.setup_task(cfg, **kwargs)
  File "/home/hanbing/projects/mtmodeltrainer/.fairseq/fairseq/tasks/translation.py", line 262, in setup_task
    "Could not infer language pair, please provide it explicitly"
Exception: Could not infer language pair, please provide it explicitly
```
In some cases, we must explicit assignment arguments `source_lang` and `target_lang`.

After fixing these two problems, conversion succeeds.

 