### PR TITLE
Apply length penalty only when the hypothesis is finished

### DIFF
--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -13,9 +13,12 @@ namespace ctranslate2 {
   struct TranslationOptions {
     // Beam size to use for beam search (set 1 to run greedy search).
     size_t beam_size = 2;
-    // Length penalty value to apply during beam search.
+    // Length penalty value to apply during beam search (set 0 to disable).
+    // If normalize_scores is enabled, the scores are normalized with:
+    //   hypothesis_score /= (hypothesis_length ** length_penalty)
+    // Otherwise, the length penalty is applied as described in https://arxiv.org/pdf/1609.08144.pdf.
     float length_penalty = 0;
-    // Coverage value to apply during beam search.
+    // Coverage value to apply during beam search (set 0 to disable).
     float coverage_penalty = 0;
     // Biases decoding towards a given prefix, see https://arxiv.org/abs/1912.03393 --section 4.2
     // Only activates biased-decoding when beta is in range (0, 1) and SearchStrategy is set to BeamSearch.


### PR DESCRIPTION
This PR also changes the length penalty formula when `normalize_scores` is enabled to:

```text
hypothesis_score /= (hypothesis_length ** length_penalty)
```

The same is implemented in e.g. Fairseq and HuggingFace.