### PR TITLE
Allow passing decoder start tokens in the target prefix

### DIFF
--- a/include/ctranslate2/models/sequence_to_sequence.h
+++ b/include/ctranslate2/models/sequence_to_sequence.h
@@ -77,7 +77,8 @@ namespace ctranslate2 {
 
       bool _with_source_bos = false;
       bool _with_source_eos = false;
-      int32_t _decoder_start_token_id;
+      bool _with_target_bos = true;
+      bool _user_decoder_start_tokens = false;
     };
 
   }

--- a/include/ctranslate2/models/sequence_to_sequence.h
+++ b/include/ctranslate2/models/sequence_to_sequence.h
@@ -77,7 +77,7 @@ namespace ctranslate2 {
 
       bool _with_source_bos = false;
       bool _with_source_eos = false;
-      bool _with_target_bos = true;
+      int32_t _decoder_start_token_id;
     };
 
   }

--- a/python/ctranslate2/converters/fairseq.py
+++ b/python/ctranslate2/converters/fairseq.py
@@ -113,6 +113,7 @@ class FairseqConverter(Converter):
 
             model_spec = _get_model_spec(args)
             model_spec.with_source_eos = True
+            model_spec.with_target_bos = False
 
             task = fairseq.tasks.setup_task(args)
             model = fairseq.models.build_model(args, task)
@@ -122,7 +123,6 @@ class FairseqConverter(Converter):
             set_transformer_spec(model_spec, model)
             model_spec.register_source_vocabulary(_get_vocab(task.source_dictionary))
             model_spec.register_target_vocabulary(_get_vocab(task.target_dictionary))
-            model_spec.decoder_start_token_id = task.target_dictionary.eos()
             return model_spec
 
 

--- a/python/ctranslate2/converters/fairseq.py
+++ b/python/ctranslate2/converters/fairseq.py
@@ -113,7 +113,6 @@ class FairseqConverter(Converter):
 
             model_spec = _get_model_spec(args)
             model_spec.with_source_eos = True
-            model_spec.with_target_bos = False
 
             task = fairseq.tasks.setup_task(args)
             model = fairseq.models.build_model(args, task)
@@ -123,6 +122,7 @@ class FairseqConverter(Converter):
             set_transformer_spec(model_spec, model)
             model_spec.register_source_vocabulary(_get_vocab(task.source_dictionary))
             model_spec.register_target_vocabulary(_get_vocab(task.target_dictionary))
+            model_spec.decoder_start_token_id = task.target_dictionary.eos()
             return model_spec
 
 

--- a/python/ctranslate2/specs/model_spec.py
+++ b/python/ctranslate2/specs/model_spec.py
@@ -74,8 +74,6 @@ class LayerSpec(object):
             elif isinstance(value, bool):
                 # Convert bool to an integer type.
                 setattr(spec, attr_name, np.dtype("int8").type(value))
-            elif isinstance(value, int):
-                setattr(spec, attr_name, np.dtype("int32").type(value))
 
         self.visit(_check)
 
@@ -250,15 +248,10 @@ class SequenceToSequenceModelSpec(ModelSpec):
           source_embeddings_specs: List of source EmbeddingsSpec modules.
           target_embeddings_specs: List of target EmbeddingsSpec modules.
         """
-
-        # Whether <s> and </s> should be added to the source sequences.
         self.with_source_bos = False
         self.with_source_eos = False
-
-        # The token ID to start the decoding (default: index of <s>).
-        # Set -1 to require the user to pass the start tokens.
-        self.decoder_start_token_id = OPTIONAL
-
+        self.with_target_bos = True
+        self.user_decoder_start_tokens = False
         self._embeddings_specs = {
             "source": source_embeddings_specs,
             "target": target_embeddings_specs,

--- a/python/ctranslate2/specs/model_spec.py
+++ b/python/ctranslate2/specs/model_spec.py
@@ -74,6 +74,8 @@ class LayerSpec(object):
             elif isinstance(value, bool):
                 # Convert bool to an integer type.
                 setattr(spec, attr_name, np.dtype("int8").type(value))
+            elif isinstance(value, int):
+                setattr(spec, attr_name, np.dtype("int32").type(value))
 
         self.visit(_check)
 
@@ -248,9 +250,15 @@ class SequenceToSequenceModelSpec(ModelSpec):
           source_embeddings_specs: List of source EmbeddingsSpec modules.
           target_embeddings_specs: List of target EmbeddingsSpec modules.
         """
+
+        # Whether <s> and </s> should be added to the source sequences.
         self.with_source_bos = False
         self.with_source_eos = False
-        self.with_target_bos = True
+
+        # The token ID to start the decoding (default: index of <s>).
+        # Set -1 to require the user to pass the start tokens.
+        self.decoder_start_token_id = OPTIONAL
+
         self._embeddings_specs = {
             "source": source_embeddings_specs,
             "target": target_embeddings_specs,

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -786,6 +786,34 @@ def test_fairseq_model_conversion(tmpdir):
     assert output[0].hypotheses[0] == ["a", "t", "z", "m", "o", "n"]
 
 
+@skip_if_data_missing
+@skip_on_windows
+def test_fairseq_user_start_token(tmpdir):
+    class _CustomFairseqConverter(ctranslate2.converters.FairseqConverter):
+        def _load(self):
+            model_spec = super()._load()
+            model_spec.decoder_start_token_id = -1
+            return model_spec
+
+    data_dir = os.path.join(
+        _TEST_DATA_DIR,
+        "models",
+        "transliteration-aren-all",
+        "fairseq",
+    )
+    converter = _CustomFairseqConverter(os.path.join(data_dir, "model.pt"), data_dir)
+    output_dir = str(tmpdir.join("ctranslate2_model"))
+    converter.convert(output_dir)
+    translator = ctranslate2.Translator(output_dir)
+    tokens = [["آ", "ت", "ز", "م", "و", "ن"]]
+
+    with pytest.raises(ValueError, match="start token"):
+        translator.translate_batch(tokens)
+
+    output = translator.translate_batch(tokens, target_prefix=[["</s>"]])
+    assert output[0].hypotheses[0] == ["a", "t", "z", "m", "o", "n"]
+
+
 def test_layer_spec_validate():
     class SubSpec(ctranslate2.specs.LayerSpec):
         def __init__(self):

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -792,7 +792,7 @@ def test_fairseq_user_start_token(tmpdir):
     class _CustomFairseqConverter(ctranslate2.converters.FairseqConverter):
         def _load(self):
             model_spec = super()._load()
-            model_spec.decoder_start_token_id = -1
+            model_spec.user_decoder_start_tokens = True
             return model_spec
 
     data_dir = os.path.join(

--- a/src/models/sequence_to_sequence.cc
+++ b/src/models/sequence_to_sequence.cc
@@ -274,7 +274,7 @@ namespace ctranslate2 {
 
       std::vector<size_t> start_ids;
       start_ids.reserve(target_prefix.size());
-      bool prefix_has_only_bos = true;
+      bool prefix_has_only_start_token = true;
 
       for (auto& prefix : target_prefix) {
         if (prefix.empty())
@@ -284,10 +284,10 @@ namespace ctranslate2 {
         prefix.erase(prefix.begin());
 
         if (!prefix.empty())
-          prefix_has_only_bos = false;
+          prefix_has_only_start_token = false;
       }
 
-      if (prefix_has_only_bos)
+      if (prefix_has_only_start_token)
         target_prefix.clear();
 
       return start_ids;


### PR DESCRIPTION
Some models use the decoder start token to pass some information (e.g. MBART-25 passes the language token). This PR adds a way to pass the start tokens in the target prefix.