### PR TITLE
Make the Model instance directly usable after load

### DIFF
--- a/include/ctranslate2/models/model.h
+++ b/include/ctranslate2/models/model.h
@@ -32,7 +32,7 @@ namespace ctranslate2 {
 
       // Clone this model instance.
       // The cloned model shares the model weights but it can be safely used in parallel.
-      std::shared_ptr<const Model> clone() const;
+      std::unique_ptr<const Model> clone() const;
 
       virtual ~Model() = default;
       virtual size_t current_spec_revision() const;

--- a/include/ctranslate2/models/transformer.h
+++ b/include/ctranslate2/models/transformer.h
@@ -14,8 +14,6 @@ namespace ctranslate2 {
     public:
       TransformerModel(ModelReader& model_reader, size_t spec_revision, size_t num_heads = 0);
       size_t current_spec_revision() const override;
-      std::unique_ptr<layers::Encoder> make_encoder() const override;
-      std::unique_ptr<layers::Decoder> make_decoder() const override;
 
     protected:
       bool is_quantizable(const std::string& variable_name) const override;
@@ -24,6 +22,9 @@ namespace ctranslate2 {
       void register_variable(std::string name, StorageView variable) override;
       void register_variable_alias(std::string alias, std::string variable_name) override;
       void finalize() override;
+      std::unique_ptr<Model> copy_instance() const override;
+      std::unique_ptr<layers::Encoder> make_encoder() const override;
+      std::unique_ptr<layers::Decoder> make_decoder() const override;
 
     private:
       size_t _num_heads;

--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -90,7 +90,7 @@ namespace ctranslate2 {
     Translator(const std::shared_ptr<const models::Model>& model);
 
     // Copy constructor.
-    // The copy shares the same model instance, but it can be safely used in another thread.
+    // The copy shares the same model weights, but it can be safely used in another thread.
     Translator(const Translator& other);
 
     // WARNING: The translator methods are not thread-safe. To run multiple translations in
@@ -148,8 +148,6 @@ namespace ctranslate2 {
     void register_current_allocator();
 
     std::shared_ptr<const models::Model> _model;
-    std::unique_ptr<layers::Encoder> _encoder;
-    std::unique_ptr<layers::Decoder> _decoder;
     const models::SequenceToSequenceModel* _seq2seq_model = nullptr;
     Allocator* _allocator = nullptr;
   };

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -125,7 +125,7 @@ namespace ctranslate2 {
       : _spec_revision(spec_revision) {
     }
 
-    std::shared_ptr<const Model> Model::clone() const {
+    std::unique_ptr<const Model> Model::clone() const {
       const auto scoped_device_setter = get_scoped_device_setter();
       auto model = copy_instance();
       model->build();

--- a/src/models/transformer.cc
+++ b/src/models/transformer.cc
@@ -89,6 +89,10 @@ namespace ctranslate2 {
       _alignment_heads = get_attribute_with_default<int16_t>("alignment_heads", 1);
     }
 
+    std::unique_ptr<Model> TransformerModel::copy_instance() const {
+      return std::make_unique<TransformerModel>(*this);
+    }
+
     std::unique_ptr<layers::Encoder> TransformerModel::make_encoder() const {
       return std::make_unique<layers::TransformerEncoder>(*this,
                                                           "encoder",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(ctranslate2_test
   ops_test.cc
   primitives_test.cc
   translator_test.cc
+  test_utils.cc
   test.cc)
 target_include_directories(ctranslate2_test PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../src

--- a/tests/model_test.cc
+++ b/tests/model_test.cc
@@ -1,9 +1,30 @@
-#include <ctranslate2/models/model.h>
+#include <ctranslate2/models/sequence_to_sequence.h>
 
 #include "test_utils.h"
 
-extern std::string g_data_dir;
-
 TEST(ModelTest, ContainsModel) {
-  ASSERT_TRUE(models::contains_model(g_data_dir + "/models/v2/aren-transliteration"));
+  ASSERT_TRUE(models::contains_model(default_model_dir()));
+}
+
+TEST(ModelTest, LoadReplicas) {
+  const auto replicas = models::load_replicas(default_model_dir(),
+                                              Device::CPU,
+                                              {0, 0},
+                                              ComputeType::DEFAULT);
+
+  // The replicas should use the same model weights but be different models instances.
+  ASSERT_EQ(replicas.size(), 2);
+  EXPECT_NE(replicas[0], replicas[1]);
+
+  const std::string weight_name = "decoder/projection/weight";
+  EXPECT_EQ(replicas[0]->get_variable(weight_name).buffer(),
+            replicas[1]->get_variable(weight_name).buffer());
+
+  for (const auto replica : replicas) {
+    const auto* seq2seq = dynamic_cast<const models::SequenceToSequenceModel*>(replica.get());
+    ASSERT_NE(seq2seq, nullptr);
+
+    const auto results = seq2seq->sample({{"آ" ,"ت" ,"ز" ,"م" ,"و" ,"ن"}});
+    EXPECT_EQ(results[0].output(), (std::vector<std::string>{"a", "t", "z", "m", "o", "n"}));
+  }
 }

--- a/tests/model_test.cc
+++ b/tests/model_test.cc
@@ -12,7 +12,7 @@ TEST(ModelTest, LoadReplicas) {
                                               {0, 0},
                                               ComputeType::DEFAULT);
 
-  // The replicas should use the same model weights but be different models instances.
+  // The replicas should use the same model weights but be different model instances.
   ASSERT_EQ(replicas.size(), 2);
   EXPECT_NE(replicas[0], replicas[1]);
 

--- a/tests/test_utils.cc
+++ b/tests/test_utils.cc
@@ -1,0 +1,11 @@
+#include "test_utils.h"
+
+extern std::string g_data_dir;
+
+const std::string& get_data_dir() {
+  return g_data_dir;
+}
+
+std::string default_model_dir() {
+  return g_data_dir + "/models/v2/aren-transliteration";
+}

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -8,6 +8,9 @@
 
 using namespace ctranslate2;
 
+const std::string& get_data_dir();
+std::string default_model_dir();
+
 #define ASSERT_RAISES(STMT, EXCEPT)                     \
   do {                                                  \
     try {                                               \

--- a/tests/translator_test.cc
+++ b/tests/translator_test.cc
@@ -6,8 +6,6 @@
 
 #include "test_utils.h"
 
-extern std::string g_data_dir;
-
 static std::string
 path_to_test_name(::testing::TestParamInfo<std::pair<std::string, DataType>> param_info) {
   std::string name = param_info.param.first;
@@ -53,7 +51,7 @@ class ModelVariantTest : public ::testing::TestWithParam<std::pair<std::string, 
 
 TEST_P(ModelVariantTest, Transliteration) {
   auto params = GetParam();
-  const std::string model_path = g_data_dir + "/models/" + params.first;
+  const std::string model_path = get_data_dir() + "/models/" + params.first;
   const DataType model_dtype = params.second;
   const Device device = Device::CPU;
   std::vector<std::string> input = {"آ" ,"ت" ,"ز" ,"م" ,"و" ,"ن"};
@@ -99,10 +97,6 @@ INSTANTIATE_TEST_CASE_P(
 
 class SearchVariantTest : public ::testing::TestWithParam<size_t> {
 };
-
-static std::string default_model_dir() {
-  return g_data_dir + "/models/v2/aren-transliteration";
-}
 
 static Translator default_translator(Device device = Device::CPU) {
   return Translator(default_model_dir(), device);
@@ -762,6 +756,12 @@ TEST(TranslatorTest, AlternativesFromFullTarget) {
   EXPECT_EQ(result.hypotheses[0], (std::vector<std::string>{"a", "t", "z", "m", "o", "n", "e"}));
 }
 
+TEST(TranslatorTest, Clone) {
+  const Translator translator = default_translator();
+  const Translator clone(translator);
+  EXPECT_NE(translator.get_model(), clone.get_model());
+}
+
 TEST(TranslatorTest, DetachModel) {
   const std::vector<std::string> input = {"آ" ,"ت" ,"ز" ,"م" ,"و" ,"ن"};
   Translator translator = default_translator();
@@ -769,8 +769,7 @@ TEST(TranslatorTest, DetachModel) {
   EXPECT_THROW(translator.translate(input), std::runtime_error);
   Translator clone(translator);
   EXPECT_THROW(clone.translate(input), std::runtime_error);
-  translator.set_model(models::Model::load(g_data_dir + "/models/v2/aren-transliteration",
-                                           Device::CPU));
+  translator.set_model(models::Model::load(default_model_dir()));
   translator.translate(input);
 }
 


### PR DESCRIPTION
This change is moving the layers inside the model instance.

It is now required to call the method `clone()` in order to use the model in another thread. The cloned model will still share the model weights thanks to #608.