### PR TITLE
Reduce multi-head attention based on options alignment_{layer,heads}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,8 @@ set(SOURCES
   src/ops/layer_norm_cpu.cc
   src/ops/log.cc
   src/ops/matmul.cc
+  src/ops/mean.cc
+  src/ops/mean_cpu.cc
   src/ops/min_max.cc
   src/ops/mul.cc
   src/ops/multinomial.cc
@@ -394,6 +396,7 @@ if (WITH_CUDA)
     src/ops/dequantize_gpu.cu
     src/ops/gather_gpu.cu
     src/ops/layer_norm_gpu.cu
+    src/ops/mean_gpu.cu
     src/ops/multinomial_gpu.cu
     src/ops/softmax_gpu.cu
     src/ops/tile_gpu.cu

--- a/include/ctranslate2/layers/attention.h
+++ b/include/ctranslate2/layers/attention.h
@@ -9,6 +9,8 @@ namespace ctranslate2 {
     StorageView make_relative_positions(dim_t length,
                                         dim_t max_position,
                                         bool with_cache = false);
+    StorageView reduce_multi_head_attention(const StorageView& attention,
+                                            dim_t num_heads_to_average);
 
     class MultiHeadAttention : public Layer
     {

--- a/include/ctranslate2/layers/transformer.h
+++ b/include/ctranslate2/layers/transformer.h
@@ -139,7 +139,9 @@ namespace ctranslate2 {
                          const bool with_position_encoding = true,
                          const bool with_encoder_attention = true,
                          const bool pre_norm = true,
-                         const ops::ActivationType activation_type = ops::ActivationType::ReLU);
+                         const ops::ActivationType activation_type = ops::ActivationType::ReLU,
+                         const dim_t alignment_layer = -1,
+                         const dim_t alignment_heads = 1);
 
       void set_vocabulary_mask(const StorageView& ids) override;
       void reset_vocabulary_mask() override;
@@ -176,6 +178,8 @@ namespace ctranslate2 {
 
       const bool _with_encoder_attention;
       const dim_t _num_heads;
+      dim_t _alignment_layer;
+      dim_t _alignment_heads;
       const ComputeType _compute_type;
       const Embeddings _embeddings;
       const std::unique_ptr<PositionEncoder> _position_encoder;

--- a/include/ctranslate2/models/transformer.h
+++ b/include/ctranslate2/models/transformer.h
@@ -30,6 +30,8 @@ namespace ctranslate2 {
       bool _with_relative_position;
       bool _pre_norm;
       ops::ActivationType _activation_type;
+      dim_t _alignment_layer;
+      dim_t _alignment_heads;
     };
 
   }

--- a/include/ctranslate2/ops/mean.h
+++ b/include/ctranslate2/ops/mean.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "op.h"
+
+namespace ctranslate2 {
+  namespace ops {
+
+    class Mean : public UnaryOp {
+    public:
+      Mean(const dim_t axis);
+
+      void operator()(const StorageView& input, StorageView& output) const override;
+
+    private:
+      template <Device D, typename T>
+      void compute(const StorageView& input,
+                   const dim_t outer_size,
+                   const dim_t axis_size,
+                   const dim_t inner_size,
+                   StorageView& output) const;
+
+      const dim_t _axis;
+    };
+
+  }
+}

--- a/include/ctranslate2/ops/ops.h
+++ b/include/ctranslate2/ops/ops.h
@@ -12,6 +12,7 @@
 #include "identity.h"
 #include "layer_norm.h"
 #include "matmul.h"
+#include "mean.h"
 #include "mul.h"
 #include "multinomial.h"
 #include "quantize.h"

--- a/python/ctranslate2/converters/fairseq.py
+++ b/python/ctranslate2/converters/fairseq.py
@@ -8,12 +8,14 @@ from ctranslate2.specs import transformer_spec
 
 _SUPPORTED_ARCHS = {
     "transformer",
+    "transformer_align",
     "transformer_iwslt_de_en",
     "transformer_tiny",
     "transformer_vaswani_wmt_en_de_big",
     "transformer_vaswani_wmt_en_fr_big",
     "transformer_wmt_en_de",
     "transformer_wmt_en_de_big",
+    "transformer_wmt_en_de_big_align",
     "transformer_wmt_en_de_big_t2t",
 }
 
@@ -65,6 +67,8 @@ def _get_model_spec(args):
         args.encoder_attention_heads,
         pre_norm=args.encoder_normalize_before,
         activation=_SUPPORTED_ACTIVATIONS[activation_fn],
+        alignment_layer=getattr(args, "alignment_layer", -1),
+        alignment_heads=getattr(args, "alignment_heads", 0),
     )
 
 

--- a/python/ctranslate2/converters/opennmt_py.py
+++ b/python/ctranslate2/converters/opennmt_py.py
@@ -47,6 +47,8 @@ def _get_model_spec(opt):
         num_heads,
         with_relative_position=with_relative_position,
         activation=_SUPPORTED_ACTIVATIONS[activation_fn],
+        alignment_layer=getattr(opt, "alignment_layer", -1),
+        alignment_heads=getattr(opt, "alignment_heads", 1),
     )
 
 

