### PR TITLE
Allow batch encoding in return_alternatives mode

### DIFF
--- a/include/ctranslate2/translation.h
+++ b/include/ctranslate2/translation.h
@@ -68,7 +68,6 @@ namespace ctranslate2 {
     bool replace_unknowns = false;
 
     void validate() const;
-    bool support_batch_translation() const;
 
     std::unique_ptr<const Sampler> make_sampler() const;
     std::unique_ptr<const SearchStrategy> make_search_strategy() const;

--- a/include/ctranslate2/translator_pool.h
+++ b/include/ctranslate2/translator_pool.h
@@ -602,10 +602,6 @@ namespace ctranslate2 {
       create_batches(const std::vector<Example>& examples,
                      size_t max_batch_size,
                      BatchType batch_type) const override {
-        if (!_options.support_batch_translation()) {
-          max_batch_size = 1;
-          batch_type = BatchType::Examples;
-        }
         return rebatch_input(examples, max_batch_size, batch_type);
       }
 

--- a/src/translation.cc
+++ b/src/translation.cc
@@ -27,10 +27,6 @@ namespace ctranslate2 {
       throw std::invalid_argument("prefix_bias_beta is not compatible with greedy-search");
   }
 
-  bool TranslationOptions::support_batch_translation() const {
-    return !return_alternatives;
-  }
-
   std::unique_ptr<const Sampler> TranslationOptions::make_sampler() const {
     if (sampling_topk == 1)
       return std::make_unique<BestSampler>();

--- a/src/translator.cc
+++ b/src/translator.cc
@@ -73,8 +73,7 @@ namespace ctranslate2 {
                                          options.return_scores);
     std::vector<TranslationResult> results(source.size(), empty_result);
 
-    const size_t max_batch_size = options.support_batch_translation() ? 0 : 1;
-    for (const auto& batch : rebatch_input(load_examples({source, target_prefix}), max_batch_size)) {
+    for (const auto& batch : rebatch_input(load_examples({source, target_prefix}), 0)) {
       auto batch_results = _model->sample(*_encoder,
                                           *_decoder,
                                           batch.get_stream(0),

--- a/tests/translator_test.cc
+++ b/tests/translator_test.cc
@@ -715,6 +715,26 @@ TEST(TranslatorTest, AlternativesFromPrefix) {
   EXPECT_EQ(result.attention[0].size(), 6);
 }
 
+TEST(TranslatorTest, AlternativesFromPrefixBatch) {
+  Translator translator = default_translator();
+  TranslationOptions options;
+  options.num_hypotheses = 10;
+  options.return_alternatives = true;
+  const std::vector<std::vector<std::string>> input = {
+    {"آ", "ز", "ا"},
+    {"آ" ,"ت" ,"ز" ,"م" ,"و" ,"ن"}
+  };
+  const std::vector<std::vector<std::string>> prefix = {{"a"}, {"a", "t"}};
+  const auto results = translator.translate_batch_with_prefix(input, prefix, options);
+  ASSERT_EQ(results.size(), 2);
+  ASSERT_EQ(results[0].num_hypotheses(), options.num_hypotheses);
+  EXPECT_EQ(results[0].hypotheses[0], (std::vector<std::string>{"a", "z", "z", "a"}));
+  EXPECT_EQ(results[0].hypotheses[1], (std::vector<std::string>{"a", "s", "z", "a"}));
+  ASSERT_EQ(results[1].num_hypotheses(), options.num_hypotheses);
+  EXPECT_EQ(results[1].hypotheses[0], (std::vector<std::string>{"a", "t", "z", "m", "o", "n"}));
+  EXPECT_EQ(results[1].hypotheses[1], (std::vector<std::string>{"a", "t", "s", "u", "m", "o", "n"}));
+}
+
 TEST(TranslatorTest, AlternativesFromScratch) {
   Translator translator = default_translator();
   TranslationOptions options;


### PR DESCRIPTION
Only the decoding logic cannot run in batch mode at the moment.