### PR TITLE
Improve correctness of the scoring output

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -149,6 +149,7 @@ The `Translator` object (see previous section) can also be used to score existin
 
 ```python
 # Batch scoring:
+# The returned score sequences include the score of the end of sentence token </s>.
 scores = translator.score_batch(
     source: List[List[str]],
     target: List[List[str]],
@@ -160,7 +161,7 @@ scores = translator.score_batch(
 
 # File scoring:
 # Each line in output_path will have the format: <score> ||| <target>
-# The score is normalized by the target length.
+# The score is normalized by the target length which includes the end of sentence token </s>.
 #
 # The returned stats object has the following properties:
 # * num_tokens: the number of scored target tokens

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -424,8 +424,17 @@ def test_score_api(tmpdir):
         ["a", "c", "h", "i", "s", "o", "n"],
     ]
     expected = [
-        [-0.106023, -0.065410, -0.056002, -0.447953, -0.230714, -0.092184],
-        [-0.072660, -0.300309, -0.181187, -0.395671, -0.025631, -0.123466, -0.002034],
+        [-0.106023, -0.065410, -0.056002, -0.447953, -0.230714, -0.092184, -0.063463],
+        [
+            -0.072660,
+            -0.300309,
+            -0.181187,
+            -0.395671,
+            -0.025631,
+            -0.123466,
+            -0.002034,
+            -0.012639,
+        ],
     ]
 
     translator = _get_transliterator()
@@ -446,7 +455,7 @@ def test_score_api(tmpdir):
         with_tokens_score=True,
     )
     assert stats.num_examples == 2
-    assert stats.num_tokens == 13
+    assert stats.num_tokens == 15
 
     with open(output_path, encoding="utf-8") as output_file:
         for line, expected_tokens, expected_scores in zip(
@@ -459,7 +468,7 @@ def test_score_api(tmpdir):
             tokens = parts[1].split()
             scores = list(map(float, parts[2].split()))
 
-            assert tokens == expected_tokens
+            assert tokens == expected_tokens + ["</s>"]
             assert mean_score == pytest.approx(np.mean(expected_scores), 1e-4)
             assert scores == pytest.approx(expected_scores, 1e-4)
 

--- a/src/models/sequence_to_sequence.cc
+++ b/src/models/sequence_to_sequence.cc
@@ -229,13 +229,14 @@ namespace ctranslate2 {
       const dim_t batch_size = scores.dim(0);
       std::vector<ScoringResult> results(batch_size);
       for (dim_t b = 0; b < batch_size; ++b) {
-        const dim_t original_length = target[b].size();
-        const dim_t output_length = target_inputs[b].size();
+        const dim_t output_length = target_ids_out[b].size();
         auto& result = results[b];
-        result.tokens = target[b];
-        result.tokens_score.resize(original_length, 0);
-        for (dim_t t = 0; t < output_length; ++t)
-          result.tokens_score[t] = scores.at<float>({b, t});
+        result.tokens.reserve(output_length);
+        result.tokens_score.reserve(output_length);
+        for (dim_t t = 0; t < output_length; ++t) {
+          result.tokens.emplace_back(_target_vocabulary->to_token(target_ids_out[b][t]));
+          result.tokens_score.emplace_back(scores.at<float>({b, t}));
+        }
       }
 
       return results;

--- a/tests/translator_test.cc
+++ b/tests/translator_test.cc
@@ -851,11 +851,11 @@ TEST(TranslatorTest, Scoring) {
     {"a", "r", "t", "h", "e", "r"},
   };
   const std::vector<std::vector<float>> expected_scores = {
-    {-0.106023, -0.065410, -0.056002, -0.447953, -0.230714, -0.092184},
-    {-0.072660, -0.300309, -0.181187, -0.395671, -0.025631, -0.123466, -0.002034},
-    {-0.103136, -0.089504, -0.063889, -0.007327, -0.452072, -0.060154},
-    {},
-    {-0.076704, -0.036037, -0.029253, -0.030273, -0.149276, -0.002440},
+    {-0.106023, -0.065410, -0.056002, -0.447953, -0.230714, -0.092184, -0.063463},
+    {-0.072660, -0.300309, -0.181187, -0.395671, -0.025631, -0.123466, -0.002034, -0.012639},
+    {-0.103136, -0.089504, -0.063889, -0.007327, -0.452072, -0.060154, -0.016636},
+    {-6.00171},
+    {-0.076704, -0.036037, -0.029253, -0.030273, -0.149276, -0.002440, -0.003742},
   };
   constexpr float abs_diff = 1e-5;
 
@@ -875,11 +875,8 @@ TEST(TranslatorTest, ScoringMaxInputLength) {
   options.max_input_length = 3;
   Translator translator = default_translator();
   const auto result = translator.score_batch({source}, {target}, options)[0];
+  constexpr float abs_diff = 1e-5;
 
-  // Check the result has the size of the original input even though it was truncated.
-  EXPECT_EQ(result.tokens, target);
-  ASSERT_EQ(result.tokens_score.size(), target.size());
-  for (size_t i = options.max_input_length; i < target.size(); ++i) {
-    EXPECT_EQ(result.tokens_score[i], 0);
-  }
+  EXPECT_EQ(result.tokens, (std::vector<std::string>{"a", "t", "z", "</s>"}));
+  expect_vector_eq(result.tokens_score, {-0.081900, -0.037582, -0.145343, -0.024944}, abs_diff);
 }


### PR DESCRIPTION
* Include score of EOS token
* Return the actual tokens that were scored (after vocabulary lookup and sequence truncation)