### PR TITLE
Add new constructors with ModelReader parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes and improvements
 
+* Add constructors in `Translator` and `TranslatorPool` classes with `ModelReader` parameter
+
 ## [v2.9.0](https://github.com/OpenNMT/CTranslate2/releases/tag/v2.9.0) (2021-12-01)
 
 ### New features

--- a/include/ctranslate2/models/model.h
+++ b/include/ctranslate2/models/model.h
@@ -122,7 +122,7 @@ namespace ctranslate2 {
     // Load a model replica on each device ID configured in device_indices.
     // Replicas on the same device ID will reference the same model instance.
     std::vector<std::shared_ptr<const Model>>
-    load_replicas(const std::string& model_path,
+    load_replicas(models::ModelReader& model_reader,
                   const Device device,
                   const std::vector<int>& device_indices,
                   const ComputeType compute_type);

--- a/include/ctranslate2/models/model.h
+++ b/include/ctranslate2/models/model.h
@@ -127,5 +127,11 @@ namespace ctranslate2 {
                   const std::vector<int>& device_indices,
                   const ComputeType compute_type);
 
+    std::vector<std::shared_ptr<const Model>>
+    load_replicas(const std::string& model_path,
+                  const Device device,
+                  const std::vector<int>& device_indices,
+                  const ComputeType compute_type);
+
   }
 }

--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -86,6 +86,10 @@ namespace ctranslate2 {
                Device device = Device::CPU,
                int device_index = 0,
                ComputeType compute_type = ComputeType::DEFAULT);
+    Translator(models::ModelReader& model_reader,
+               Device device = Device::CPU,
+               int device_index = 0,
+               ComputeType compute_type = ComputeType::DEFAULT);
     Translator(const std::shared_ptr<const models::Model>& model);
 
     // Copy constructor.

--- a/include/ctranslate2/translator_pool.h
+++ b/include/ctranslate2/translator_pool.h
@@ -31,10 +31,26 @@ namespace ctranslate2 {
                    const int device_index = 0,
                    const ComputeType compute_type = ComputeType::DEFAULT);
 
+    // Constructor with ModelReader.
+    TranslatorPool(size_t num_translators,
+                   size_t num_threads_per_translator,
+                   models::ModelReader& model_reader,
+                   const Device device,
+                   const int device_index,
+                   const ComputeType compute_type = ComputeType::DEFAULT);
+
     // Multi-device constructor.
     TranslatorPool(size_t num_translators_per_device,
                    size_t num_threads_per_translator,
                    const std::string& model_dir,
+                   const Device device,
+                   const std::vector<int>& device_indices,
+                   const ComputeType compute_type = ComputeType::DEFAULT);
+
+    // Multi-device constructor with ModelReader.
+    TranslatorPool(size_t num_translators_per_device,
+                   size_t num_threads_per_translator,
+                   models::ModelReader& model_reader,
                    const Device device,
                    const std::vector<int>& device_indices,
                    const ComputeType compute_type = ComputeType::DEFAULT);
