### PR TITLE
Use 32-bit indexing in CUDA kernels

### DIFF
--- a/src/ops/bias_add_gpu.cu
+++ b/src/ops/bias_add_gpu.cu
@@ -10,12 +10,12 @@ namespace ctranslate2 {
     __global__ void bias_add_kernel(const T* value,
                                     const T* bias,
                                     T* output,
-                                    dim_t depth,
+                                    cuda::index_t depth,
                                     const AddFunc& add_func,
                                     const Epilogue& epilogue) {
-      const dim_t i = blockIdx.x;
-      for (dim_t j = threadIdx.x; j < depth; j += blockDim.x) {
-        const dim_t index = i * depth + j;
+      const cuda::index_t i = blockIdx.x;
+      for (cuda::index_t j = threadIdx.x; j < depth; j += blockDim.x) {
+        const cuda::index_t index = i * depth + j;
         output[index] = epilogue(add_func(value[index], bias[j]));
       }
     }

--- a/src/ops/dequantize_gpu.cu
+++ b/src/ops/dequantize_gpu.cu
@@ -45,15 +45,15 @@ namespace ctranslate2 {
                                                   const T* bias,
                                                   const Epilogue& epilogue,
                                                   T* y,
-                                                  dim_t depth) {
+                                                  cuda::index_t depth) {
       // y = c / (expand_dims(a_scales, trans_a ? 0 : 1) * expand_dims(b_scales, trans_b ? 0 : 1)
       // if bias: y += expand_dims(bias, 0)
       // y = epilogue(y)
       const auto add_func = cuda::plus<T>();
       const auto rescale_func = dequantize_func<int32_t, T>();
-      const dim_t i = blockIdx.x;
-      for (dim_t j = threadIdx.x; j < depth; j += blockDim.x) {
-        const dim_t index = i * depth + j;
+      const cuda::index_t i = blockIdx.x;
+      for (cuda::index_t j = threadIdx.x; j < depth; j += blockDim.x) {
+        const cuda::index_t index = i * depth + j;
         const float scale = a_scales[transpose_a ? j : i] * b_scales[transpose_b ? j : i];
         T v = rescale_func(scale, c[index]);
         if (bias)

--- a/src/ops/quantize_gpu.cu
+++ b/src/ops/quantize_gpu.cu
@@ -45,7 +45,7 @@ namespace ctranslate2 {
 
     template <typename T>
     __global__ void quantize_kernel(const T* input,
-                                    dim_t depth,
+                                    cuda::index_t depth,
                                     float* scales,
                                     int8_t* output) {
       extern __shared__ unsigned char smem[];

--- a/src/ops/tile_gpu.cu
+++ b/src/ops/tile_gpu.cu
@@ -4,6 +4,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
+#include "cuda/helpers.h"
 #include "cuda/utils.h"
 #include "type_dispatch.h"
 
@@ -11,21 +12,22 @@ namespace ctranslate2 {
   namespace ops {
 
     // Functor mapping an index in the tiled output to an input index.
+    template <typename T>
     class tiled_index_map {
     private:
-      const dim_t _inner_size;
-      const dim_t _num_tiles;
+      const T _inner_size;
+      const T _num_tiles;
     public:
-      tiled_index_map(const dim_t inner_size,
-                      const dim_t num_tiles)
+      tiled_index_map(const T inner_size,
+                      const T num_tiles)
         : _inner_size(inner_size)
         , _num_tiles(num_tiles)
       {
       }
       __host__ __device__
-      dim_t operator()(const dim_t i) const {
-        const dim_t r = i / (_inner_size * _num_tiles);
-        const dim_t c = i % _inner_size;
+      T operator()(const T i) const {
+        const T r = i / (_inner_size * _num_tiles);
+        const T c = i % _inner_size;
         return r * _inner_size + c;
       }
     };
@@ -35,8 +37,9 @@ namespace ctranslate2 {
                        const dim_t,
                        const dim_t inner_size,
                        StorageView& output) const {
-      auto gather_ids = thrust::make_transform_iterator(thrust::counting_iterator<dim_t>(0),
-                                                        tiled_index_map(inner_size, _num_tiles));
+      auto gather_ids = thrust::make_transform_iterator(
+        thrust::counting_iterator<cuda::index_t>(0),
+        tiled_index_map<cuda::index_t>(inner_size, _num_tiles));
       THRUST_CALL(thrust::gather,
                   gather_ids,
                   gather_ids + output.size(),


### PR DESCRIPTION
The code did not consistently use the same indexing type in CUDA kernels. Sometimes it used 32-bit integers and sometimes 64-bit. To maximize performance we prefer using a 32-bit type.