### PR TITLE
Pin PyTorch version for the macOS Python tests

### DIFF
--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -1,4 +1,5 @@
 transformers==4.20.1;platform_system=='Linux'
+torch==1.11.*;platform_system=='Darwin'
 fairseq==0.10.2;platform_system=='Linux' or platform_system=='Darwin'
 OpenNMT-py==2.2.*;platform_system=='Linux' or platform_system=='Darwin'
 OpenNMT-tf[tensorflow]==2.22.*


### PR DESCRIPTION
It seems the Fairseq conversion tests get stuck with PyTorch 1.12.