### PR TITLE
Move the LayerNorm CPU kernel to the vectorized kernels

### DIFF
--- a/src/cpu/kernels.h
+++ b/src/cpu/kernels.h
@@ -58,6 +58,15 @@ namespace ctranslate2 {
                  float epsilon);
 
     template <CpuIsa ISA>
+    void layer_norm(const float* input,
+                    const float* gamma,
+                    const float* beta,
+                    float* output,
+                    dim_t batch_size,
+                    dim_t depth,
+                    float epsilon);
+
+    template <CpuIsa ISA>
     void quantize_s8(const float* x,
                      int8_t* y,
                      float* scales,

--- a/src/ops/layer_norm_cpu.cc
+++ b/src/ops/layer_norm_cpu.cc
@@ -1,40 +1,11 @@
 #include "ctranslate2/ops/layer_norm.h"
 
-#include <algorithm>
-#include <cmath>
+#include "cpu/kernels.h"
 
 #define EPSILON 1e-5
 
 namespace ctranslate2 {
   namespace ops {
-
-    template <typename T>
-    static void layer_norm_kernel(dim_t m,
-                                  dim_t n,
-                                  T eps,
-                                  const T* input,
-                                  const T* gamma,
-                                  const T* beta,
-                                  T* output) {
-      #pragma omp parallel for
-      for (dim_t i = 0; i < m; ++i) {
-        const auto offset = i * n;
-        const T* x = input + offset;
-        T* y = output + offset;
-        T mean = 0;  // sum(x)/n
-        T rstd = 0;  // 1/sqrt(var(x)) where var(x) = sum((x-mean)^2)/n = sum(x^2)/n - mean^2
-        for (dim_t j = 0; j < n; ++j) {
-          mean += x[j];
-          rstd += x[j] * x[j];
-        }
-        mean /= n;
-        rstd = std::max(rstd / n - mean * mean, static_cast<T>(0));
-        rstd = static_cast<T>(1) / std::sqrt(rstd + eps);
-        for (dim_t j = 0; j < n; ++j) {
-          y[j] = (x[j] - mean) * rstd * gamma[j] + beta[j];
-        }
-      }
-    }
 
     template <Device D, typename T>
     void LayerNorm::compute(const StorageView& beta,
@@ -43,13 +14,13 @@ namespace ctranslate2 {
                             StorageView& output) const {
       const dim_t depth = input.dim(-1);
       const dim_t batch_size = input.size() / depth;
-      layer_norm_kernel(batch_size,
-                        depth,
-                        static_cast<T>(EPSILON),
-                        input.data<T>(),
-                        gamma.data<T>(),
-                        beta.data<T>(),
-                        output.data<T>());
+      CPU_ISA_DISPATCH((cpu::layer_norm<ISA>(input.data<T>(),
+                                             gamma.data<T>(),
+                                             beta.data<T>(),
+                                             output.data<T>(),
+                                             batch_size,
+                                             depth,
+                                             static_cast<T>(EPSILON))));
     }
 
 #define DECLARE_IMPL(T)                                                 \


### PR DESCRIPTION
The compiler is able to vectorize its implementation.