### PR TITLE
Support conversion of custom Fairseq architectures

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -26,6 +26,7 @@ converter = ctranslate2.converters.FairseqConverter(
     target_lang: str = None,      # Target language (may be required if not declared in the model).
     fixed_dictionary: str = None, # Path to the fixed dictionary for multilingual models.
     no_default_special_tokens: bool = False,  # Require all special tokens to be provided by the user.
+    user_dir: str = None,         # Path to the user module containing custom extensions.
 )
 
 converter = ctranslate2.converters.MarianConverter(


### PR DESCRIPTION
* Add conversion option `--user_dir` to configure the directory containing the user module
* Check the base model name instead of the architecture name

Closes #781.