--- a/python/ctranslate2/specs/transformer_spec.py
+++ b/python/ctranslate2/specs/transformer_spec.py
@@ -21,6 +21,8 @@ class TransformerSpec(model_spec.SequenceToSequenceModelSpec):
         with_relative_position=False,
         pre_norm=True,
         activation=common_spec.Activation.RELU,
+        alignment_layer=-1,
+        alignment_heads=1,
     ):
         super().__init__()
         if isinstance(num_layers, (list, tuple)):
@@ -30,6 +32,8 @@ class TransformerSpec(model_spec.SequenceToSequenceModelSpec):
         self.num_heads = np.dtype("int8").type(num_heads)
         self.pre_norm = np.dtype("int8").type(pre_norm)
         self.activation = np.dtype("int8").type(activation)
+        self.alignment_layer = np.dtype("int16").type(alignment_layer)
+        self.alignment_heads = np.dtype("int16").type(alignment_heads)
         self.with_relative_position = with_relative_position
         self.encoder = TransformerEncoderSpec(num_encoder_layers, pre_norm=pre_norm)
         self.decoder = TransformerDecoderSpec(num_decoder_layers, pre_norm=pre_norm)

--- a/src/models/transformer.cc
+++ b/src/models/transformer.cc
@@ -84,6 +84,9 @@ namespace ctranslate2 {
         _activation_type = static_cast<ops::ActivationType>(activation_type->as_scalar<int8_t>());
       else
         _activation_type = ops::ActivationType::ReLU;
+
+      _alignment_layer = get_attribute_with_default<int16_t>("alignment_layer", -1);
+      _alignment_heads = get_attribute_with_default<int16_t>("alignment_heads", 1);
     }
 
     std::unique_ptr<layers::Encoder> TransformerModel::make_encoder() const {
@@ -102,7 +105,9 @@ namespace ctranslate2 {
                                                           !_with_relative_position,
                                                           /*with_encoder_attention=*/true,
                                                           _pre_norm,
-                                                          _activation_type);
+                                                          _activation_type,
+                                                          _alignment_layer,
+                                                          _alignment_heads);
     }
 
   }

