### PR TITLE
Support additional source features

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ The table below compares the model size on disk of the pretrained Transformer mo
 * [What is the difference between `intra_threads` and `inter_threads`?](#what-is-the-difference-between-intra_threads-and-inter_threads)
 * [Do you provide a translation server?](#do-you-provide-a-translation-server)
 * [How do I generate a vocabulary mapping file?](#how-do-i-generate-a-vocabulary-mapping-file)
+* [Are additional source features supported?](#are-additional-source-features-supported)
 
 ### How does it relate to the original CTranslate project?
 
@@ -554,3 +555,11 @@ src_1 src_2 ... src_N<TAB>tgt_1 tgt_2 ... tgt_K
 If the source N-gram is empty (N = 0), the assiocated target tokens will always be included in the reduced vocabulary.
 
 See [here](https://github.com/OpenNMT/papers/tree/master/WNMT2018/vmap) for an example on how to generate this file. The file can then be passed to the converter script to be included in the model directory (see option `--vocab_mapping`) and can be used during translation after enabling the `use_vmap` translation option.
+
+### Are additional source features supported?
+
+Yes, models using additional source features (a.k.a. source factors) are supported. The features should be added directly to the source input tokens using the special separator ￨ in both the file and batch translations APIs. For example:
+
+```text
+hello￨C world￨L !￨N
+```

--- a/include/ctranslate2/layers/common.h
+++ b/include/ctranslate2/layers/common.h
@@ -35,6 +35,28 @@ namespace ctranslate2 {
       std::unique_ptr<const StorageView> _scale;
     };
 
+    // This enum order should remain fixed.
+    enum class EmbeddingsMerge {
+      Concat,
+      Add,
+    };
+
+    class ParallelEmbeddings : public Layer {
+    public:
+      ParallelEmbeddings(const models::Model& model,
+                         const std::string& scope,
+                         const EmbeddingsMerge merge);
+      size_t num_inputs() const {
+        return _layers.size();
+      }
+      DataType output_type() const override;
+      dim_t output_size() const override;
+      void operator()(const std::vector<StorageView>& ids, StorageView& output) const;
+    private:
+      const EmbeddingsMerge _merge;
+      std::vector<std::unique_ptr<const Embeddings>> _layers;
+    };
+
     // Base class for position encoders.
     class PositionEncoder : public Layer {
     public:

--- a/include/ctranslate2/layers/encoder.h
+++ b/include/ctranslate2/layers/encoder.h
@@ -9,7 +9,11 @@ namespace ctranslate2 {
     // Base class for encoders.
     class Encoder : public Layer {
     public:
-      virtual void operator()(const StorageView& ids,
+      virtual size_t num_input_features() const {
+        return 1;
+      }
+
+      virtual void operator()(const std::vector<StorageView>& ids,
                               const StorageView& lengths,
                               StorageView& output) = 0;
     };

--- a/include/ctranslate2/layers/transformer.h
+++ b/include/ctranslate2/layers/transformer.h
@@ -107,11 +107,16 @@ namespace ctranslate2 {
                          const size_t num_heads,
                          const bool with_position_encoding = true,
                          const bool pre_norm = true,
-                         const ops::ActivationType activation_type = ops::ActivationType::ReLU);
+                         const ops::ActivationType activation_type = ops::ActivationType::ReLU,
+                         const EmbeddingsMerge merge = EmbeddingsMerge::Concat);
 
-      void operator()(const StorageView& ids,
+      void operator()(const std::vector<StorageView>& ids,
                       const StorageView& lengths,
                       StorageView& output) override;
+
+      size_t num_input_features() const override {
+        return _embeddings.num_inputs();
+      }
 
       DataType output_type() const override {
         return _layers.back()->output_type();
@@ -122,7 +127,8 @@ namespace ctranslate2 {
       }
 
     private:
-      const Embeddings _embeddings;
+      const ParallelEmbeddings _embeddings;
+      const std::unique_ptr<const StorageView> _embeddings_scale;
       const dim_t _num_heads;
       const ComputeType _compute_type;
       const std::unique_ptr<PositionEncoder> _position_encoder;
@@ -182,6 +188,7 @@ namespace ctranslate2 {
       dim_t _alignment_heads;
       const ComputeType _compute_type;
       const Embeddings _embeddings;
+      const std::unique_ptr<const StorageView> _embeddings_scale;
       const std::unique_ptr<PositionEncoder> _position_encoder;
       const std::unique_ptr<LayerNorm> _output_norm;
       std::vector<std::unique_ptr<const TransformerDecoderLayer>> _layers;

--- a/include/ctranslate2/models/sequence_to_sequence.h
+++ b/include/ctranslate2/models/sequence_to_sequence.h
@@ -24,7 +24,7 @@ namespace ctranslate2 {
       virtual std::unique_ptr<layers::Decoder> make_decoder() const = 0;
 
       void forward_encoder(layers::Encoder& encoder,
-                           const std::vector<std::vector<std::string>>& source,
+                           const std::vector<std::vector<std::vector<std::string>>>& source,
                            StorageView& memory,
                            StorageView& memory_lengths) const;
 
@@ -35,7 +35,7 @@ namespace ctranslate2 {
 
       void forward(layers::Encoder& encoder,
                    layers::Decoder& decoder,
-                   const std::vector<std::vector<std::string>>& source,
+                   const std::vector<std::vector<std::vector<std::string>>>& source,
                    const std::vector<std::vector<std::string>>& target,
                    StorageView& logits) const;
 
@@ -71,7 +71,7 @@ namespace ctranslate2 {
       virtual void finalize() override;
 
     private:
-      std::shared_ptr<const Vocabulary> _source_vocabulary;
+      std::vector<std::shared_ptr<const Vocabulary>> _source_vocabularies;
       std::shared_ptr<const Vocabulary> _target_vocabulary;
       std::unique_ptr<const VocabularyMap> _vocabulary_map;
 

--- a/include/ctranslate2/models/transformer.h
+++ b/include/ctranslate2/models/transformer.h
@@ -32,6 +32,7 @@ namespace ctranslate2 {
       ops::ActivationType _activation_type;
       dim_t _alignment_layer;
       dim_t _alignment_heads;
+      layers::EmbeddingsMerge _embeddings_merge;
     };
 
   }

--- a/include/ctranslate2/utils.h
+++ b/include/ctranslate2/utils.h
@@ -32,6 +32,7 @@ namespace ctranslate2 {
   bool starts_with(const std::string& str, const std::string& prefix);
 
   std::vector<std::string> split_string(const std::string& str, char delimiter);
+  std::vector<std::string> split_string(const std::string& str, const std::string& delimiter);
 
   template <typename T, typename I>
   static std::vector<T> index_vector(const std::vector<T>& v,

--- a/python/ctranslate2/converters/fairseq.py
+++ b/python/ctranslate2/converters/fairseq.py
@@ -155,7 +155,7 @@ def set_input_layers(spec, module):
         spec.embeddings[0] if isinstance(spec.embeddings, list) else spec.embeddings,
         module.embed_tokens,
     )
-    spec.scale_embeddings = module.embed_scale != 1.0
+    spec.scale_embeddings = module.embed_scale
 
 
 def set_transformer_encoder_layer(spec, module):

--- a/python/ctranslate2/converters/fairseq.py
+++ b/python/ctranslate2/converters/fairseq.py
@@ -122,8 +122,8 @@ class FairseqConverter(Converter):
             model.load_state_dict(checkpoint["model"])
 
             set_transformer_spec(model_spec, model)
-            model_spec.register_vocabulary("source", _get_vocab(task.source_dictionary))
-            model_spec.register_vocabulary("target", _get_vocab(task.target_dictionary))
+            model_spec.register_source_vocabulary(_get_vocab(task.source_dictionary))
+            model_spec.register_target_vocabulary(_get_vocab(task.target_dictionary))
             return model_spec
 
 
@@ -152,10 +152,10 @@ def set_transformer_decoder(spec, module):
 def set_input_layers(spec, module):
     set_position_encodings(spec.position_encodings, module.embed_positions)
     set_embeddings(
-        spec.embeddings,
+        spec.embeddings[0] if isinstance(spec.embeddings, list) else spec.embeddings,
         module.embed_tokens,
-        multiply_by_sqrt_depth=module.embed_scale != 1.0,
     )
+    spec.scale_embeddings = module.embed_scale != 1.0
 
 
 def set_transformer_encoder_layer(spec, module):
@@ -205,9 +205,8 @@ def set_linear(spec, module):
         spec.bias = module.bias.numpy()
 
 
-def set_embeddings(spec, module, multiply_by_sqrt_depth=True):
+def set_embeddings(spec, module):
     spec.weight = module.weight.numpy()
-    spec.multiply_by_sqrt_depth = multiply_by_sqrt_depth
 
 
 def set_position_encodings(spec, module):

--- a/python/ctranslate2/converters/opennmt_py.py
+++ b/python/ctranslate2/converters/opennmt_py.py
@@ -139,6 +139,7 @@ def set_input_layers(spec, variables, scope, relative=False):
     except KeyError:
         if not relative:
             raise
+        # See https://github.com/OpenNMT/OpenNMT-py/issues/1722
         spec.scale_embeddings = False
 
     embeddings_specs = spec.embeddings

--- a/python/ctranslate2/converters/opennmt_py.py
+++ b/python/ctranslate2/converters/opennmt_py.py
@@ -11,11 +11,17 @@ _SUPPORTED_ACTIVATIONS = {
     "relu": common_spec.Activation.RELU,
 }
 
+_SUPPORTED_FEATURES_MERGE = {
+    "concat": common_spec.EmbeddingsMerge.CONCAT,
+    "sum": common_spec.EmbeddingsMerge.ADD,
+}
 
-def _get_model_spec(opt):
+
+def _get_model_spec(opt, num_source_embeddings):
     """Creates a model specification from the model options."""
     with_relative_position = getattr(opt, "max_relative_positions", 0) > 0
     activation_fn = getattr(opt, "pos_ffn_activation_fn", "relu")
+    feat_merge = getattr(opt, "feat_merge", "concat")
 
     reasons = []
     if opt.encoder_type != "transformer" or opt.decoder_type != "transformer":
@@ -27,7 +33,7 @@ def _get_model_spec(opt):
             "Option --self_attn_type %s is not supported (supported values are: scaled-dot)"
             % opt.self_attn_type
         )
-    if activation_fn not in _SUPPORTED_ACTIVATIONS.keys():
+    if activation_fn not in _SUPPORTED_ACTIVATIONS:
         reasons.append(
             "Option --pos_ffn_activation_fn %s is not supported (supported activations are: %s)"
             % (activation_fn, ", ".join(_SUPPORTED_ACTIVATIONS.keys()))
@@ -36,6 +42,11 @@ def _get_model_spec(opt):
         reasons.append(
             "Options --position_encoding and --max_relative_positions cannot be both enabled "
             "or both disabled"
+        )
+    if num_source_embeddings > 1 and feat_merge not in _SUPPORTED_FEATURES_MERGE:
+        reasons.append(
+            "Option --feat_merge %s is not supported (supported merge modes are: %s)"
+            % (feat_merge, " ".join(_SUPPORTED_FEATURES_MERGE.keys()))
         )
 
     if reasons:
@@ -49,6 +60,8 @@ def _get_model_spec(opt):
         activation=_SUPPORTED_ACTIVATIONS[activation_fn],
         alignment_layer=getattr(opt, "alignment_layer", -1),
         alignment_heads=getattr(opt, "alignment_heads", 1),
+        num_source_embeddings=num_source_embeddings,
+        embeddings_merge=_SUPPORTED_FEATURES_MERGE[feat_merge],
     )
 
 
@@ -62,24 +75,29 @@ class OpenNMTPyConverter(Converter):
         import torch
 
         checkpoint = torch.load(self._model_path, map_location="cpu")
-        model_spec = _get_model_spec(checkpoint["opt"])
+
+        vocab = checkpoint["vocab"]
+        if isinstance(vocab, dict) and "src" in vocab:
+            src_vocabs = [field[1].vocab.itos for field in vocab["src"].fields]
+            tgt_vocabs = [field[1].vocab.itos for field in vocab["tgt"].fields]
+        else:
+            # Compatibility with older models.
+            src_vocabs = [vocab[0][1].itos]
+            tgt_vocabs = [vocab[1][1].itos]
+
+        model_spec = _get_model_spec(
+            checkpoint["opt"], num_source_embeddings=len(src_vocabs)
+        )
 
         variables = checkpoint["model"]
         variables["generator.weight"] = checkpoint["generator"]["0.weight"]
         variables["generator.bias"] = checkpoint["generator"].get("0.bias")
 
-        vocab = checkpoint["vocab"]
-        if isinstance(vocab, dict) and "src" in vocab:
-            src_vocab = vocab["src"].fields[0][1].vocab
-            tgt_vocab = vocab["tgt"].fields[0][1].vocab
-        else:
-            # Compatibility with older models.
-            src_vocab = vocab[0][1]
-            tgt_vocab = vocab[1][1]
-
         set_transformer_spec(model_spec, variables)
-        model_spec.register_vocabulary("source", src_vocab.itos)
-        model_spec.register_vocabulary("target", tgt_vocab.itos)
+        for src_vocab in src_vocabs:
+            model_spec.register_source_vocabulary(src_vocab)
+        for tgt_vocab in tgt_vocabs:
+            model_spec.register_target_vocabulary(tgt_vocab)
         return model_spec
 
 
@@ -118,17 +136,21 @@ def set_input_layers(spec, variables, scope, relative=False):
             variables,
             "%s.embeddings.make_embedding.pe" % scope,
         )
-        with_pe = True
     except KeyError:
         if not relative:
             raise
-        with_pe = False
-    set_embeddings(
-        spec.embeddings,
-        variables,
-        "%s.embeddings.make_embedding.emb_luts.0" % scope,
-        multiply_by_sqrt_depth=with_pe,
-    )
+        spec.scale_embeddings = False
+
+    embeddings_specs = spec.embeddings
+    if not isinstance(embeddings_specs, list):
+        embeddings_specs = [embeddings_specs]
+
+    for i, embeddings_spec in enumerate(embeddings_specs):
+        set_embeddings(
+            embeddings_spec,
+            variables,
+            "%s.embeddings.make_embedding.emb_luts.%d" % (scope, i),
+        )
 
 
 def set_transformer_encoder_layer(spec, variables, scope, relative=False):
@@ -203,9 +225,8 @@ def set_linear(spec, variables, scope):
         spec.bias = bias.numpy()
 
 
-def set_embeddings(spec, variables, scope, multiply_by_sqrt_depth=True):
+def set_embeddings(spec, variables, scope):
     spec.weight = _get_variable(variables, "%s.weight" % scope)
-    spec.multiply_by_sqrt_depth = multiply_by_sqrt_depth
 
 
 def set_position_encodings(spec, variables, scope):

--- a/python/ctranslate2/converters/opennmt_tf.py
+++ b/python/ctranslate2/converters/opennmt_tf.py
@@ -92,14 +92,14 @@ class OpenNMTTFConverter(Converter):
             set_transformer_spec_v2(model_spec, variables)
         else:
             set_transformer_spec(model_spec, variables)
-        model_spec.register_vocabulary("source", _load_vocab(self._src_vocab))
-        model_spec.register_vocabulary("target", _load_vocab(self._tgt_vocab))
+        model_spec.register_source_vocabulary(_load_vocab(self._src_vocab))
+        model_spec.register_target_vocabulary(_load_vocab(self._tgt_vocab))
         return model_spec
 
 
 def set_transformer_spec_v2(spec, variables):
     set_embeddings(
-        spec.encoder.embeddings,
+        spec.encoder.embeddings[0],
         variables,
         "model/examples_inputter/features_inputter",
         version=2,
@@ -232,10 +232,10 @@ def set_transformer_spec(spec, variables):
 def set_transformer_encoder(spec, variables):
     set_layer_norm(spec.layer_norm, variables, "transformer/encoder/LayerNorm")
     try:
-        set_embeddings(spec.embeddings, variables, "transformer/encoder")
+        set_embeddings(spec.embeddings[0], variables, "transformer/encoder")
     except KeyError:
         # Try shared embeddings scope instead.
-        set_embeddings(spec.embeddings, variables, "transformer/shared_embeddings")
+        set_embeddings(spec.embeddings[0], variables, "transformer/shared_embeddings")
     for i, layer in enumerate(spec.layer):
         set_transformer_encoder_layer(
             layer, variables, "transformer/encoder/layer_%d" % i
@@ -325,7 +325,6 @@ def set_embeddings(spec, variables, scope, version=1):
         name = "w_embs"
     variable_name = "%s/%s" % (scope, name)
     spec.weight = variables[variable_name]
-    spec.multiply_by_sqrt_depth = True
     return variable_name
 
 

--- a/python/ctranslate2/specs/common_spec.py
+++ b/python/ctranslate2/specs/common_spec.py
@@ -9,6 +9,12 @@ class Activation(enum.IntEnum):
     GELU = 1
 
 
+# This enum should match the C++ equivalent in include/ctranslate2/layers/common.h.
+class EmbeddingsMerge(enum.IntEnum):
+    CONCAT = 0
+    ADD = 1
+
+
 class LayerNormSpec(model_spec.LayerSpec):
     def __init__(self):
         self.gamma = None

--- a/python/ctranslate2/specs/model_spec.py
+++ b/python/ctranslate2/specs/model_spec.py
@@ -224,43 +224,63 @@ class ModelSpec(LayerSpec):
                 _write_string(variable_name)
 
 
+def _flatten_vocabularies(vocabularies):
+    for name, vocabulary in vocabularies.items():
+        if len(vocabulary) == 1:
+            yield name, vocabulary[0]
+        else:
+            for i, vocab in enumerate(vocabulary):
+                yield "%s_%d" % (name, i + 1), vocab
+
+
 class SequenceToSequenceModelSpec(ModelSpec):
     """Base specification for sequence to sequence models."""
 
-    def __init__(self):
+    def __init__(self, source_embeddings_specs, target_embeddings_specs):
         self.with_source_bos = False
         self.with_source_eos = False
         self.with_target_bos = True
-        self._vocabularies = {}
+        self._embeddings_specs = {
+            "source": source_embeddings_specs,
+            "target": target_embeddings_specs,
+        }
+        self._vocabularies = {
+            "source": [],
+            "target": [],
+        }
         self._vmap = None
 
-    def register_vocabulary(self, name, tokens):
-        """Registers a vocabulary of tokens."""
-        self._vocabularies[name] = tokens
+    def register_source_vocabulary(self, tokens):
+        """Registers a source vocabulary of tokens."""
+        self._vocabularies["source"].append(tokens)
+
+    def register_target_vocabulary(self, tokens):
+        """Registers a target vocabulary of tokens."""
+        self._vocabularies["target"].append(tokens)
 
     def register_vocabulary_mapping(self, path):
         """Registers a vocabulary mapping file."""
         self._vmap = path
 
-    @property
-    def vocabulary_size(self):
-        """Vocabulary sizes based on the model weights."""
-        return {
-            "source": None,
-            "target": None,
-        }
-
     def validate(self):
         # Check that vocabularies are registered and have the correct size.
-        for name, expected_size in self.vocabulary_size.items():
-            vocabulary = self._vocabularies.get(name)
-            if vocabulary is None:
-                raise ValueError("No %s vocabulary has been registered" % name)
-            if expected_size is not None and len(vocabulary) != expected_size:
+        for name, embeddings_specs in self._embeddings_specs.items():
+            vocabularies = self._vocabularies[name]
+            if len(vocabularies) != len(embeddings_specs):
                 raise ValueError(
-                    "%s vocabulary has size %d but the model expected a vocabulary "
-                    "of size %d" % (name.capitalize(), len(vocabulary), expected_size)
+                    "Incorrect number of %s vocabularies: %d registered, but expected %d"
+                    % (name, len(vocabularies), len(embeddings_specs))
                 )
+            for i, (vocabulary, embeddings_spec) in enumerate(
+                zip(vocabularies, embeddings_specs)
+            ):
+                expected_size = embeddings_spec.weight.shape[0]
+                if len(vocabulary) != expected_size:
+                    raise ValueError(
+                        "%s vocabulary %d has size %d but the model expected a vocabulary "
+                        "of size %d"
+                        % (name.capitalize(), i, len(vocabulary), expected_size)
+                    )
 
         if self._vmap is not None and not os.path.exists(self._vmap):
             raise ValueError("Vocabulary mapping file %s does not exist" % self._vmap)
@@ -270,11 +290,10 @@ class SequenceToSequenceModelSpec(ModelSpec):
 
     def save(self, output_dir):
         # Save the vocabularies.
-        all_vocabularies = list(self._vocabularies.values())
+        vocabularies = dict(_flatten_vocabularies(self._vocabularies))
+        all_vocabularies = list(vocabularies.values())
         if all(vocabulary == all_vocabularies[0] for vocabulary in all_vocabularies):
             vocabularies = {"shared": all_vocabularies[0]}
-        else:
-            vocabularies = self._vocabularies
 
         for name, tokens in vocabularies.items():
             path = os.path.join(output_dir, "%s_vocabulary.txt" % name)

--- a/python/ctranslate2/specs/model_spec.py
+++ b/python/ctranslate2/specs/model_spec.py
@@ -239,6 +239,12 @@ class SequenceToSequenceModelSpec(ModelSpec):
     """Base specification for sequence to sequence models."""
 
     def __init__(self, source_embeddings_specs, target_embeddings_specs):
+        """Initializes a sequence to sequence model specification.
+
+        Args:
+          source_embeddings_specs: List of source EmbeddingsSpec modules.
+          target_embeddings_specs: List of target EmbeddingsSpec modules.
+        """
         self.with_source_bos = False
         self.with_source_eos = False
         self.with_target_bos = True

--- a/python/ctranslate2/specs/model_spec.py
+++ b/python/ctranslate2/specs/model_spec.py
@@ -68,6 +68,8 @@ class LayerSpec(object):
                 # Use float32 as the working floating point type.
                 if value.dtype in (np.float16, np.float64):
                     setattr(spec, attr_name, value.astype(np.float32))
+            elif isinstance(value, float):
+                setattr(spec, attr_name, np.dtype("float32").type(value))
             elif isinstance(value, bool):
                 # Convert bool to an integer type.
                 setattr(spec, attr_name, np.dtype("int8").type(value))

--- a/python/ctranslate2/specs/transformer_spec.py
+++ b/python/ctranslate2/specs/transformer_spec.py
@@ -26,6 +26,21 @@ class TransformerSpec(model_spec.SequenceToSequenceModelSpec):
         num_source_embeddings=1,
         embeddings_merge=common_spec.EmbeddingsMerge.CONCAT,
     ):
+        """Initializes a Transformer model specification.
+
+        Args:
+          num_layers: Number of encoder and decoder layers, or a 2-tuple if the
+            number is different.
+          num_heads: Number of attention heads.
+          with_relative_position: Enable relative position representations modules.
+          pre_norm: Enable the pre-norm Transformer architecture.
+          activation: Activation to apply in the feed-forward network.
+          alignment_layer: Layer index selected for alignment.
+          alignment_heads: Number of attention heads selected for alignment.
+          num_source_embeddings: Number of source embeddings.
+          embeddings_merge: When num_source_embeddings > 1, specify how the
+            embeddings are merged.
+        """
         if isinstance(num_layers, (list, tuple)):
             num_encoder_layers, num_decoder_layers = num_layers
         else:

--- a/src/layers/transformer.cc
+++ b/src/layers/transformer.cc
@@ -139,11 +139,11 @@ namespace ctranslate2 {
 
       StorageView value;
 
-      // The attribute can either be the actual scale value or a boolean flag.
-      if (scale->dtype() == DataType::FLOAT && scale->as_scalar<float>() != 1.f)
-        value = *scale;
+      // The attribute can either be a boolean flag or the actual scale value.
       if (scale->dtype() == DataType::INT8 && scale->as_scalar<int8_t>())
         value = StorageView(std::sqrt(static_cast<float>(embeddings.output_size())));
+      else if (scale->dtype() != DataType::INT8 && scale->as_scalar<float>() != 1.f)
+        value = *scale;
       else
         return nullptr;
 

--- a/src/models/sequence_to_sequence.cc
+++ b/src/models/sequence_to_sequence.cc
@@ -10,6 +10,7 @@ namespace ctranslate2 {
     static const std::string source_vocabulary_file = "source_vocabulary.txt";
     static const std::string target_vocabulary_file = "target_vocabulary.txt";
     static const std::string vmap_file = "vmap.txt";
+    static const std::string features_separator = "￨";
 
     template <typename T>
     static std::vector<std::vector<T>>
@@ -37,7 +38,7 @@ namespace ctranslate2 {
         }
 
         for (const auto& token : tokens) {
-          auto fields = split_string(token, "￨");
+          auto fields = split_string(token, features_separator);
           if (fields.size() != num_features)
             throw std::invalid_argument("Expected " + std::to_string(num_features)
                                         + " input features, but token '" + token

--- a/src/models/sequence_to_sequence.cc
+++ b/src/models/sequence_to_sequence.cc
@@ -22,18 +22,65 @@ namespace ctranslate2 {
       return truncated_inputs;
     }
 
+    static std::vector<std::vector<std::vector<std::string>>>
+    extract_features(const std::vector<std::vector<std::string>>& batch, size_t num_features) {
+      if (num_features == 1)
+        return {batch};
+
+      std::vector<std::vector<std::vector<std::string>>> features;
+      features.resize(num_features);
+
+      for (const auto& tokens : batch) {
+        for (auto& stream : features) {
+          stream.emplace_back();
+          stream.back().reserve(tokens.size());
+        }
+
+        for (const auto& token : tokens) {
+          auto fields = split_string(token, "￨");
+          if (fields.size() != num_features)
+            throw std::invalid_argument("Expected " + std::to_string(num_features)
+                                        + " input features, but token '" + token
+                                        + "' has " + std::to_string(fields.size())
+                                        + " features");
+
+          for (size_t i = 0; i < fields.size(); ++i)
+            features[i].back().emplace_back(std::move(fields[i]));
+        }
+      }
+
+      return features;
+    }
+
+
     SequenceToSequenceModel::SequenceToSequenceModel(ModelReader& model_reader, size_t spec_revision)
       : Model(model_reader, spec_revision) {
       {
         auto shared_vocabulary = model_reader.get_file(shared_vocabulary_file);
         if (shared_vocabulary) {
-          _source_vocabulary = std::make_shared<Vocabulary>(*shared_vocabulary);
-          _target_vocabulary = _source_vocabulary;
+          _target_vocabulary = std::make_shared<Vocabulary>(*shared_vocabulary);
+          _source_vocabularies.emplace_back(_target_vocabulary);
         } else {
+
           {
-            auto source_vocabulary = model_reader.get_required_file(source_vocabulary_file);
-            _source_vocabulary = std::make_shared<Vocabulary>(*source_vocabulary);
+            auto source_vocabulary = model_reader.get_file(source_vocabulary_file);
+            if (source_vocabulary)
+              _source_vocabularies.emplace_back(std::make_shared<Vocabulary>(*source_vocabulary));
+            else {
+              for (size_t i = 1;; i++) {
+                const std::string filename = "source_" + std::to_string(i) + "_vocabulary.txt";
+                const auto vocabulary_file = model_reader.get_file(filename);
+                if (!vocabulary_file)
+                  break;
+                _source_vocabularies.emplace_back(std::make_shared<Vocabulary>(*vocabulary_file));
+              }
+            }
+
+            // If no source vocabularies were loaded, raise an error for the first filename.
+            if (_source_vocabularies.empty())
+              model_reader.get_required_file(source_vocabulary_file);
           }
+
           {
             auto target_vocabulary = model_reader.get_required_file(target_vocabulary_file);
             _target_vocabulary = std::make_shared<Vocabulary>(*target_vocabulary);
@@ -57,7 +104,7 @@ namespace ctranslate2 {
     }
 
     const Vocabulary& SequenceToSequenceModel::get_source_vocabulary() const {
-      return *_source_vocabulary;
+      return *_source_vocabularies[0];
     }
 
     const Vocabulary& SequenceToSequenceModel::get_target_vocabulary() const {
@@ -69,19 +116,32 @@ namespace ctranslate2 {
     }
 
     void SequenceToSequenceModel::forward_encoder(layers::Encoder& encoder,
-                                                  const std::vector<std::vector<std::string>>& source,
+                                                  const std::vector<std::vector<std::vector<std::string>>>& source,
                                                   StorageView& memory,
                                                   StorageView& memory_lengths) const {
       const auto scoped_device_setter = get_scoped_device_setter();
       PROFILE("SequenceToSequenceModel::forward_encoder");
-      const auto source_ids = _source_vocabulary->to_ids(source,
-                                                         _with_source_bos,
-                                                         _with_source_eos);
 
-      const StorageView ids = layers::make_sequence_inputs(source_ids,
-                                                           _device,
-                                                           _preferred_size_multiple,
-                                                           &memory_lengths);
+      const size_t num_input_features = source.size();
+      if (_source_vocabularies.size() != source.size())
+        throw std::runtime_error("The encoder expects "
+                                 + std::to_string(num_input_features)
+                                 + " input features, but "
+                                 + std::to_string(_source_vocabularies.size())
+                                 + " source vocabularies are loaded");
+
+      std::vector<StorageView> ids;
+      ids.reserve(num_input_features);
+
+      for (size_t i = 0; i < num_input_features; ++i) {
+        const auto tokens_ids = _source_vocabularies[i]->to_ids(source[i],
+                                                                _with_source_bos,
+                                                                _with_source_eos);
+        ids.emplace_back(layers::make_sequence_inputs(tokens_ids,
+                                                      _device,
+                                                      _preferred_size_multiple,
+                                                      i == 0 ? &memory_lengths : nullptr));
+      }
 
       encoder(ids, memory_lengths, memory);
     }
@@ -107,7 +167,7 @@ namespace ctranslate2 {
 
     void SequenceToSequenceModel::forward(layers::Encoder& encoder,
                                           layers::Decoder& decoder,
-                                          const std::vector<std::vector<std::string>>& source,
+                                          const std::vector<std::vector<std::vector<std::string>>>& source,
                                           const std::vector<std::vector<std::string>>& target,
                                           StorageView& logits) const {
       const auto scoped_device_setter = get_scoped_device_setter();
@@ -138,8 +198,10 @@ namespace ctranslate2 {
         target_inputs = truncate_inputs(target_inputs, max_input_length);
       }
 
+      const auto source_features = extract_features(source_inputs, encoder.num_input_features());
+
       StorageView logits(decoder.output_type(), _device);
-      forward(encoder, decoder, source_inputs, target_inputs, logits);
+      forward(encoder, decoder, source_features, target_inputs, logits);
       StorageView log_probs = std::move(logits);
       ops::LogSoftMax()(log_probs);
 
@@ -218,10 +280,12 @@ namespace ctranslate2 {
         target_prefix_inputs = truncate_inputs(target_prefix_inputs, max_input_length);
       }
 
+      const auto source_features = extract_features(source_inputs, encoder.num_input_features());
+
       // Encode the sequence.
       StorageView memory(encoder.output_type(), _device);
       StorageView memory_lengths(DataType::INT32, _device);
-      forward_encoder(encoder, source_inputs, memory, memory_lengths);
+      forward_encoder(encoder, source_features, memory, memory_lengths);
 
       layers::DecoderState state = decoder.initial_state();
       state.emplace("memory", std::move(memory));
@@ -229,7 +293,7 @@ namespace ctranslate2 {
 
       std::vector<size_t> output_ids_map;
       if (use_vmap && _vocabulary_map) {
-        output_ids_map = _vocabulary_map->get_candidates(source);
+        output_ids_map = _vocabulary_map->get_candidates(source_features[0]);
       } else if (_target_vocabulary->size() % _preferred_size_multiple != 0) {
         output_ids_map.resize(_target_vocabulary->size());
         std::iota(output_ids_map.begin(), output_ids_map.end(), size_t(0));
@@ -310,7 +374,7 @@ namespace ctranslate2 {
             }
 
             if (replace_unknowns)
-              replace_unknown_tokens(source[i], hypotheses[h], attention);
+              replace_unknown_tokens(source_features[0][i], hypotheses[h], attention);
           }
 
           if (!return_attention)

--- a/src/models/transformer.cc
+++ b/src/models/transformer.cc
@@ -40,7 +40,7 @@ namespace ctranslate2 {
     }
 
     size_t TransformerModel::current_spec_revision() const {
-      return 3;
+      return 4;
     }
 
     bool TransformerModel::is_quantizable(const std::string& variable_name) const {
@@ -78,13 +78,10 @@ namespace ctranslate2 {
         _num_heads = get_variable("num_heads").as_scalar<int8_t>();
       _with_relative_position = get_flag_with_default("with_relative_position", false);
       _pre_norm = get_flag_with_default("pre_norm", true);
-
-      const auto* activation_type = get_variable_if_exists("activation");
-      if (activation_type)
-        _activation_type = static_cast<ops::ActivationType>(activation_type->as_scalar<int8_t>());
-      else
-        _activation_type = ops::ActivationType::ReLU;
-
+      _activation_type = static_cast<ops::ActivationType>(
+        get_attribute_with_default<int8_t>("activation", 0));
+      _embeddings_merge = static_cast<layers::EmbeddingsMerge>(
+        get_attribute_with_default<int8_t>("embeddings_merge", 0));
       _alignment_layer = get_attribute_with_default<int16_t>("alignment_layer", -1);
       _alignment_heads = get_attribute_with_default<int16_t>("alignment_heads", 1);
     }
@@ -95,7 +92,8 @@ namespace ctranslate2 {
                                                           _num_heads,
                                                           !_with_relative_position,
                                                           _pre_norm,
-                                                          _activation_type);
+                                                          _activation_type,
+                                                          _embeddings_merge);
     }
 
     std::unique_ptr<layers::Decoder> TransformerModel::make_decoder() const {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -212,20 +212,24 @@ namespace ctranslate2 {
   }
 
   std::vector<std::string> split_string(const std::string& str, char delimiter) {
+    return split_string(str, std::string(1, delimiter));
+  }
+
+  std::vector<std::string> split_string(const std::string& str, const std::string& delimiter) {
     std::vector<std::string> parts;
-    std::string part;
-    for (const char c : str) {
-      if (c == delimiter) {
-        if (!part.empty()) {
-          parts.emplace_back(std::move(part));
-          part.clear();
-        }
-      } else {
-        part += c;
-      }
+    parts.reserve(str.size() / 2);
+    size_t offset = 0;
+
+    while (offset < str.size()) {
+      size_t pos = str.find(delimiter, offset);
+      if (pos == std::string::npos)
+        pos = str.size();
+      const size_t length = pos - offset;
+      if (length > 0)
+        parts.emplace_back(str.substr(offset, length));
+      offset = pos + delimiter.size();
     }
-    if (!part.empty())
-      parts.emplace_back(std::move(part));
+
     return parts;
   }
 


### PR DESCRIPTION
To facilitate the code integration, the features should be added to the input tokens directly using the special separator ￨ (as used in the OpenNMT Tokenizer). For example:

```text
hello￨C world￨L !￨N
```

For now, only OpenNMT-py models are supported out of the box. Other frameworks can easily extend the converter to register additional word embeddings and vocabularies.

Closes #596.