### PR TITLE
Fix float to uint8 conversion in quantization kernel

### DIFF
--- a/src/cpu/kernels.h
+++ b/src/cpu/kernels.h
@@ -72,7 +72,7 @@ namespace ctranslate2 {
                      float* scales,
                      dim_t batch_size,
                      dim_t depth,
-                     float shift);
+                     bool shift_to_uint8);
 
   }
 }

--- a/src/ops/quantize_cpu.cc
+++ b/src/ops/quantize_cpu.cc
@@ -11,18 +11,14 @@ namespace ctranslate2 {
                                                         StorageView& output,
                                                         StorageView& scale) const {
       // INT8 quantization rescales based on the per batch absolute maximum.
-      constexpr float int8_min = std::numeric_limits<int8_t>::min();
-
       const dim_t batch_size = scale.size();
       const dim_t depth = input.dim(-1);
-      const float shift = (_shift_to_uint8 ? -int8_min : 0);
-
       CPU_ISA_DISPATCH(cpu::quantize_s8<ISA>(input.data<float>(),
                                              output.data<int8_t>(),
                                              scale.data<float>(),
                                              batch_size,
                                              depth,
-                                             shift));
+                                             _shift_to_uint8));
     }
 
     template<>


### PR DESCRIPTION
On Intel CPUs, inputs are quantized into the uint8 range [0, 255] even though the output buffer is of type int8 [-128, 127]. In that case we simply want values above 127 to overflow in the negative range. However, it seems some compilers will saturate the value instead, leading to incorrect outputs. This PR ensures the uint8 range is preserved.

Fixes the issue reported in https://github.com/argosopentech/argos-translate/issues/197.