--- a/src/ops/mean.cc
+++ b/src/ops/mean.cc
@@ -1,0 +1,61 @@
+#include "ctranslate2/ops/mean.h"
+
+#include "dispatch.h"
+
+namespace ctranslate2 {
+  namespace ops {
+
+    Mean::Mean(const dim_t axis)
+      : _axis(axis)
+    {
+    }
+
+    void Mean::operator()(const StorageView& input, StorageView& output) const {
+      PROFILE("Mean");
+
+      const dim_t axis = _axis < 0 ? input.rank() + _axis : _axis;
+      if (axis >= input.rank())
+        throw std::out_of_range("Cannot compute mean of axis " + std::to_string(axis)
+                                + " for input with rank " + std::to_string(input.rank()));
+
+      const dim_t axis_size = input.dim(axis);
+      if (axis_size == 1) {
+        output = input;
+        output.squeeze(axis);
+        return;
+      }
+
+      {
+        Shape output_shape(input.shape());
+        output_shape.erase(output_shape.begin() + axis);
+        output.resize(std::move(output_shape));
+      }
+
+      dim_t inner_size = 1;
+      dim_t outer_size = 1;
+      for (dim_t i = 0; i < axis; ++i)
+        outer_size *= input.dim(i);
+      for (dim_t i = axis + 1; i < input.rank(); ++i)
+        inner_size *= input.dim(i);
+
+      switch (input.dtype()) {
+      case DataType::FLOAT: {
+        DEVICE_DISPATCH(input.device(),
+                        (compute<D, float>(input, outer_size, axis_size, inner_size, output)));
+        break;
+      }
+#ifdef CT2_WITH_CUDA
+      case DataType::FLOAT16: {
+        if (input.device() != Device::CUDA)
+          throw std::invalid_argument("FP16 Mean is only supported on GPU");
+        compute<Device::CUDA, float16_t>(input, outer_size, axis_size, inner_size, output);
+        break;
+      }
+#endif
+      default:
+        throw std::invalid_argument("Mean only supports float (or float16 on GPU)");
+      }
+    }
+
+  }
+}

--- a/src/ops/mean_cpu.cc
+++ b/src/ops/mean_cpu.cc
@@ -1,0 +1,40 @@
+#include "ctranslate2/ops/mean.h"
+
+#include "type_dispatch.h"
+
+namespace ctranslate2 {
+  namespace ops {
+
+    template <Device D, typename T>
+    void Mean::compute(const StorageView& input,
+                       const dim_t outer_size,
+                       const dim_t axis_size,
+                       const dim_t inner_size,
+                       StorageView& output) const {
+      const auto* src = input.data<T>();
+      auto* dst = output.data<T>();
+
+      #pragma omp parallel for
+      for (dim_t i = 0; i < outer_size; ++i) {
+        for (dim_t j = 0; j < inner_size; ++j) {
+          float sum = 0.f;
+          for (dim_t k = 0; k < axis_size; ++k) {
+            sum += src[i * axis_size * inner_size + k * inner_size + j];
+          }
+          dst[i * inner_size + j] = sum / float(axis_size);
+        }
+      }
+    }
+
+#define DECLARE_IMPL(T)                                         \
+    template void                                               \
+    Mean::compute<Device::CPU, T>(const StorageView& input,     \
+                                  const dim_t outer_size,       \
+                                  const dim_t axis_size,        \
+                                  const dim_t inner_size,       \
+                                  StorageView& output) const;
+
+    DECLARE_IMPL(float)
+
+  }
+}

