### PR TITLE
Move device synchronization in Model methods

### DIFF
--- a/include/ctranslate2/devices.h
+++ b/include/ctranslate2/devices.h
@@ -16,6 +16,8 @@ namespace ctranslate2 {
   int get_device_index(Device device);
   void set_device_index(Device device, int index);
 
+  void synchronize_device(Device device, int index);
+
   class ScopedDeviceSetter {
   public:
     ScopedDeviceSetter(Device device, int index)

--- a/include/ctranslate2/models/model.h
+++ b/include/ctranslate2/models/model.h
@@ -30,7 +30,7 @@ namespace ctranslate2 {
                                                int device_index,
                                                const std::string& compute_type);
 
-      virtual ~Model() = default;
+      virtual ~Model();
 
       size_t binary_version() const {
         return _binary_version;

--- a/include/ctranslate2/translator.h
+++ b/include/ctranslate2/translator.h
@@ -138,7 +138,7 @@ namespace ctranslate2 {
     void set_model(const std::shared_ptr<const models::Model>& model);
 
     // Detach the model from this translator, which becomes unusable until set_model is called.
-    void detach_model();
+    std::shared_ptr<const models::Model> detach_model();
 
     // Return the memory allocator associated with this translator.
     // The allocator is registered on the first translation.

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -420,13 +420,14 @@ public:
       _cached_models.reserve(translators.size());
 
     for (const auto& translator : translators) {
-      if (to_cpu) {
-        const auto& model = translator.get_model();
-        const_cast<ctranslate2::models::Model&>(*model).set_device(ctranslate2::Device::CPU);
-        _cached_models.emplace_back(model);
-      }
+      {
+        const auto model = const_cast<ctranslate2::Translator&>(translator).detach_model();
 
-      const_cast<ctranslate2::Translator&>(translator).detach_model();
+        if (to_cpu) {
+          const_cast<ctranslate2::models::Model&>(*model).set_device(ctranslate2::Device::CPU);
+          _cached_models.emplace_back(model);
+        }
+      }
 
       // Clear cache of memory allocator associated with this translator.
       auto* allocator = translator.get_allocator();

--- a/src/devices.cc
+++ b/src/devices.cc
@@ -76,4 +76,16 @@ namespace ctranslate2 {
     DEVICE_DISPATCH(device, set_device_index<D>(index));
   }
 
+  void synchronize_device(Device device, int index) {
+#ifdef CT2_WITH_CUDA
+    if (device == Device::CUDA) {
+      const ScopedDeviceSetter scoped_device_setter(device, index);
+      cudaDeviceSynchronize();
+    }
+#else
+    (void)device;
+    (void)index;
+#endif
+  }
+
 }

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -127,12 +127,18 @@ namespace ctranslate2 {
       : _spec_revision(spec_revision) {
     }
 
+    Model::~Model() {
+      _variable_index.clear();
+      synchronize_device(_device, _device_index);  // Wait for asynchronous deallocations.
+    }
+
     size_t Model::current_spec_revision() const {
       return 1;
     }
 
     void Model::set_device(const Device device, const int index) {
       move_variables(_variable_index, _device, _device_index, device, index);
+      synchronize_device(_device, _device_index);  // Wait for asynchronous deallocations.
       _device = device;
       _device_index = index;
     }

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -1,9 +1,5 @@
 #include "ctranslate2/translator.h"
 
-#ifdef CT2_WITH_CUDA
-#  include <cuda_runtime.h>
-#endif
-
 #include "ctranslate2/batch_reader.h"
 
 namespace ctranslate2 {
@@ -207,18 +203,13 @@ namespace ctranslate2 {
     _decoder = seq2seq_model->make_decoder();
   }
 
-  void Translator::detach_model() {
-    if (!_model)
-      return;
-    auto scoped_device_setter = _model->get_scoped_device_setter();
+  std::shared_ptr<const models::Model> Translator::detach_model() {
+    auto model = _model;
     _encoder.reset();
     _decoder.reset();
     _model.reset();
     _seq2seq_model = nullptr;
-#ifdef CT2_WITH_CUDA
-    // We synchronize the device to ensure all asynchronous memory deallocations are completed.
-    cudaDeviceSynchronize();
-#endif
+    return model;
   }
 
   void Translator::assert_has_model() const {


### PR DESCRIPTION
This change fixes the previous PR #713. We want to synchronize after destroying the model and after moving the weights to another device.