### PR TITLE
Fix missing processing of linear weights in language models

### DIFF
--- a/include/ctranslate2/models/model.h
+++ b/include/ctranslate2/models/model.h
@@ -118,7 +118,7 @@ namespace ctranslate2 {
       virtual void remove_variable(const std::string& name);
 
       // Runs some initialization after the model is loaded.
-      virtual void initialize(ModelReader& model_reader);
+      virtual void initialize(ModelReader&) {}
 
     private:
       void process_linear_weights();

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -354,10 +354,6 @@ namespace ctranslate2 {
       }
     }
 
-    void Model::initialize(ModelReader&) {
-      process_linear_weights();
-    }
-
     // This method runs some precomputations on linear weights when possible.
     void Model::process_linear_weights() {
       if (_device != Device::CPU)
@@ -559,6 +555,7 @@ namespace ctranslate2 {
 
       // Run additional model initialization.
       const ScopedDeviceSetter scoped_device_setter(device, device_index);
+      model->process_linear_weights();
       model->initialize(model_reader);
       return model;
     }

--- a/src/models/sequence_to_sequence.cc
+++ b/src/models/sequence_to_sequence.cc
@@ -63,7 +63,6 @@ namespace ctranslate2 {
     }
 
     void SequenceToSequenceModel::initialize(ModelReader& model_reader) {
-      Model::initialize(model_reader);
       load_vocabularies(model_reader);
       _with_source_bos = get_flag_with_default("with_source_bos", false);
       _with_source_eos = get_flag_with_default("with_source_eos", false);


### PR DESCRIPTION
This processing can pre-compute a compensation term for INT8 GEMM on CPU. However, language models did not call this function so the compensation term was recomputed in each GEMM call.