### PR TITLE
Fix in-place implementation of Gather op

### DIFF
--- a/src/ops/gather.cc
+++ b/src/ops/gather.cc
@@ -19,10 +19,12 @@ namespace ctranslate2 {
 
     static bool support_gather_batch_inplace(const StorageView& data, const StorageView& input) {
       // We can gather in place if the output is not larger than data and indices are in
-      // increasing order (i.e. we never need to gather from a previous index).
+      // strictly increasing order (i.e. we never need to gather from a previous index).
+      const auto* input_begin = input.data<int32_t>();
+      const auto* input_end = input.data<int32_t>() + input.size();
       return (input.device() == Device::CPU
               && input.size() <= data.dim(0)
-              && std::is_sorted(input.data<int32_t>(), input.data<int32_t>() + input.size()));
+              && std::adjacent_find(input_begin, input_end, std::greater_equal<int32_t>()) == input_end);
     }
 
     template <typename T>

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -67,11 +67,11 @@ TEST(OpDeviceTest, GatherInPlaceStrictlyIncreasing) {
 TEST(OpDeviceTest, GatherInPlaceIncreasing) {
   StorageView data({4, 2}, std::vector<float>{1, 1, 2, 2, 3, 3, 4, 4});
   void* data_ptr = data.buffer();
-  StorageView ids({3}, std::vector<int32_t>{1, 1, 3});
-  StorageView expected({3, 2}, std::vector<float>{2, 2, 2, 2, 4, 4});
+  StorageView ids({3}, std::vector<int32_t>{0, 0, 1});
+  StorageView expected({3, 2}, std::vector<float>{1, 1, 1, 1, 2, 2});
   ops::Gather(0)(data, ids);
   expect_storage_eq(data, expected);
-  EXPECT_EQ(data.buffer(), data_ptr);
+  EXPECT_NE(data.buffer(), data_ptr);
 }
 
 TEST(OpDeviceTest, GatherInPlaceDecreasing) {


### PR DESCRIPTION
The in-place implementation should only be selected when the ids are strictly increasing, not just increasing.

Fixes #546.