### PR TITLE
Update benchmark numbers for 2.6.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,9 +363,46 @@ Depending on your build configuration, you might need to set `LD_LIBRARY_PATH` i
 
 ## Benchmarks
 
-We compare CTranslate2 with OpenNMT-py and OpenNMT-tf on their pretrained English-German Transformer models (available on the [website](https://opennmt.net/)). **For this benchmark, CTranslate2 models are using the weights of the OpenNMT-py model.**
+### Performance
+
+For a fair comparison, we restrict the benchmark to toolkits compatible with the pretrained English-German Transformer model from [OpenNMT-py](https://opennmt.net/Models-py/) or [OpenNMT-tf](https://opennmt.net/Models-tf/).
+
+We translate the test set *newstest2014* and report the number of target tokens generated per second. The results are aggregated over multiple runs (see the [benchmark scripts](tools/benchmark) for more details).
+
+**Please note that the results presented below are only valid for the configuration used during this benchmark: absolute and relative performance may change with different settings.**
+
+#### CPU
+
+| | Tokens per second | Max. memory | BLEU |
+| --- | --- | --- | --- |
+| OpenNMT-tf 2.22.0 (with TensorFlow 2.6.0) | 356.2 | 2641MB | 26.93 |
+| OpenNMT-py 2.2.0 (with PyTorch 1.9.0) | 466.5 | 1830MB | 26.77 |
+| - int8 | 505.0 | 1510MB | 26.80 |
+| CTranslate2 2.6.0 | 1202.3 | 1129MB | 26.77 |
+| - int16 | 1591.2 | 935MB | 26.84 |
+| - int8 | 1870.6 | 839MB | 26.88 |
+| - int8 + vmap | 2319.3 | 792MB | 26.65 |
+
+Executed with 8 threads on a [*c5.metal*](https://aws.amazon.com/ec2/instance-types/c5/) Amazon EC2 instance equipped with an Intel(R) Xeon(R) Platinum 8275CL CPU.
+
+#### GPU
+
+| | Tokens per second | Max. GPU memory | Max. CPU memory | BLEU |
+| --- | --- | --- | --- | --- |
+| OpenNMT-tf 2.22.0 (with TensorFlow 2.6.0) | 1361.4 | 2660MB | 1737MB | 26.93 |
+| OpenNMT-py 2.2.0 (with PyTorch 1.9.0) | 1280.5 | 3046MB | 3523MB | 26.77 |
+| FasterTransformer 4.0 | 2782.9 | 5868MB | 2977MB | 26.77 |
+| - float16 | 6346.2 | 3916MB | 2976MB | 26.83 |
+| CTranslate2 2.6.0 | 3399.3 | 1234MB | 669MB | 26.77 |
+| - int8 | 5106.6 | 1010MB | 566MB | 26.82 |
+| - float16 | 5020.6 | 818MB | 604MB | 26.75 |
+| - int8 + float16 | 5625.5 | 658MB | 568MB | 26.88 |
+
+Executed with CUDA 11 on a [*g4dn.xlarge*](https://aws.amazon.com/ec2/instance-types/g4/) Amazon EC2 instance equipped with a NVIDIA T4 GPU (driver version: 460.91.03).
 
 ### Model size
+
+The table below compares the model size on disk of the pretrained Transformer models which are "base" Transformers without shared embeddings and a vocabulary of size 32k:
 
 | | Model size |
 | --- | --- |
@@ -376,47 +413,6 @@ We compare CTranslate2 with OpenNMT-py and OpenNMT-tf on their pretrained Englis
 | - float16 | 182MB |
 | - int8 | 100MB |
 | - int8 + float16 | 95MB |
-
-CTranslate2 models are generally lighter and can go as low as 100MB when quantized to int8. This also results in a fast loading time and noticeable lower memory usage during runtime.
-
-### Results
-
-We translate the test set *newstest2014* and report:
-
-* the number of target tokens generated per second (higher is better)
-* the maximum memory usage (lower is better)
-* the BLEU score of the detokenized output (higher is better)
-
-See the directory [`tools/benchmark`](tools/benchmark) for more details about the benchmark procedure and how to run it. Also see the [Performance](docs/performance.md) document to further improve CTranslate2 performance.
-
-**Please note that the results presented below are only valid for the configuration used during this benchmark: absolute and relative performance may change with different settings.**
-
-#### CPU
-
-| | Tokens per second | Max. memory | BLEU |
-| --- | --- | --- | --- |
-| OpenNMT-tf 2.19.0 (with TensorFlow 2.5.0) | 364.1 | 2620MB | 26.93 |
-| OpenNMT-py 2.1.2 (with PyTorch 1.9.0) | 472.6 | 1856MB | 26.77 |
-| - int8 | 510.4 | 1712MB | 26.80 |
-| CTranslate2 2.3.0 | 1182.3 | 1037MB | 26.77 |
-| - int16 | 1532.0 | 954MB | 26.83 |
-| - int8 | 1785.2 | 810MB | 26.86 |
-| - int8 + vmap | 2263.4 | 692MB | 26.70 |
-
-Executed with 8 threads on a [*c5.metal*](https://aws.amazon.com/ec2/instance-types/c5/) Amazon EC2 instance equipped with an Intel(R) Xeon(R) Platinum 8275CL CPU.
-
-#### GPU
-
-| | Tokens per second | Max. GPU memory | Max. CPU memory | BLEU |
-| --- | --- | --- | --- | --- |
-| OpenNMT-tf 2.19.0 (with TensorFlow 2.5.0) | 1815.2 | 2660MB | 1724MB | 26.93 |
-| OpenNMT-py 2.1.2 (with PyTorch 1.9.0) | 1536.7 | 3046MB | 2987MB | 26.77 |
-| CTranslate2 2.3.0 | 3696.7 | 1234MB | 555MB | 26.77 |
-| - int8 | 5201.9 | 946MB | 565MB | 26.82 |
-| - float16 | 5303.5 | 818MB | 607MB | 26.75 |
-| - int8 + float16 | 5824.3 | 722MB | 566MB | 26.88 |
-
-Executed with CUDA 11 on a [*g4dn.xlarge*](https://aws.amazon.com/ec2/instance-types/g4/) Amazon EC2 instance equipped with a NVIDIA T4 GPU (driver version: 460.73.01).
 
 ## Frequently asked questions
 

--- a/tools/benchmark/benchmark_pretrained.py
+++ b/tools/benchmark/benchmark_pretrained.py
@@ -29,6 +29,11 @@ opennmt_tf, _ = client.images.build(
     path=os.path.join(pretrained_dir, "opennmt_tf"),
     tag="opennmt/opennmt-tf-benchmark",
 )
+if gpu:
+    fastertransformer, _ = client.images.build(
+        path=os.path.join(pretrained_dir, "fastertransformer"),
+        tag="opennmt/fastertransformer-benchmark",
+    )
 
 print("Downloading the test files...")
 source_file = sacrebleu.get_source_file(test_set, langpair=langpair)
@@ -84,6 +89,10 @@ run("OpenNMT-tf", opennmt_tf)
 run("OpenNMT-py", opennmt_py)
 if not gpu:
     run("- int8", opennmt_py, env={"INT8": "1"})
+
+if gpu:
+    run("FasterTransformer", fastertransformer)
+    run("- float16", fastertransformer, env={"FP16": "1"})
 
 run("CTranslate2", ctranslate2)
 if gpu:

--- a/tools/benchmark/pretrained_transformer_base/ctranslate2/Dockerfile
+++ b/tools/benchmark/pretrained_transformer_base/ctranslate2/Dockerfile
@@ -1,4 +1,4 @@
-FROM opennmt/ctranslate2:2.3.0-ubuntu20.04-cuda11.2 as model_converter
+FROM opennmt/ctranslate2:2.6.0-ubuntu20.04-cuda11.2 as model_converter
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -11,13 +11,13 @@ RUN wget -q https://opennmt-models.s3.amazonaws.com/transformer-ende-wmt-pyOnmt.
     tar xf *.tar.gz && \
     rm *.tar.gz
 
-RUN pip install --no-cache-dir OpenNMT-py==2.1.2
+RUN pip install --no-cache-dir OpenNMT-py==2.2.0
 
 RUN ct2-opennmt-py-converter --model_path averaged-10-epoch.pt --output_dir /model
 RUN wget -q -P /model https://opennmt-models.s3.amazonaws.com/vmap.txt
 RUN cp sentencepiece.model /model
 
-FROM opennmt/ctranslate2:2.3.0-ubuntu20.04-cuda11.2
+FROM opennmt/ctranslate2:2.6.0-ubuntu20.04-cuda11.2
 
 COPY --from=model_converter /model /model
 

--- a/tools/benchmark/pretrained_transformer_base/fastertransformer/Dockerfile
+++ b/tools/benchmark/pretrained_transformer_base/fastertransformer/Dockerfile
@@ -1,0 +1,22 @@
+FROM nvcr.io/nvidia/pytorch:21.09-py3
+
+RUN git clone --branch v4.0 https://github.com/NVIDIA/FasterTransformer.git && \
+    cd FasterTransformer && \
+    mkdir build && \
+    cd build && \
+    cmake -DSM=75 -DCMAKE_BUILD_TYPE=Release -DBUILD_PYT=ON .. && \
+    make -j4
+
+RUN wget -q https://opennmt-models.s3.amazonaws.com/transformer-ende-wmt-pyOnmt.tar.gz && \
+    tar xf *.tar.gz && \
+    rm *.tar.gz
+
+RUN pip install --no-cache-dir OpenNMT-py==1.1.1
+
+WORKDIR FasterTransformer/build
+
+# Patch to fix translation of empty files.
+RUN sed -i '121i\ \ \ \ \ \ \ \ ex_fields = {}' /opt/conda/lib/python3.8/site-packages/onmt/inputters/dataset_base.py
+RUN sed -i 's/report_time=True/report_time=False/g' pytorch/run_translation.py
+
+COPY *.sh /

--- a/tools/benchmark/pretrained_transformer_base/fastertransformer/detokenize.sh
+++ b/tools/benchmark/pretrained_transformer_base/fastertransformer/detokenize.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 -c 'import sys; import pyonmttok; pyonmttok.Tokenizer("none", sp_model_path="/workspace/sentencepiece.model").detokenize_file(sys.argv[1], sys.argv[2])' $1 $2

--- a/tools/benchmark/pretrained_transformer_base/fastertransformer/tokenize.sh
+++ b/tools/benchmark/pretrained_transformer_base/fastertransformer/tokenize.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 -c 'import sys; import pyonmttok; pyonmttok.Tokenizer("none", sp_model_path="/workspace/sentencepiece.model").tokenize_file(sys.argv[1], sys.argv[2])' $1 $2

--- a/tools/benchmark/pretrained_transformer_base/fastertransformer/translate.sh
+++ b/tools/benchmark/pretrained_transformer_base/fastertransformer/translate.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+SOURCE_FILE=$2
+OUTPUT_FILE=$3
+
+BATCH_SIZE=32
+BEAM_SIZE=4
+FP16=${FP16:-0}
+if [ $FP16 = "1" ]; then
+    DATA_TYPE="fp16"
+else
+    DATA_TYPE="fp32"
+fi
+
+./bin/decoding_gemm $BATCH_SIZE $BEAM_SIZE 8 64 31538 100 512 $FP16
+python3 pytorch/run_translation.py --model_path /workspace/averaged-10-epoch.pt --input_file $SOURCE_FILE --output_file $OUTPUT_FILE --batch_size $BATCH_SIZE --beam_size $BEAM_SIZE --model_type decoding_ext --data_type $DATA_TYPE

--- a/tools/benchmark/pretrained_transformer_base/opennmt_py/Dockerfile
+++ b/tools/benchmark/pretrained_transformer_base/opennmt_py/Dockerfile
@@ -11,8 +11,6 @@ RUN wget -q https://opennmt-models.s3.amazonaws.com/transformer-ende-wmt-pyOnmt.
     tar xf *.tar.gz && \
     rm *.tar.gz
 
-# TODO: remove --no-deps once OpenNMT-py includes PyTorch 1.9 in its dependencies.
-RUN pip install --no-cache-dir --no-deps OpenNMT-py==2.1.2 && \
-    pip install --no-cache-dir torchtext==0.5.* configargparse==1.* pyonmttok==1.*
+RUN pip install --no-cache-dir OpenNMT-py==2.2.0
 
 COPY *.sh /

--- a/tools/benchmark/pretrained_transformer_base/opennmt_tf/Dockerfile
+++ b/tools/benchmark/pretrained_transformer_base/opennmt_tf/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.5.0-gpu
+FROM tensorflow/tensorflow:2.6.0-gpu
 
 RUN curl -O https://opennmt-models.s3.amazonaws.com/averaged-ende-ckpt500k-v2.tar.gz && \
     tar xf *.tar.gz && \
@@ -6,7 +6,7 @@ RUN curl -O https://opennmt-models.s3.amazonaws.com/averaged-ende-ckpt500k-v2.ta
 RUN cd averaged-ende-ckpt500k-v2 && \
     curl -O https://opennmt-trainingdata.s3.amazonaws.com/wmtende.model
 
-RUN python3 -m pip install --no-cache-dir OpenNMT-tf==2.19.*
+RUN python3 -m pip install --no-cache-dir OpenNMT-tf==2.22.*
 
 COPY *.yml /
 COPY *.sh /

--- a/tools/benchmark/pretrained_transformer_base/opennmt_tf/config.yml
+++ b/tools/benchmark/pretrained_transformer_base/opennmt_tf/config.yml
@@ -1,7 +1,7 @@
-model_dir: /averaged-ende-ckpt500k-v2
+auto_config: true
 data:
-  source_vocabulary: /averaged-ende-ckpt500k-v2/wmtende.vocab
-  target_vocabulary: /averaged-ende-ckpt500k-v2/wmtende.vocab
+  source_vocabulary: wmtende.vocab
+  target_vocabulary: wmtende.vocab
 params:
   beam_width: 4
 infer:

--- a/tools/benchmark/pretrained_transformer_base/opennmt_tf/translate.sh
+++ b/tools/benchmark/pretrained_transformer_base/opennmt_tf/translate.sh
@@ -3,6 +3,9 @@
 SOURCE_FILE=$2
 OUTPUT_FILE=$3
 
-onmt-main --model_type Transformer --config /config.yml --auto_config --gpu_allow_growth \
+onmt-main --model_dir /averaged-ende-ckpt500k-v2 \
+          --model_type Transformer \
+          --config /config.yml \
+          --gpu_allow_growth \
           infer \
           --features_file $SOURCE_FILE --predictions_file $OUTPUT_FILE


### PR DESCRIPTION
Also added [NVIDIA/FasterTransformer](https://github.com/NVIDIA/FasterTransformer) in the GPU benchmark since they support OpenNMT models.