### PR TITLE
Add option max_input_length to truncate long inputs

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -82,7 +82,8 @@ results = translator.translate_batch(
     repetition_penalty: float = 1,     # Repetition penalty constant to use during beam search.
     prefix_bias_beta: float = 0,       # Parameter for biasing translations towards given prefix.
     allow_early_exit: bool = True,     # Allow the beam search to exit early when the first beam finishes.
-    max_decoding_length: int = 250,    # Maximum prediction length.
+    max_input_length: int = 1024,      # Truncate inputs after this many tokens (set 0 to disable).
+    max_decoding_length: int = 256,    # Maximum prediction length.
     min_decoding_length: int = 1,      # Minimum prediction length.
     use_vmap: bool = False,            # Use the vocabulary mapping file saved in this model.
     normalize_scores: bool = False,    # Normalize the score by the hypothesis length.
@@ -113,7 +114,8 @@ stats = translator.translate_file(
     repetition_penalty: float = 1,
     prefix_bias_beta: float = 0,
     allow_early_exit: bool = True,
-    max_decoding_length: int = 250,
+    max_input_length: int = 1024,
+    max_decoding_length: int = 256,
     min_decoding_length: int = 1,
     use_vmap: bool = False,
     normalize_scores: bool = False,
@@ -141,6 +143,7 @@ scores = translator.score_batch(
     *,
     max_batch_size: int = 0,       # Maximum batch size to run the model on.
     batch_type: str = "examples",  # Whether max_batch_size is the number of examples or tokens.
+    max_input_length: int = 1024,  # Truncate inputs after this many tokens (set 0 to disable).
 )
 
 # File scoring:
@@ -159,6 +162,8 @@ stats = translator.score_file(
     max_batch_size: int = 32,      # Maximum batch size to run the model on.
     read_batch_size: int = 0,      # Number of sentences to read at once.
     batch_type: str = "examples",  # Whether the batch size is the number of examples or tokens.
+    max_input_length: int = 1024,  # Truncate inputs after this many tokens (set 0 to disable).
+    with_tokens_score: bool = False,       # Include token-level scores in the output.
     source_tokenize_fn: callable = None,   # Function with signature: string -> list of strings
     target_tokenize_fn: callable = None,   # Function with signature: string -> list of strings
     target_detokenize_fn: callable = None, # Function with signature: list of strings -> string

--- a/include/ctranslate2/models/sequence_to_sequence.h
+++ b/include/ctranslate2/models/sequence_to_sequence.h
@@ -43,7 +43,8 @@ namespace ctranslate2 {
       score(layers::Encoder& encoder,
             layers::Decoder& decoder,
             const std::vector<std::vector<std::string>>& source,
-            const std::vector<std::vector<std::string>>& target) const;
+            const std::vector<std::vector<std::string>>& target,
+            const size_t max_input_length = 0) const;
 
       std::vector<GenerationResult<std::string>>
       sample(layers::Encoder& encoder,
@@ -53,8 +54,9 @@ namespace ctranslate2 {
              const SearchStrategy& search_strategy = GreedySearch(),
              const Sampler& sampler = BestSampler(),
              const bool use_vmap = false,
-             const size_t max_length = 250,
-             const size_t min_length = 1,
+             const size_t max_input_length = 0,
+             const size_t max_output_length = 256,
+             const size_t min_output_length = 1,
              const size_t num_hypotheses = 1,
              const bool return_alternatives = false,
              const bool return_scores = false,

--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -33,8 +33,11 @@ namespace ctranslate2 {
     // continues until beam_size hypotheses are finished.
     bool allow_early_exit = true;
 
+    // Truncate the inputs after this many tokens (set 0 to disable truncation).
+    size_t max_input_length = 1024;
+
     // Decoding length constraints.
-    size_t max_decoding_length = 250;
+    size_t max_decoding_length = 256;
     size_t min_decoding_length = 1;
 
     // Randomly sample from the top K candidates (not compatible with beam search, set to 0
@@ -67,6 +70,11 @@ namespace ctranslate2 {
 
     void validate() const;
     bool support_batch_translation() const;
+  };
+
+  struct ScoringOptions {
+    // Truncate the inputs after this many tokens (set 0 to disable truncation).
+    size_t max_input_length = 1024;
   };
 
   // The Translator can run translations from a sequence-to-sequence model.
@@ -109,7 +117,8 @@ namespace ctranslate2 {
 
     std::vector<ScoringResult>
     score_batch(const std::vector<std::vector<std::string>>& source,
-                const std::vector<std::vector<std::string>>& target);
+                const std::vector<std::vector<std::string>>& target,
+                const ScoringOptions& options = ScoringOptions());
 
     Device device() const;
     int device_index() const;

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -128,6 +128,7 @@ namespace ctranslate2 {
                                                   *make_search_strategy(options),
                                                   *make_sampler(options),
                                                   options.use_vmap,
+                                                  options.max_input_length,
                                                   options.max_decoding_length,
                                                   options.min_decoding_length,
                                                   options.num_hypotheses,
@@ -146,12 +147,13 @@ namespace ctranslate2 {
 
   std::vector<ScoringResult>
   Translator::score_batch(const std::vector<std::vector<std::string>>& source,
-                          const std::vector<std::vector<std::string>>& target) {
+                          const std::vector<std::vector<std::string>>& target,
+                          const ScoringOptions& options) {
     assert_has_model();
     register_current_allocator();
     if (source.empty())
       return {};
-    return _seq2seq_model->score(*_encoder, *_decoder, source, target);
+    return _seq2seq_model->score(*_encoder, *_decoder, source, target, options.max_input_length);
   }
 
   Device Translator::device() const {


### PR DESCRIPTION
The default value is 1024.

Closes #544.