### PR TITLE
Build ARM64 wheels for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,8 @@ jobs:
         include:
         - os: ubuntu-20.04
           arch: aarch64
+        - os: macos-10.15
+          arch: arm64
 
     steps:
       - uses: actions/checkout@v2
@@ -190,6 +192,7 @@ jobs:
         env:
           CIBW_ENVIRONMENT_PASS_LINUX: CIBW_ARCHS
           CIBW_ENVIRONMENT_WINDOWS: CTRANSLATE2_ROOT='${{ github.workspace }}\install'
+          CIBW_ENVIRONMENT_MACOS: CTRANSLATE2_ROOT='/usr/local'
           CIBW_BEFORE_ALL_LINUX: python/tools/prepare_build_environment_linux.sh
           CIBW_BEFORE_ALL_MACOS: python/tools/prepare_build_environment_macos.sh
           CIBW_BEFORE_ALL_WINDOWS: bash python/tools/prepare_build_environment_windows.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,11 @@ macro(ct2_compile_kernels_for_isa isa flag)
   list(APPEND SOURCES ${CMAKE_CURRENT_BINARY_DIR}/kernels_${isa}.cc)
 endmacro()
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(amd64)|(AMD64)")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(arm64)|(aarch64)"
+    OR (APPLE AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64"))
+  add_definitions(-DCT2_ARM64_BUILD)
+  set(CT2_BUILD_ARCH "arm64")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(amd64)|(AMD64)")
   add_definitions(-DCT2_X86_BUILD)
   set(CT2_BUILD_ARCH "x86_64")
 
@@ -174,9 +178,6 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(amd64)|(AMD64)")
   add_subdirectory(third_party/cpu_features EXCLUDE_FROM_ALL)
   set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
   list(APPEND LIBRARIES cpu_features)
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(arm64)|(aarch64)")
-  add_definitions(-DCT2_ARM64_BUILD)
-  set(CT2_BUILD_ARCH "arm64")
 endif()
 
 if(ENABLE_CPU_DISPATCH)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The project is production-oriented and comes with [backward compatibility guaran
 
 * **Fast and efficient execution on CPU and GPU**<br/>The execution [is significantly faster and requires less resources](#benchmarks) than general-purpose deep learning frameworks on supported models and tasks thanks to many advanced optimizations: padding removal, batch reordering, in-place operations, caching mechanism, etc.
 * **Quantization and reduced precision**<br/>The model serialization and computation support weights with [reduced precision](docs/quantization.md): 16-bit floating points (FP16), 16-bit integers (INT16), and 8-bit integers (INT8).
-* **Multiple CPU architectures support**<br/>The project supports x86-64 and AArch64 processors and integrates multiple backends that are optimized for these platforms: [Intel MKL](https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html), [oneDNN](https://github.com/oneapi-src/oneDNN), [OpenBLAS](https://www.openblas.net/), [Ruy](https://github.com/google/ruy), and [Apple Accelerate](https://developer.apple.com/documentation/accelerate).
+* **Multiple CPU architectures support**<br/>The project supports x86-64 and AArch64/ARM64 processors and integrates multiple backends that are optimized for these platforms: [Intel MKL](https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html), [oneDNN](https://github.com/oneapi-src/oneDNN), [OpenBLAS](https://www.openblas.net/), [Ruy](https://github.com/google/ruy), and [Apple Accelerate](https://developer.apple.com/documentation/accelerate).
 * **Automatic CPU detection and code dispatch**<br/>One binary can include multiple backends (e.g. Intel MKL and oneDNN) and instruction set architectures (e.g. AVX, AVX2) that are automatically selected at runtime based on the CPU information.
 * **Parallel and asynchronous translations**<br/>Translations can be run efficiently in parallel and asynchronously using multiple GPUs or CPU cores.
 * **Dynamic memory usage**<br/>The memory usage changes dynamically depending on the request size while still meeting performance requirements thanks to caching allocators on both CPU and GPU.
@@ -147,7 +147,7 @@ pip install ctranslate2
 
 **Requirements:**
 
-* OS: Linux (x86-64, AArch64), macOS (x86-64), Windows (x86-64)
+* OS: Linux (x86-64, AArch64), macOS (x86-64, ARM64), Windows (x86-64)
 * Python version: >= 3.6
 * pip version: >= 19.3
 
@@ -558,7 +558,7 @@ However, you should probably **not** use this project when:
 **CPU**
 
 * x86-64 processors supporting at least SSE 4.1
-* AArch64 processors
+* AArch64/ARM64 processors
 
 On x86-64, prebuilt binaries are configured to automatically select the best backend and instruction set architecture for the platform (AVX, AVX2, or AVX512). In particular, they are compiled with both [Intel MKL](https://software.intel.com/en-us/mkl) and [oneDNN](https://github.com/oneapi-src/oneDNN) so that Intel MKL is only used on Intel processors where it performs best, whereas oneDNN is used on other x86-64 processors such as AMD.
 

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -53,7 +53,8 @@ By default, the runtime tries to use the type that is saved in the converted mod
 | --- | --- | --- | --- | --- |
 | x86-64 (Intel) | int8 | int8 | int16 | float |
 | x86-64 (other) | int8 | int8 | int8 | float |
-| AArch64 | int8 | int8 | int8 | float |
+| AArch64/ARM64 (Apple) | float | float | float | float |
+| AArch64/ARM64 (other) | int8 | int8 | int8 | float |
 
 **On GPU:**
 
@@ -74,7 +75,7 @@ You can get more information about the detected capabilities of your system by s
 
 * NVIDIA GPU with Compute Capability >= 7.0 or Compute Capability 6.1
 * x86-64 CPU with the Intel MKL or oneDNN backends
-* AArch64 CPU with the Ruy backend
+* AArch64/ARM64 CPU with the Ruy backend
 
 The implementation applies the equation from [Wu et al. 2016](https://arxiv.org/abs/1609.08144) to compute the quantized weights:
 

--- a/python/tools/prepare_build_environment_macos.sh
+++ b/python/tools/prepare_build_environment_macos.sh
@@ -3,22 +3,34 @@
 set -e
 set -x
 
-# Install OneAPI MKL
-# See https://github.com/oneapi-src/oneapi-ci for installer URLs
-ONEAPI_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18342/m_BaseKit_p_2022.1.0.92_offline.dmg
-wget -q $ONEAPI_INSTALLER_URL
-hdiutil attach -noverify -noautofsck $(basename $ONEAPI_INSTALLER_URL)
-sudo /Volumes/$(basename $ONEAPI_INSTALLER_URL .dmg)/bootstrapper.app/Contents/MacOS/bootstrapper --silent --eula accept --components intel.oneapi.mac.mkl.devel
-
-# Install LLVM's libomp because Intel's OpenMP runtime included in MKL does
-# not ship with the header file.
-brew install libomp
-
 pip install "cmake==3.18.4"
 
 mkdir build-release && cd build-release
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_CLI=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_CXX_FLAGS="-Wno-unused-command-line-argument" ..
-make -j$(sysctl -n hw.physicalcpu_max) install
+
+CMAKE_COMMON_OPTIONS='-DCMAKE_BUILD_TYPE=Release -DBUILD_CLI=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_CXX_FLAGS="-Wno-unused-command-line-argument"'
+
+if [ "$CIBW_ARCHS" == "arm64" ]; then
+
+    cmake $CMAKE_COMMON_OPTIONS -DCMAKE_OSX_ARCHITECTURES="arm64" -DWITH_ACCELERATE=ON -DWITH_MKL=OFF -DOPENMP_RUNTIME=NONE  ..
+
+else
+
+    # Install OneAPI MKL
+    # See https://github.com/oneapi-src/oneapi-ci for installer URLs
+    ONEAPI_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18342/m_BaseKit_p_2022.1.0.92_offline.dmg
+    wget -q $ONEAPI_INSTALLER_URL
+    hdiutil attach -noverify -noautofsck $(basename $ONEAPI_INSTALLER_URL)
+    sudo /Volumes/$(basename $ONEAPI_INSTALLER_URL .dmg)/bootstrapper.app/Contents/MacOS/bootstrapper --silent --eula accept --components intel.oneapi.mac.mkl.devel
+
+    # Install LLVM's libomp because Intel's OpenMP runtime included in MKL does
+    # not ship with the header file.
+    brew install libomp
+
+    cmake $CMAKE_COMMON_OPTIONS ..
+
+fi
+
+VERBOSE=1 make -j$(sysctl -n hw.physicalcpu_max) install
 cd ..
 rm -r build-release
 

--- a/python/tools/prepare_build_environment_macos.sh
+++ b/python/tools/prepare_build_environment_macos.sh
@@ -7,11 +7,11 @@ pip install "cmake==3.18.4"
 
 mkdir build-release && cd build-release
 
-CMAKE_COMMON_OPTIONS='-DCMAKE_BUILD_TYPE=Release -DBUILD_CLI=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_CXX_FLAGS="-Wno-unused-command-line-argument"'
+CMAKE_EXTRA_OPTIONS=''
 
 if [ "$CIBW_ARCHS" == "arm64" ]; then
 
-    cmake $CMAKE_COMMON_OPTIONS -DCMAKE_OSX_ARCHITECTURES="arm64" -DWITH_ACCELERATE=ON -DWITH_MKL=OFF -DOPENMP_RUNTIME=NONE  ..
+    CMAKE_EXTRA_OPTIONS='-DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_ACCELERATE=ON -DWITH_MKL=OFF -DOPENMP_RUNTIME=NONE'
 
 else
 
@@ -26,10 +26,9 @@ else
     # not ship with the header file.
     brew install libomp
 
-    cmake $CMAKE_COMMON_OPTIONS ..
-
 fi
 
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_CLI=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_CXX_FLAGS="-Wno-unused-command-line-argument" $CMAKE_EXTRA_OPTIONS ..
 VERBOSE=1 make -j$(sysctl -n hw.physicalcpu_max) install
 cd ..
 rm -r build-release

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -102,13 +102,17 @@ namespace ctranslate2 {
     if (num_threads == 0)
       num_threads = read_int_from_env("OMP_NUM_THREADS", get_default_num_threads());
     omp_set_num_threads(num_threads);
-#else
-    (void)num_threads;
 #endif
+
 #ifdef CT2_WITH_RUY
     if (num_threads == 0)
       num_threads = get_default_num_threads();
     cpu::get_ruy_context()->set_max_num_threads(num_threads);
+#endif
+
+#if !defined(_OPENMP) && !defined(CT2_WITH_RUY)
+    if (num_threads > 0)
+      spdlog::warn("The number of threads (intra_threads) is ignored in this build");
 #endif
   }
 


### PR DESCRIPTION
The wheels are using the Apple Accelerate backend which does not support quantization but should be the most efficient on Apple M1. See some numbers in this PR https://github.com/OpenNMT/CTranslate2/pull/558.

Closes #724.