### PR TITLE
Cache output layer transformations when possible

### DIFF
--- a/include/ctranslate2/decoding.h
+++ b/include/ctranslate2/decoding.h
@@ -17,7 +17,6 @@ namespace ctranslate2 {
            const Sampler& sampler,
            const std::vector<size_t>& start_ids,
            const size_t end_id,
-           const size_t unk_id,
            const dim_t start_step,
            const dim_t max_length,
            const dim_t min_length,
@@ -27,7 +26,6 @@ namespace ctranslate2 {
            const bool return_attention = false,
            const size_t num_hypotheses = 1,
            const float repetition_penalty = 1,
-           const bool disable_unk = false,
            const std::vector<std::vector<size_t>>* prefix_ids = nullptr) const = 0;
   };
 
@@ -45,7 +43,6 @@ namespace ctranslate2 {
            const Sampler& sampler,
            const std::vector<size_t>& start_ids,
            const size_t end_id,
-           const size_t unk_id,
            const dim_t start_step,
            const dim_t max_length,
            const dim_t min_length,
@@ -55,7 +52,6 @@ namespace ctranslate2 {
            const bool return_attention = false,
            const size_t num_hypotheses = 1,
            const float repetition_penalty = 1,
-           const bool disable_unk = false,
            const std::vector<std::vector<size_t>>* prefix_ids = nullptr) const override;
 
   private:
@@ -92,7 +88,6 @@ namespace ctranslate2 {
            const Sampler& sampler,
            const std::vector<size_t>& start_ids,
            const size_t end_id,
-           const size_t unk_id,
            const dim_t start_step,
            const dim_t max_length,
            const dim_t min_length,
@@ -102,7 +97,6 @@ namespace ctranslate2 {
            const bool return_attention = false,
            const size_t num_hypotheses = 1,
            const float repetition_penalty = 1,
-           const bool disable_unk = false,
            const std::vector<std::vector<size_t>>* prefix_ids = nullptr) const override;
   };
 
@@ -114,7 +108,6 @@ namespace ctranslate2 {
          const std::vector<std::vector<size_t>>& start_tokens,
          const std::vector<size_t>* output_ids_map,
          const size_t end_id,
-         const size_t unk_id,
          dim_t max_length,
          dim_t min_length,
          const size_t num_hypotheses,
@@ -122,7 +115,6 @@ namespace ctranslate2 {
          const bool return_scores,
          const bool return_attention,
          const bool normalize_scores,
-         const float repetition_penalty,
-         const bool disable_unk);
+         const float repetition_penalty);
 
 }

