### PR TITLE
Describe the models used in the performance benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ We translate the En->De test set *newstest2014* with multiple models:
 
 * [OpenNMT-tf WMT14](https://opennmt.net/Models-tf/#translation): a base Transformer trained with OpenNMT-tf on the WMT14 dataset (4.5M lines)
 * [OpenNMT-py WMT14](https://opennmt.net/Models-py/#translation): a base Transformer trained with OpenNMT-py on the WMT14 dataset (4.5M lines)
-* [OPUS-MT](https://github.com/Helsinki-NLP/OPUS-MT-train/tree/master/models/en-de#opus-2020-02-26zip): a base Transformer trained with Marian on the OPUS dataset (81.9M lines)
+* [OPUS-MT](https://github.com/Helsinki-NLP/OPUS-MT-train/tree/master/models/en-de#opus-2020-02-26zip): a base Transformer trained with Marian on all OPUS data available on 2020-02-26 (81.9M lines)
 
 The benchmark reports the number of target tokens generated per second (higher is better). The results are aggregated over multiple runs. See the [benchmark scripts](tools/benchmark) for more details and reproduce these numbers.
 

--- a/README.md
+++ b/README.md
@@ -414,7 +414,13 @@ Depending on your build configuration, you might need to set `LD_LIBRARY_PATH` i
 
 ### Performance
 
-We translate the En->De test set *newstest2014* and report the number of target tokens generated per second. The results are aggregated over multiple runs. See the [benchmark scripts](tools/benchmark) for more details and reproduce these numbers.
+We translate the En->De test set *newstest2014* with multiple models:
+
+* [OpenNMT-tf WMT14](https://opennmt.net/Models-tf/#translation): a base Transformer trained with OpenNMT-tf on the WMT14 dataset (4.5M lines)
+* [OpenNMT-py WMT14](https://opennmt.net/Models-py/#translation): a base Transformer trained with OpenNMT-py on the WMT14 dataset (4.5M lines)
+* [OPUS-MT](https://github.com/Helsinki-NLP/OPUS-MT-train/tree/master/models/en-de#opus-2020-02-26zip): a base Transformer trained with Marian on the OPUS dataset (81.9M lines)
+
+The benchmark reports the number of target tokens generated per second (higher is better). The results are aggregated over multiple runs. See the [benchmark scripts](tools/benchmark) for more details and reproduce these numbers.
 
 **Please note that the results presented below are only valid for the configuration used during this benchmark: absolute and relative performance may change with different settings.**
 


### PR DESCRIPTION
@vince62s Does this look OK to you?

I got the OPUS data size from the training logs of the model:

```text
[2020-02-19 11:01:22] [sqlite] Inserted 1000000 lines
[2020-02-19 11:01:26] [sqlite] Inserted 2000000 lines
[2020-02-19 11:01:35] [sqlite] Inserted 4000000 lines
[2020-02-19 11:01:53] [sqlite] Inserted 8000000 lines
[2020-02-19 11:02:33] [sqlite] Inserted 16000000 lines
[2020-02-19 11:03:14] [sqlite] Inserted 32000000 lines
[2020-02-19 11:05:53] [sqlite] Inserted 64000000 lines
[2020-02-19 11:07:22] [sqlite] Inserted 81907410 lines
```