### PR TITLE
Improve API reference generated from the pybind11 module

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import sys
 
@@ -33,14 +34,54 @@ html_favicon = "_static/favicon.png"
 autodoc_member_order = "groupwise"
 autodoc_typehints_format = "short"
 autodoc_class_signature = "separated"
-autodoc_default_options = {
-    "exclude-members": "__new__",
-}
 
 autosectionlabel_prefix_document = True
 
 napoleon_include_init_with_doc = True
 napoleon_include_special_with_doc = True
 
+
+def fix_pybind11_signatures(
+    app, what, name, obj, options, signature, return_annotation
+):
+    def _remove_self(signature):
+        arguments = signature[1:-1].split(", ")
+        if arguments and arguments[0].startswith("self:"):
+            arguments.pop(0)
+        return "(%s)" % ", ".join(arguments)
+
+    def _hide_internal_module(content):
+        return content.replace("ctranslate2.translator", "ctranslate2")
+
+    if signature is not None:
+        signature = _remove_self(signature)
+        signature = _hide_internal_module(signature)
+
+    if return_annotation is not None:
+        return_annotation = _hide_internal_module(return_annotation)
+
+    return (signature, return_annotation)
+
+
+def skip_pybind11_builtin_members(app, what, name, obj, skip, options):
+    skipped_entries = {
+        "__init__": ["self", "args", "kwargs"],
+        "__new__": ["args", "kwargs"],
+    }
+
+    ref_arguments = skipped_entries.get(name)
+    if ref_arguments is not None:
+        try:
+            arguments = list(inspect.signature(obj).parameters.keys())
+            if arguments == ref_arguments:
+                return True
+        except ValueError:
+            pass
+
+    return None
+
+
 def setup(app):
     app.add_css_file("custom.css")
+    app.connect("autodoc-skip-member", skip_pybind11_builtin_members)
+    app.connect("autodoc-process-signature", fix_pybind11_signatures)


### PR DESCRIPTION
* Remove `self` in method signature
* Hide internal module `.translator` in type information
* Remove builtin members `__new__` and `__init__`