### PR TITLE
Keep verbose mode enabled for Transformers' tokenizer

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -76,9 +76,7 @@ class ModelLoader(abc.ABC):
 
         model_class = getattr(transformers, self.architecture_name)
         model = model_class.from_pretrained(model_name_or_path)
-        tokenizer = transformers.AutoTokenizer.from_pretrained(
-            model_name_or_path, verbose=False
-        )
+        tokenizer = transformers.AutoTokenizer.from_pretrained(model_name_or_path)
 
         spec = self.get_model_spec(model)
 


### PR DESCRIPTION
Properties of unset special tokens are incorrect when the verbose mode is disabled. See https://github.com/huggingface/transformers/issues/17796.