### PR TITLE
Add missing -fvisibility=hidden flag when compiling the Python module

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -39,7 +39,7 @@ def _maybe_add_library_root(lib_name):
 
 _maybe_add_library_root("CTRANSLATE2")
 
-cflags = ["-std=c++17"]
+cflags = ["-std=c++17", "-fvisibility=hidden"]
 ldflags = []
 package_data = {}
 if sys.platform == "darwin":


### PR DESCRIPTION
https://pybind11.readthedocs.io/en/stable/faq.html#someclass-declared-with-greater-visibility-than-the-type-of-its-field-someclass-member-wattributes