### PR TITLE
Fix asynchronous result state when a runtime exception is raised

### DIFF
--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -287,6 +287,22 @@ def test_invalid_translation_options():
         )
 
 
+def test_invalid_translation_options_async():
+    translator = _get_transliterator()
+    outputs = translator.translate_batch(
+        [["آ", "ت", "ز", "م", "و", "ن"]],
+        min_decoding_length=10,
+        max_decoding_length=5,
+        asynchronous=True,
+    )
+
+    # All calls to result() should raise the exception.
+    for _ in range(2):
+        with pytest.raises(ValueError, match="is greater than"):
+            outputs[0].result()
+        assert outputs[0].done()
+
+
 def test_hard_target_prefix():
     translator = _get_transliterator()
     output = translator.translate_batch(

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -646,7 +646,13 @@ get_supported_compute_types(const std::string& device_str, const int device_inde
 template <typename T>
 static void declare_async_wrapper(py::module& m, const char* name) {
   py::class_<AsyncResult<T>>(m, name, "Asynchronous wrapper around a result object.")
-    .def("result", &AsyncResult<T>::result, "Blocks until the result is available and returns it.")
+    .def("result", &AsyncResult<T>::result,
+         R"pbdoc(
+             Blocks until the result is available and returns it.
+
+             If an exception was raised when computing the result,
+             this method raises the exception.
+         )pbdoc")
     .def("done", &AsyncResult<T>::done, "Returns ``True`` if the result is available.")
     ;
 }

--- a/python/translator.cc
+++ b/python/translator.cc
@@ -112,10 +112,16 @@ public:
     if (!_done) {
       {
         py::gil_scoped_release release;
-        _result = _future.get();
+        try {
+          _result = _future.get();
+        } catch (...) {
+          _exception = std::current_exception();
+        }
       }
       _done = true;  // Assign done attribute while the GIL is held.
     }
+    if (_exception)
+      std::rethrow_exception(_exception);
     return _result;
   }
 
@@ -128,6 +134,7 @@ private:
   std::future<T> _future;
   T _result;
   bool _done = false;
+  std::exception_ptr _exception;
 };
 
 


### PR DESCRIPTION
The exception should be catched in the wrapper and raised in all subsequent calls to `result()`.