### PR TITLE
Enable inter_threads for GPU translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,12 +532,12 @@ There are many ways to make this project better and even faster. See the open is
 
 ### What is the difference between `intra_threads` and `inter_threads`?
 
-* `intra_threads` is the number of OpenMP threads that is used per translation: increase this value to decrease the latency.
-* `inter_threads` is the maximum number of CPU translations executed in parallel: increase this value to increase the throughput. Even though the model data are shared, this execution mode will increase the memory usage as some internal buffers are duplicated for thread safety.
+* `intra_threads` is the number of OpenMP threads that is used per translation: increase this value to decrease the latency of CPU translations.
+* `inter_threads` is the maximum number of translations executed in parallel: increase this value to increase the throughput. Even though the model data are shared, this execution mode will increase the memory usage as some internal buffers are duplicated for thread safety.
 
 The total number of computing threads launched by the process is `inter_threads * intra_threads`.
 
-Note that these options are only defined for CPU translation and are forced to 1 when executing on GPU. Parallel translations on GPU require multiple GPUs. See the option `device_index` that accepts multiple device IDs.
+On GPU, translations executed in parallel are using separate CUDA streams. Depending on the workload and GPU specifications this may or may not improve the translation throughput. For better parallelism on GPU, consider running the translation on multiple GPUs. See the option `device_index` that accepts multiple device IDs.
 
 ### Do you provide a translation server?
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -50,8 +50,8 @@ translator = ctranslate2.Translator(
     # or a dict mapping a device to a computation type.
     compute_type: Union[str, Dict[str, str]] = "default",
 
-    inter_threads: int = 1,         # Maximum number of parallel translations (CPU only).
-    intra_threads: int = 0,         # Threads to use per translation (CPU only).
+    inter_threads: int = 1,         # Maximum number of parallel translations.
+    intra_threads: int = 0,         # Number of OpenMP threads to use per translation (CPU only).
                                     # Set 0 to use a default value.
 )
 
@@ -201,6 +201,9 @@ translator = ctranslate2.Translator(model_path, device="cpu", inter_threads=4, i
 
 # Create a GPU translator with 4 workers each running on a separate GPU:
 translator = ctranslate2.Translator(model_path, device="cuda", device_index=[0, 1, 2, 3])
+
+# Create a GPU translator with 4 workers each using a different CUDA stream:
+translator = ctranslate2.Translator(model_path, device="cuda", inter_threads=4)
 ```
 
 Parallel translations are enabled in the following cases:

--- a/include/ctranslate2/translator_pool.h
+++ b/include/ctranslate2/translator_pool.h
@@ -22,8 +22,8 @@ namespace ctranslate2 {
   // and asynchronous translations.
   class TranslatorPool {
   public:
-    // num_translators (a.k.a. inter_threads) and num_threads_per_translator (a.k.a. intra_threads)
-    // are forced to 1 when the translator is running on a CUDA device.
+    // num_threads_per_translator (a.k.a. intra_threads) is forced to 1 when the translator
+    // is running on a CUDA device.
     TranslatorPool(size_t num_translators,
                    size_t num_threads_per_translator,
                    const std::string& model_dir,

--- a/src/translator_pool.cc
+++ b/src/translator_pool.cc
@@ -1,6 +1,5 @@
 #include "ctranslate2/translator_pool.h"
 
-#include <algorithm>
 #include <stdexcept>
 
 #include <spdlog/spdlog.h>
@@ -145,12 +144,6 @@ namespace ctranslate2 {
   }
 
   template <typename T>
-  static bool all_unique(std::vector<T> v) {
-    std::sort(v.begin(), v.end());
-    return std::adjacent_find(v.begin(), v.end()) == v.end();
-  }
-
-  template <typename T>
   static std::vector<T> repeat_elements(const std::vector<T>& v, const size_t repeat) {
     std::vector<int> repeated;
     repeated.reserve(v.size() * repeat);
@@ -194,14 +187,9 @@ namespace ctranslate2 {
       throw std::invalid_argument("At least one device index should be set");
 
     if (device == Device::CUDA) {
-      // On GPU, we currently don't benefit much from running translators in parallel
-      // on the same device. This could be revisited/improved in the future.
-      num_translators_per_device = 1;
       // Most computation will run on GPU so multiple CPU computation threads are not useful.
       num_threads_per_translator = 1;
 
-      if (!all_unique(device_indices))
-        throw std::invalid_argument("GPU IDs in device_index should be unique");
       if (!have_same_compute_capability(device_indices))
         throw std::invalid_argument("All GPU used in parallel must have the same Compute Capability");
     }


### PR DESCRIPTION
Each translation thread is using a different CUDA stream which allows some parts of the GPU execution to overlap.