### PR TITLE
Remove unnecessary libomp installation command on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,6 @@ jobs:
           wget -q $ONEAPI_INSTALLER_URL
           hdiutil attach -noverify -noautofsck $(basename $ONEAPI_INSTALLER_URL)
 
-      - name: Install libomp
-        if: startsWith(matrix.os, 'macos')
-        run: brew install libomp
-
       - name: Configure with MKL
         if: startsWith(matrix.os, 'ubuntu') && matrix.backend == 'mkl'
         run: |

--- a/python/tools/prepare_build_environment_macos.sh
+++ b/python/tools/prepare_build_environment_macos.sh
@@ -22,10 +22,6 @@ else
     hdiutil attach -noverify -noautofsck $(basename $ONEAPI_INSTALLER_URL)
     sudo /Volumes/$(basename $ONEAPI_INSTALLER_URL .dmg)/bootstrapper.app/Contents/MacOS/bootstrapper --silent --eula accept --components intel.oneapi.mac.mkl.devel
 
-    # Install LLVM's libomp because Intel's OpenMP runtime included in MKL does
-    # not ship with the header file.
-    brew install libomp
-
 fi
 
 cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_CLI=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_CXX_FLAGS="-Wno-unused-command-line-argument" $CMAKE_EXTRA_OPTIONS ..


### PR DESCRIPTION
The library is already installed on the GitHub runner.