### PR TITLE
Use the asynchronous memory allocator by default with CUDA >= 11.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,9 @@ int main() {
 
 Some environment variables can be configured to customize the execution:
 
-* `CT2_CUDA_ALLOCATOR`: Select the CUDA memory allocator. Possible values are: `cub_caching` (default), `cuda_malloc_async` (requires CUDA >= 11.2).
+* `CT2_CUDA_ALLOCATOR`: Select the CUDA memory allocator. Possible values are: `cub_caching`, `cuda_malloc_async` (requires CUDA >= 11.2). The default allocator depends on the CUDA version:
+  * CUDA >= 11.2: `cuda_malloc_async`
+  * CUDA < 11.2: `cub_caching`
 * `CT2_CUDA_ALLOW_FP16`: Allow using FP16 computation on GPU even if the device does not have efficient FP16 support.
 * `CT2_CUDA_CACHING_ALLOCATOR_CONFIG`: Tune the CUDA caching allocator (see [Performance](docs/performance.md)).
 * `CT2_FORCE_CPU_ISA`: Force CTranslate2 to select a specific instruction set architecture (ISA). Possible values are: `GENERIC`, `AVX`, `AVX2`. Note: this does not impact backend libraries (such as Intel MKL) which usually have their own environment variables to configure ISA dispatching.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -57,7 +57,11 @@ The list is ordered on 5. from the largest to smallest time.
 
 Allocating memory on the GPU with `cudaMalloc` is costly and is best avoided in high-performance code. For this reason CTranslate2 integrates caching allocators which enable a fast reuse of previously allocated buffers. The allocator can be selected with the environment variable `CT2_CUDA_ALLOCATOR`:
 
-#### `cub_caching` (default)
+#### `cuda_malloc_async`
+
+CUDA 11.2 introduced an [asynchronous allocator with memory pools](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html). This allocator is used by default with CUDA >= 11.2.
+
+#### `cub_caching`
 
 This caching allocator from the [CUB project](https://github.com/NVIDIA/cub) can be tuned to tradeoff memory usage and speed. By default, CTranslate2 uses the following values which have been selected experimentally:
 
@@ -73,10 +77,6 @@ export CT2_CUDA_CACHING_ALLOCATOR_CONFIG=8,3,7,6291455
 ```
 
 See the description of each value in the [allocator implementation](https://github.com/NVIDIA/cub/blob/main/cub/util_allocator.cuh).
-
-#### `cuda_malloc_async`
-
-CUDA 11.2 introduced an [asynchronous allocator with memory pools](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html). It is usually faster than `cub_caching` but uses more memory.
 
 ## CPU performance
 

--- a/src/cuda/allocator.cc
+++ b/src/cuda/allocator.cc
@@ -1,12 +1,14 @@
 #include "ctranslate2/allocator.h"
 
 #include <memory>
+#include <mutex>
 
 #include "ctranslate2/utils.h"
 #include "cuda/utils.h"
 
 #include <cuda.h>
 #include <cub/util_allocator.cuh>
+#include <spdlog/spdlog.h>
 
 namespace ctranslate2 {
   namespace cuda {
@@ -93,27 +95,45 @@ namespace ctranslate2 {
     };
 #endif
 
-    static std::unique_ptr<Allocator> create_allocator() {
-      const auto allocator = read_string_from_env("CT2_CUDA_ALLOCATOR", "cub_caching");
-
-      if (allocator == "cub_caching") {
-        return std::make_unique<CubCachingAllocator>();
-      } else if (allocator == "cuda_malloc_async") {
+    static bool support_cuda_malloc_async() {
 #if CUDA_VERSION < 11020
-        throw std::runtime_error("The asynchronous CUDA allocator requires CUDA >= 11.2");
+      return false;
 #else
-        for (int i = 0; i < get_gpu_count(); ++i) {
-          int supported = 0;
-          cudaDeviceGetAttribute(&supported, cudaDevAttrMemoryPoolsSupported, i);
-          if (!supported)
-            throw std::runtime_error("Asynchronous allocation is not supported by the current GPU");
-        }
-
-        return std::make_unique<CudaAsyncAllocator>();
+      for (int i = 0; i < get_gpu_count(); ++i) {
+        int supported = 0;
+        cudaDeviceGetAttribute(&supported, cudaDevAttrMemoryPoolsSupported, i);
+        if (!supported)
+          return false;
+      }
+      return true;
 #endif
+    }
+
+    static std::unique_ptr<Allocator> create_allocator() {
+      const bool cuda_malloc_async_is_supported = support_cuda_malloc_async();
+      const auto allocator_str = read_string_from_env("CT2_CUDA_ALLOCATOR",
+                                                      cuda_malloc_async_is_supported
+                                                      ? "cuda_malloc_async"
+                                                      : "cub_caching");
+
+      std::unique_ptr<Allocator> allocator;
+
+      if (allocator_str == "cub_caching") {
+        allocator = std::make_unique<CubCachingAllocator>();
+      } else if (allocator_str == "cuda_malloc_async") {
+        if (!cuda_malloc_async_is_supported)
+          throw std::runtime_error("The asynchronous CUDA allocator requires CUDA >= 11.2");
+        allocator = std::make_unique<CudaAsyncAllocator>();
+      } else {
+        throw std::invalid_argument("Invalid CUDA allocator " + allocator_str);
       }
 
-      throw std::invalid_argument("Invalid CUDA allocator " + allocator);
+      static std::once_flag log_once_flag;
+      std::call_once(log_once_flag, [&allocator_str]() {
+        spdlog::info("Using CUDA allocator: {}", allocator_str);
+      });
+
+      return allocator;
     }
 
   }

--- a/src/cuda/allocator.cc
+++ b/src/cuda/allocator.cc
@@ -111,26 +111,26 @@ namespace ctranslate2 {
 
     static std::unique_ptr<Allocator> create_allocator() {
       const bool cuda_malloc_async_is_supported = support_cuda_malloc_async();
-      const auto allocator_str = read_string_from_env("CT2_CUDA_ALLOCATOR",
-                                                      cuda_malloc_async_is_supported
-                                                      ? "cuda_malloc_async"
-                                                      : "cub_caching");
+      const auto allocator_name = read_string_from_env("CT2_CUDA_ALLOCATOR",
+                                                       cuda_malloc_async_is_supported
+                                                       ? "cuda_malloc_async"
+                                                       : "cub_caching");
 
       std::unique_ptr<Allocator> allocator;
 
-      if (allocator_str == "cub_caching") {
+      if (allocator_name == "cub_caching") {
         allocator = std::make_unique<CubCachingAllocator>();
-      } else if (allocator_str == "cuda_malloc_async") {
+      } else if (allocator_name == "cuda_malloc_async") {
         if (!cuda_malloc_async_is_supported)
           throw std::runtime_error("The asynchronous CUDA allocator requires CUDA >= 11.2");
         allocator = std::make_unique<CudaAsyncAllocator>();
       } else {
-        throw std::invalid_argument("Invalid CUDA allocator " + allocator_str);
+        throw std::invalid_argument("Invalid CUDA allocator " + allocator_name);
       }
 
       static std::once_flag log_once_flag;
-      std::call_once(log_once_flag, [&allocator_str]() {
-        spdlog::info("Using CUDA allocator: {}", allocator_str);
+      std::call_once(log_once_flag, [&allocator_name]() {
+        spdlog::info("Using CUDA allocator: {}", allocator_name);
       });
 
       return allocator;


### PR DESCRIPTION
This allocator has usually better performance than the CUB allocator, especially for large batch and/or beam sizes.

Note: this allocator is already enabled in the CTranslate2 benchmark scripts.