--- a/src/ops/mean_gpu.cu
+++ b/src/ops/mean_gpu.cu
@@ -20,12 +20,12 @@ namespace ctranslate2 {
       const cuda::index_t i = blockIdx.x / inner_size;
       const cuda::index_t j = blockIdx.x % inner_size;
 
-      AccumT block_sum = 0;
+      AccumT thread_sum = 0;
       for (cuda::index_t k = threadIdx.x; k < axis_size; k += blockDim.x) {
-        block_sum += AccumT(input[i * axis_size * inner_size + k * inner_size + j]);
+        thread_sum += AccumT(input[i * axis_size * inner_size + k * inner_size + j]);
       }
 
-      AccumT sum = BlockReduce(temp_storage).Sum(block_sum);
+      AccumT sum = BlockReduce(temp_storage).Sum(thread_sum);
 
       if (threadIdx.x == 0) {
         output[blockIdx.x] = sum / AccumT(axis_size);

--- a/src/ops/mean_gpu.cu
+++ b/src/ops/mean_gpu.cu
@@ -1,0 +1,61 @@
+#include "ctranslate2/ops/mean.h"
+
+#include "type_dispatch.h"
+#include "cuda/helpers.h"
+
+namespace ctranslate2 {
+  namespace ops {
+
+    template <typename T, typename AccumT>
+    __global__ void mean_kernel(const T* input,
+                                const cuda::index_t outer_size,
+                                const cuda::index_t axis_size,
+                                const cuda::index_t inner_size,
+                                T* output) {
+      typedef cub::BlockReduce<AccumT, 256> BlockReduce;
+      __shared__ typename BlockReduce::TempStorage temp_storage;
+
+      const cuda::index_t i = blockIdx.x / inner_size;
+      const cuda::index_t j = blockIdx.x % inner_size;
+
+      AccumT block_sum = 0;
+      for (cuda::index_t k = threadIdx.x; k < axis_size; k += blockDim.x) {
+        block_sum += AccumT(input[i * axis_size * inner_size + k * inner_size + j]);
+      }
+
+      AccumT sum = BlockReduce(temp_storage).Sum(block_sum);
+
+      if (threadIdx.x == 0) {
+        output[blockIdx.x] = sum / AccumT(axis_size);
+      }
+    }
+
+    template <Device D, typename T>
+    void Mean::compute(const StorageView& input,
+                       const dim_t outer_size,
+                       const dim_t axis_size,
+                       const dim_t inner_size,
+                       StorageView& output) const {
+      const dim_t blocks = std::min(outer_size * inner_size, cuda::max_blocks);
+      const dim_t threads = 256;
+      mean_kernel<cuda::device_type<T>, float><<<blocks, threads, 0, cuda::get_cuda_stream()>>>(
+        cuda::device_cast(input.data<T>()),
+        outer_size,
+        axis_size,
+        inner_size,
+        cuda::device_cast(output.data<T>()));
+    }
+
+#define DECLARE_IMPL(T)                                         \
+    template void                                               \
+    Mean::compute<Device::CUDA, T>(const StorageView& input,    \
+                                   const dim_t outer_size,      \
+                                   const dim_t axis_size,       \
+                                   const dim_t inner_size,      \
+                                   StorageView& output) const;
+
+    DECLARE_IMPL(float)
+    DECLARE_IMPL(float16_t)
+
+  }
+}

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -319,6 +319,33 @@ TEST_P(OpDeviceTest, SplitNoCopyEqualParts) {
   EXPECT_EQ(z.data<float>(), x.data<float>() + 4);
 }
 
+TEST_P(OpDeviceTest, Mean) {
+  const Device device = GetParam();
+  const StorageView input({2, 3, 2}, std::vector<float>{
+      1, 2, 3, 4, 5, 6,
+      7, 8, 9, 10, 11, 12
+    }, device);
+  StorageView output(device);
+
+  {
+    ops::Mean(0)(input, output);
+    const StorageView expected({3, 2}, std::vector<float>{4, 5, 6, 7, 8, 9}, device);
+    expect_storage_eq(output, expected);
+  }
+
+  {
+    ops::Mean(1)(input, output);
+    const StorageView expected({2, 2}, std::vector<float>{3, 4, 9, 10}, device);
+    expect_storage_eq(output, expected);
+  }
+
+  {
+    ops::Mean(-1)(input, output);
+    const StorageView expected({2, 3}, std::vector<float>{1.5, 3.5, 5.5, 7.5, 9.5, 11.5}, device);
+    expect_storage_eq(output, expected);
+  }
+}
+
 TEST_P(OpDeviceTest, GatherData1D) {
   Device device = GetParam();
   StorageView data({4}, std::vector<float>{1, 2, 3, 4}, device);


### PR DESCRIPTION
OpenNMT-py and Fairseq define the options `--alignment_layer` and `--alignment_heads` which specify the attention heads that should be averaged and returned by the decoder. This PR correctly applies these options for future converted models.

Closes #565.