--- a/include/ctranslate2/layers/common.h
+++ b/include/ctranslate2/layers/common.h
@@ -101,8 +101,7 @@ namespace ctranslate2 {
       DataType output_type() const override;
       dim_t output_size() const override;
       void operator()(const StorageView& input, StorageView& output) const;
-      void mask_weights(const StorageView& index);
-      void reset_mask();
+      void select_weights(const StorageView* index);
     private:
       bool _packed_weight;
       const StorageView& _weight;

--- a/include/ctranslate2/layers/decoder.h
+++ b/include/ctranslate2/layers/decoder.h
@@ -18,8 +18,6 @@ namespace ctranslate2 {
     public:
       Decoder(Device device);
 
-      virtual void set_vocabulary_mask(const StorageView&) {}
-      virtual void reset_vocabulary_mask() {}
       virtual DecoderState initial_state(bool iterative_decoding = true) const = 0;
 
       // Forwards one step.
@@ -38,15 +36,37 @@ namespace ctranslate2 {
       // Gathers states based on indices.
       void gather_state(DecoderState& state, const StorageView& indices) const;
 
+      // Restrict the output layer to a set of ids and/or resize it to a preferred size multiple.
+      // If the output layer is updated, the returned vector is not null and maps new indices
+      // to original indices.
+      const std::vector<size_t>*
+      update_output_layer(const dim_t size_multiple = 1,
+                          const std::vector<size_t>& include_ids = {},
+                          const std::vector<size_t>& exclude_ids = {});
+
       Device device() const;
+
+      DataType output_type() const override {
+        return const_cast<Decoder&>(*this).output_layer().output_type();
+      }
+
+      dim_t output_size() const override {
+        return const_cast<Decoder&>(*this).output_layer().output_size();
+      }
 
     protected:
       // Returns false if the state does not need to be reordered during beam search.
       virtual bool should_reorder_state(const std::string& name) const;
       // Returns the current batch size from the decoder state.
       virtual dim_t batch_size(const DecoderState& state) const;
+      // Returns the output linear layer.
+      virtual Dense& output_layer() = 0;
 
       const Device _device;
+
+    private:
+      std::vector<size_t> _output_layer_index;
+      dim_t _vocabulary_size = 0;
     };
 
   }

--- a/include/ctranslate2/layers/decoder.h
+++ b/include/ctranslate2/layers/decoder.h
@@ -37,6 +37,7 @@ namespace ctranslate2 {
       void gather_state(DecoderState& state, const StorageView& indices) const;
 
       // Restrict the output layer to a set of ids and/or resize it to a preferred size multiple.
+      // Elements in include_ids and exclude_ids must be unique and sorted.
       // If the output layer is updated, the returned vector is not null and maps new indices
       // to original indices.
       const std::vector<size_t>*

--- a/include/ctranslate2/layers/decoder.h
+++ b/include/ctranslate2/layers/decoder.h
@@ -67,6 +67,7 @@ namespace ctranslate2 {
 
     private:
       std::vector<size_t> _output_layer_index;
+      std::vector<size_t> _previous_exclude_ids;
       dim_t _vocabulary_size = 0;
     };
 

--- a/include/ctranslate2/layers/transformer.h
+++ b/include/ctranslate2/layers/transformer.h
@@ -152,8 +152,6 @@ namespace ctranslate2 {
                          const dim_t alignment_heads = 1,
                          const bool layernorm_embedding = false);
 
-      void set_vocabulary_mask(const StorageView& ids) override;
-      void reset_vocabulary_mask() override;
       DecoderState initial_state(bool iterative_decoding = true) const override;
 
       void operator()(dim_t step,
@@ -166,16 +164,12 @@ namespace ctranslate2 {
                       DecoderState& state,
                       StorageView& logits) override;
 
-      DataType output_type() const override {
-        return _proj.output_type();
-      }
-
-      dim_t output_size() const override {
-        return _proj.output_size();
-      }
-
     protected:
       bool should_reorder_state(const std::string& name) const override;
+
+      Dense& output_layer() override {
+        return _proj;
+      }
 
     private:
       void decode(const StorageView& ids,

--- a/include/ctranslate2/models/sequence_to_sequence.h
+++ b/include/ctranslate2/models/sequence_to_sequence.h
@@ -64,7 +64,7 @@ namespace ctranslate2 {
              const bool replace_unknowns = false,
              const bool normalize_scores = false,
              const float repetition_penalty = 1,
-             bool disable_unk = false) const;
+             const bool disable_unk = false) const;
 
     protected:
       virtual void initialize(ModelReader& model_reader) override;

--- a/src/decoding.cc
+++ b/src/decoding.cc
@@ -366,7 +366,6 @@ namespace ctranslate2 {
                      const Sampler& sampler,
                      const std::vector<size_t>& start_ids,
                      const size_t end_id,
-                     const size_t unk_id,
                      const dim_t start_step,
                      const dim_t max_length,
                      const dim_t min_length,
@@ -376,7 +375,6 @@ namespace ctranslate2 {
                      const bool return_attention,
                      const size_t num_hypotheses,
                      const float repetition_penalty,
-                     const bool disable_unk,
                      const std::vector<std::vector<size_t>>* prefix_ids) const {
     PROFILE("beam_search");
     const dim_t min_step = start_step + min_length;
@@ -454,8 +452,6 @@ namespace ctranslate2 {
       // Prevent the generation of end_id until the minimum length is reached.
       if (step < min_step)
         disable_token(log_probs, end_id);
-      if (disable_unk)
-        disable_token(log_probs, unk_id);
 
       // Multiply by the current beam log probs.
       if (topk_scores) {
@@ -615,7 +611,6 @@ namespace ctranslate2 {
                        const Sampler& sampler,
                        const std::vector<size_t>& start_ids,
                        const size_t end_id,
-                       const size_t unk_id,
                        const dim_t start_step,
                        const dim_t max_length,
                        const dim_t min_length,
@@ -625,7 +620,6 @@ namespace ctranslate2 {
                        const bool return_attention,
                        const size_t,
                        const float repetition_penalty,
-                       const bool disable_unk,
                        const std::vector<std::vector<size_t>>* prefix_ids) const {
     PROFILE("greedy_search");
     const dim_t min_step = start_step + min_length;
@@ -670,8 +664,6 @@ namespace ctranslate2 {
       // Prevent the generation of end_id until the minimum length is reached.
       if (step < min_step)
         disable_token(log_probs, end_id);
-      if (disable_unk)
-        disable_token(log_probs, unk_id);
 
       sampler(log_probs, best_ids, best_probs);
       if (output_ids_map)
@@ -822,7 +814,6 @@ namespace ctranslate2 {
          const std::vector<std::vector<size_t>>& start_tokens,
          const std::vector<size_t>* output_ids_map,
          const size_t end_id,
-         const size_t unk_id,
          dim_t max_length,
          dim_t min_length,
          const size_t num_hypotheses,
@@ -830,8 +821,7 @@ namespace ctranslate2 {
          const bool return_scores,
          const bool return_attention,
          const bool normalize_scores,
-         const float repetition_penalty,
-         const bool disable_unk) {
+         const float repetition_penalty) {
     const size_t batch_size = start_tokens.size();
 
     if (return_alternatives && batch_size > 1) {
@@ -847,7 +837,6 @@ namespace ctranslate2 {
                                     {start_tokens[i]},
                                     output_ids_map,
                                     end_id,
-                                    unk_id,
                                     max_length,
                                     min_length,
                                     num_hypotheses,
@@ -855,8 +844,7 @@ namespace ctranslate2 {
                                     return_scores,
                                     return_attention,
                                     normalize_scores,
-                                    repetition_penalty,
-                                    disable_unk)[0]);
+                                    repetition_penalty)[0]);
       }
       return results;
     }
@@ -893,7 +881,6 @@ namespace ctranslate2 {
                                                             BestSampler(),
                                                             start_ids,
                                                             end_id,
-                                                            unk_id,
                                                             start_step,
                                                             /*max_length=*/1,
                                                             /*min_length=*/1,
@@ -902,8 +889,7 @@ namespace ctranslate2 {
                                                             return_scores,
                                                             return_attention,
                                                             num_hypotheses,
-                                                            /*repetition_penalty=*/1,
-                                                            disable_unk);
+                                                            /*repetition_penalty=*/1);
 
       start_ids.resize(batch_size * num_hypotheses);
       for (size_t b = 0; b < batch_size; ++b) {
@@ -937,7 +923,6 @@ namespace ctranslate2 {
                                           sampler,
                                           start_ids,
                                           end_id,
-                                          unk_id,
                                           start_step,
                                           max_length,
                                           min_length,
@@ -947,7 +932,6 @@ namespace ctranslate2 {
                                           return_attention,
                                           return_alternatives ? 1 : num_hypotheses,
                                           repetition_penalty,
-                                          disable_unk,
                                           return_alternatives ? nullptr : &prefix_ids);
 
     if (return_alternatives) {

--- a/src/layers/decoder.cc
+++ b/src/layers/decoder.cc
@@ -1,5 +1,8 @@
 #include "ctranslate2/layers/decoder.h"
 
+#include <algorithm>
+#include <numeric>
+
 #include "ctranslate2/ops/ops.h"
 
 namespace ctranslate2 {
@@ -50,6 +53,69 @@ namespace ctranslate2 {
 
     Device Decoder::device() const {
       return _device;
+    }
+
+    const std::vector<size_t>*
+    Decoder::update_output_layer(const dim_t size_multiple,
+                                 const std::vector<size_t>& include_ids,
+                                 const std::vector<size_t>& exclude_ids) {
+      const dim_t current_output_size = output_size();
+
+      if (_vocabulary_size == 0)
+        _vocabulary_size = current_output_size;
+
+      std::vector<size_t> ids;
+
+      if (!include_ids.empty()) {
+        ids = include_ids;
+
+      } else {
+        dim_t target_output_size = _vocabulary_size - exclude_ids.size();
+        if (target_output_size % size_multiple != 0)
+          target_output_size += size_multiple - (target_output_size % size_multiple);
+
+        // Do not update the layer if the output size is unchanged.
+        // If the output layer is already updated, we assume the excluded ids
+        // and size multiple were the same in previous calls.
+        if (target_output_size == current_output_size)
+          return _output_layer_index.empty() ? nullptr : &_output_layer_index;
+
+        // Reset the output layer if the output size is the vocabulary size.
+        if (target_output_size == _vocabulary_size && exclude_ids.empty()) {
+          output_layer().select_weights(nullptr);
+          _output_layer_index.clear();
+          return nullptr;
+        }
+
+        ids.reserve(target_output_size);
+        ids.resize(_vocabulary_size);
+        std::iota(ids.begin(), ids.end(), size_t(0));
+      }
+
+      if (!exclude_ids.empty()) {
+        ids.erase(
+          std::remove_if(ids.begin(), ids.end(), [&exclude_ids](size_t id) {
+            return std::find(exclude_ids.begin(), exclude_ids.end(), id) != exclude_ids.end();
+          }),
+          ids.end());
+      }
+
+      // Pad size to the next multiple.
+      while (ids.size() % size_multiple != 0)
+        ids.push_back(0);
+
+      const dim_t output_size = ids.size();
+
+      // Select weights.
+      StorageView index({output_size}, DataType::INT32);
+      for (dim_t i = 0; i < output_size; ++i)
+        index.at<int32_t>(i) = ids[i];
+      if (index.device() != _device)
+        index = index.to(_device);
+      output_layer().select_weights(&index);
+
+      _output_layer_index = std::move(ids);
+      return &_output_layer_index;
     }
 
   }

--- a/src/layers/decoder.cc
+++ b/src/layers/decoder.cc
@@ -64,12 +64,9 @@ namespace ctranslate2 {
       if (_vocabulary_size == 0)
         _vocabulary_size = current_output_size;
 
-      std::vector<size_t> ids;
+      std::vector<size_t> ids = include_ids;
 
-      if (!include_ids.empty()) {
-        ids = include_ids;
-
-      } else {
+      if (ids.empty()) {
         dim_t target_output_size = _vocabulary_size - exclude_ids.size();
         if (target_output_size % size_multiple != 0)
           target_output_size += size_multiple - (target_output_size % size_multiple);

--- a/src/layers/decoder.cc
+++ b/src/layers/decoder.cc
@@ -92,12 +92,10 @@ namespace ctranslate2 {
         std::iota(ids.begin(), ids.end(), size_t(0));
       }
 
-      if (!exclude_ids.empty()) {
-        ids.erase(
-          std::remove_if(ids.begin(), ids.end(), [&exclude_ids](size_t id) {
-            return std::find(exclude_ids.begin(), exclude_ids.end(), id) != exclude_ids.end();
-          }),
-          ids.end());
+      for (const size_t exclude_id : exclude_ids) {
+        const auto it = std::lower_bound(ids.begin(), ids.end(), exclude_id);
+        if (it != ids.end() && *it == exclude_id)
+          ids.erase(it);
       }
 
       // Pad size to the next multiple.

--- a/src/layers/decoder.cc
+++ b/src/layers/decoder.cc
@@ -75,15 +75,14 @@ namespace ctranslate2 {
           target_output_size += size_multiple - (target_output_size % size_multiple);
 
         // Do not update the layer if the output size is unchanged.
-        // If the output layer is already updated, we assume the excluded ids
-        // and size multiple were the same in previous calls.
-        if (target_output_size == current_output_size)
+        if (target_output_size == current_output_size && exclude_ids == _previous_exclude_ids)
           return _output_layer_index.empty() ? nullptr : &_output_layer_index;
 
         // Reset the output layer if the output size is the vocabulary size.
         if (target_output_size == _vocabulary_size && exclude_ids.empty()) {
           output_layer().select_weights(nullptr);
           _output_layer_index.clear();
+          _previous_exclude_ids.clear();
           return nullptr;
         }
 
@@ -113,6 +112,7 @@ namespace ctranslate2 {
       output_layer().select_weights(&index);
 
       _output_layer_index = std::move(ids);
+      _previous_exclude_ids = exclude_ids;
       return &_output_layer_index;
     }
 

--- a/src/layers/transformer.cc
+++ b/src/layers/transformer.cc
@@ -280,14 +280,6 @@ namespace ctranslate2 {
       _alignment_heads = (alignment_heads == 0 ? _num_heads : alignment_heads);
     }
 
-    void TransformerDecoder::set_vocabulary_mask(const StorageView& ids) {
-      _proj.mask_weights(ids);
-    }
-
-    void TransformerDecoder::reset_vocabulary_mask() {
-      _proj.reset_mask();
-    }
-
     DecoderState TransformerDecoder::initial_state(bool iterative_decoding) const {
       DecoderState state;
       if (iterative_decoding) {

--- a/tests/model_test.cc
+++ b/tests/model_test.cc
@@ -26,6 +26,10 @@ TEST(ModelTest, UpdateDecoderOutputLayer) {
   EXPECT_NE(decoder->update_output_layer(43, {}, {1}), nullptr);
   EXPECT_EQ(decoder->output_size(), 43);
 
+  // Reset output layer.
+  EXPECT_EQ(decoder->update_output_layer(), nullptr);
+  EXPECT_EQ(decoder->output_size(), 43);
+
   // Restrict to {0, 1, 2, 5} - {1} and pad to a multiple of 5.
   EXPECT_EQ(*decoder->update_output_layer(5, {0, 1, 2, 5}, {1}),
             (std::vector<size_t>{0, 2, 5, 0, 0}));

--- a/tests/model_test.cc
+++ b/tests/model_test.cc
@@ -1,7 +1,37 @@
-#include <ctranslate2/models/model.h>
+#include <ctranslate2/models/sequence_to_sequence.h>
 
 #include "test_utils.h"
 
 TEST(ModelTest, ContainsModel) {
   ASSERT_TRUE(models::contains_model(default_model_dir()));
+}
+
+TEST(ModelTest, UpdateDecoderOutputLayer) {
+  auto base_model = models::Model::load(default_model_dir());
+  auto model = std::dynamic_pointer_cast<const models::SequenceToSequenceModel>(base_model);
+  auto decoder = model->make_decoder();
+
+  EXPECT_EQ(decoder->update_output_layer(), nullptr);
+  EXPECT_EQ(decoder->output_size(), 43);
+
+  // Pad to a multiple of 5.
+  EXPECT_NE(decoder->update_output_layer(5), nullptr);
+  EXPECT_EQ(decoder->output_size(), 45);
+
+  // Exclude index 1 and pad to a multiple of 2.
+  EXPECT_NE(decoder->update_output_layer(2, {}, {1}), nullptr);
+  EXPECT_EQ(decoder->output_size(), 42);
+
+  // Exclude index 1 and pad to a multiple of 43.
+  EXPECT_NE(decoder->update_output_layer(43, {}, {1}), nullptr);
+  EXPECT_EQ(decoder->output_size(), 43);
+
+  // Restrict to {0, 1, 2, 5} - {1} and pad to a multiple of 5.
+  EXPECT_EQ(*decoder->update_output_layer(5, {0, 1, 2, 5}, {1}),
+            (std::vector<size_t>{0, 2, 5, 0, 0}));
+  EXPECT_EQ(decoder->output_size(), 5);
+
+  // Remove restriction.
+  EXPECT_EQ(decoder->update_output_layer(), nullptr);
+  EXPECT_EQ(decoder->output_size(), 43);
 }


### PR DESCRIPTION
The output layer can be updated in some cases:

1. padded to a multiple of 8 to enable Tensor Cores (`compute_type=float16`)
2. sliced to prevent the generation of some tokens (`disable_unk`)
3. sliced to restrict the generation to some tokens (`use_vmap`)

For 1. and 2., we can apply the transformation once and reuse the updated layer in future calls.