### PR TITLE
MarianMTLoader: default to normalize_before = False

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -235,6 +235,11 @@ class MarianMTLoader(BartLoader):
     def architecture_name(self):
         return "MarianMTModel"
 
+    def get_model_spec(self, model):
+        model.config.normalize_before = False
+        model.config.normalize_embedding = False
+        return super().get_model_spec(model)
+
     def set_decoder(self, spec, decoder):
         spec.start_from_zero_embedding = True
         super().set_decoder(spec, decoder)


### PR DESCRIPTION
Fixes https://github.com/OpenNMT/CTranslate2/issues/803

Can confirm that `ct2-transformers-converter --model Wikidepia/marian-nmt-enid --output_dir ctranslate2-enid` ran without errors with this patch applied, and produces a working translation model.

