### PR TITLE
Add `multilingual_transformer_iwslt_de_en` to supported fairseq archs

### DIFF
--- a/python/ctranslate2/converters/fairseq.py
+++ b/python/ctranslate2/converters/fairseq.py
@@ -23,6 +23,7 @@ _SUPPORTED_ARCHS = {
     "transformer_wmt_en_de_big",
     "transformer_wmt_en_de_big_align",
     "transformer_wmt_en_de_big_t2t",
+    "multilingual_transformer_iwslt_de_en",
 }
 
 


### PR DESCRIPTION
Like the title says, adds `multilingual_transformer_iwslt_de_en` to the supported fairseq architectures, which is the same as `transformer_iwslt_de_en` but with added arguments for sharing encoders / decoders : https://github.com/pytorch/fairseq/blob/main/fairseq/models/multilingual_transformer.py#L25

I've been using this without issues for my `multilingual_transformer_iwslt_de_en` model: converting the fairseq model through `ct2-fairseq-converter`, then using `ctranslate2.Translator` with the converted model.