@@ -682,7 +698,7 @@ namespace ctranslate2 {
 
     void create_translators(size_t num_translators_per_device,
                             size_t num_threads_per_translator,
-                            const std::string& model_dir,
+                            models::ModelReader& model_reader,
                             const Device device,
                             std::vector<int> device_indices,
                             const ComputeType compute_type);

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -546,7 +546,7 @@ namespace ctranslate2 {
     }
 
     std::vector<std::shared_ptr<const Model>>
-    load_replicas(const std::string& model_path,
+    load_replicas(models::ModelReader& model_reader,
                   const Device device,
                   const std::vector<int>& device_indices,
                   const ComputeType compute_type) {
@@ -566,7 +566,7 @@ namespace ctranslate2 {
         if (main_replica_on_device != device_to_main_replica.end()) {
           models.emplace_back(models[main_replica_on_device->second]);
         } else {
-          models.emplace_back(Model::load(model_path, device, device_index, compute_type));
+          models.emplace_back(Model::load(model_reader, device, device_index, compute_type));
           device_to_main_replica.emplace(device_index, i);
         }
       }

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -574,11 +574,10 @@ namespace ctranslate2 {
       return models;
     }
 
-    std::vector<std::shared_ptr<const Model> > load_replicas(const std::string &model_path,
+    std::vector<std::shared_ptr<const Model> > load_replicas(const std::string& model_path,
                                                              const Device device,
                                                              const std::vector<int>& device_indices,
-                                                             const ComputeType compute_type)
-    {
+                                                             const ComputeType compute_type) {
       ctranslate2::models::ModelFileReader model_reader(model_path);
       return load_replicas(model_reader, device, device_indices, compute_type);
     }

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -574,5 +574,14 @@ namespace ctranslate2 {
       return models;
     }
 
+    std::vector<std::shared_ptr<const Model> > load_replicas(const std::string &model_path,
+                                                             const Device device,
+                                                             const std::vector<int>& device_indices,
+                                                             const ComputeType compute_type)
+    {
+      ctranslate2::models::ModelFileReader model_reader(model_path);
+      return load_replicas(model_reader, device, device_indices, compute_type);
+    }
+
   }
 }

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -56,7 +56,15 @@ namespace ctranslate2 {
                          Device device,
                          int device_index,
                          ComputeType compute_type) {
-    set_model(models::Model::load(model_dir, device, device_index, compute_type));
+      set_model(models::Model::load(model_dir, device, device_index, compute_type));
+  }
+
+  Translator::Translator(models::ModelReader& model_reader,
+                         Device device,
+                         int device_index,
+                         ComputeType compute_type)
+  {
+      set_model(models::Model::load(model_reader, device, device_index, compute_type));
   }
 
   Translator::Translator(const std::shared_ptr<const models::Model>& model) {

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -56,7 +56,7 @@ namespace ctranslate2 {
                          Device device,
                          int device_index,
                          ComputeType compute_type) {
-      set_model(models::Model::load(model_dir, device, device_index, compute_type));
+    set_model(models::Model::load(model_dir, device, device_index, compute_type));
   }
 
   Translator::Translator(models::ModelReader& model_reader,
@@ -64,7 +64,7 @@ namespace ctranslate2 {
                          int device_index,
                          ComputeType compute_type)
   {
-      set_model(models::Model::load(model_reader, device, device_index, compute_type));
+    set_model(models::Model::load(model_reader, device, device_index, compute_type));
   }
 
   Translator::Translator(const std::shared_ptr<const models::Model>& model) {

--- a/src/translator_pool.cc
+++ b/src/translator_pool.cc
@@ -21,9 +21,26 @@ namespace ctranslate2 {
                                  const ComputeType compute_type)
     : _num_active_jobs(0)
   {
+    models::ModelFileReader model_reader(model_dir);
     create_translators(num_translators,
                        num_threads_per_translator,
-                       model_dir,
+                       model_reader,
+                       device,
+                       {device_index},
+                       compute_type);
+  }
+
+  TranslatorPool::TranslatorPool(size_t num_translators,
+                                 size_t num_threads_per_translator,
+                                 models::ModelReader& model_reader,
+                                 const Device device,
+                                 const int device_index,
+                                 const ComputeType compute_type)
+    : _num_active_jobs(0)
+  {
+    create_translators(num_translators,
+                       num_threads_per_translator,
+                       model_reader,
                        device,
                        {device_index},
                        compute_type);
@@ -37,9 +54,26 @@ namespace ctranslate2 {
                                  const ComputeType compute_type)
     : _num_active_jobs(0)
   {
+    models::ModelFileReader model_reader(model_dir);
     create_translators(num_translators_per_device,
                        num_threads_per_translator,
-                       model_dir,
+                       model_reader,
+                       device,
+                       device_indices,
+                       compute_type);
+  }
+
+  TranslatorPool::TranslatorPool(size_t num_translators_per_device,
+                                 size_t num_threads_per_translator,
+                                 models::ModelReader& model_reader,
+                                 const Device device,
+                                 const std::vector<int>& device_indices,
+                                 const ComputeType compute_type)
+    : _num_active_jobs(0)
+  {
+    create_translators(num_translators_per_device,
+                       num_threads_per_translator,
+                       model_reader,
                        device,
                        device_indices,
                        compute_type);
@@ -186,7 +220,7 @@ namespace ctranslate2 {
 
   void TranslatorPool::create_translators(size_t num_translators_per_device,
                                           size_t num_threads_per_translator,
-                                          const std::string& model_dir,
+                                          models::ModelReader& model_reader,
                                           const Device device,
                                           std::vector<int> device_indices,
                                           const ComputeType compute_type) {
@@ -211,7 +245,7 @@ namespace ctranslate2 {
 
     // The same number of OpenMP threads should be used for loading and running model.
     set_num_threads(num_threads_per_translator);
-    const auto models = models::load_replicas(model_dir, device, device_indices, compute_type);
+    const auto models = models::load_replicas(model_reader, device, device_indices, compute_type);
 
     static const int core_offset = read_int_from_env("CT2_TRANSLATORS_CORE_OFFSET", -1);
 


### PR DESCRIPTION
Added new constructors both in `TranslatorPool` and `Translator` classes that allow easy integration of custom `ModelReader`s. Closes #658.