### PR TITLE
Expose StorageView in the Python module

### DIFF
--- a/include/ctranslate2/storage_view.h
+++ b/include/ctranslate2/storage_view.h
@@ -222,6 +222,7 @@ namespace ctranslate2 {
 
     template <typename T>
     StorageView& view(T* data, Shape shape);
+    StorageView& view(void* data, Shape shape);
 
     template <typename T>
     StorageView& fill(T value);

--- a/python/cpp/module.cc
+++ b/python/cpp/module.cc
@@ -60,6 +60,7 @@ PYBIND11_MODULE(_ext, m)
   m.def("set_random_seed", &ctranslate2::set_random_seed, py::arg("seed"),
         "Sets the seed of random generators.");
 
+  ctranslate2::python::register_storage_view(m);
   ctranslate2::python::register_translation_stats(m);
   ctranslate2::python::register_translation_result(m);
   ctranslate2::python::register_scoring_result(m);

--- a/python/cpp/module.h
+++ b/python/cpp/module.h
@@ -10,6 +10,7 @@ namespace ctranslate2 {
     void register_generation_result(py::module& m);
     void register_generator(py::module& m);
     void register_scoring_result(py::module& m);
+    void register_storage_view(py::module& m);
     void register_translation_result(py::module& m);
     void register_translation_stats(py::module& m);
     void register_translator(py::module& m);

--- a/python/cpp/storage_view.cc
+++ b/python/cpp/storage_view.cc
@@ -1,0 +1,193 @@
+#include "module.h"
+
+#include <sstream>
+
+#include <ctranslate2/storage_view.h>
+
+#include "utils.h"
+
+using namespace pybind11::literals;
+
+namespace ctranslate2 {
+  namespace python {
+
+    static DataType typestr_to_dtype(const std::string& typestr) {
+      const auto type_code = typestr[1];
+      const auto num_bytes = typestr[2];
+
+      if (type_code == 'i') {
+        if (num_bytes == '1')
+          return DataType::INT8;
+        if (num_bytes == '2')
+          return DataType::INT16;
+        if (num_bytes == '4')
+          return DataType::INT32;
+
+      } else if (type_code == 'f') {
+        if (num_bytes == '2')
+          return DataType::FLOAT16;
+        if (num_bytes == '4')
+          return DataType::FLOAT;
+      }
+
+      throw std::invalid_argument("Unsupported type: " + typestr);
+    }
+
+    static std::string dtype_to_typestr(const DataType dtype) {
+      // Assume little-endian.
+
+      switch (dtype) {
+      case DataType::FLOAT:
+        return "<f4";
+      case DataType::FLOAT16:
+        return "<f2";
+      case DataType::INT8:
+        return "|i1";
+      case DataType::INT16:
+        return "<i2";
+      case DataType::INT32:
+        return "<i4";
+      default:
+        return "";
+      }
+    }
+
+    static StorageView create_view_from_array(py::object array) {
+      auto device = Device::CPU;
+
+      py::object interface_obj = py::getattr(array, "__array_interface__", py::none());
+      if (interface_obj.is_none()) {
+        interface_obj = py::getattr(array, "__cuda_array_interface__", py::none());
+        if (interface_obj.is_none())
+          throw std::invalid_argument("Object does not implement the array interface");
+        device = Device::CUDA;
+      }
+
+      py::dict interface = interface_obj.cast<py::dict>();
+      if (interface_obj.contains("strides") && !interface_obj["strides"].is_none())
+        throw std::invalid_argument("StorageView does not support arrays with non contiguous memory");
+
+      auto shape = interface["shape"].cast<Shape>();
+      auto dtype = typestr_to_dtype(interface["typestr"].cast<std::string>());
+      auto data = interface["data"].cast<py::tuple>();
+      auto ptr = data[0].cast<uintptr_t>();
+      auto read_only = data[1].cast<bool>();
+
+      if (read_only)
+        throw std::invalid_argument("StorageView does not support read-only arrays");
+
+      StorageView view(dtype, device);
+      view.view((void*)ptr, std::move(shape));
+      return view;
+    }
+
+    static py::dict get_array_interface(const StorageView& view) {
+      py::tuple shape(view.rank());
+      for (size_t i = 0; i < shape.size(); ++i)
+        shape[i] = view.dim(i);
+
+      return py::dict(
+        "shape"_a=shape,
+        "typestr"_a=dtype_to_typestr(view.dtype()),
+        "data"_a=py::make_tuple((uintptr_t)view.buffer(), false),
+        "version"_a=3);
+    }
+
+    class StorageViewWrapper {
+    public:
+      StorageViewWrapper(StorageView view)
+        : _data_owner(py::none())
+        , _view(std::move(view))
+      {
+      }
+
+      static StorageViewWrapper from_array(py::object array) {
+        StorageViewWrapper view = create_view_from_array(array);
+        view.set_data_owner(array);
+        return view;
+      }
+
+      StorageView& get_view() {
+        return _view;
+      }
+
+      const StorageView& get_view() const {
+        return _view;
+      }
+
+      void set_data_owner(py::object array) {
+        _data_owner = array;
+      }
+
+      py::dict array_interface() const {
+        if (_view.device() == Device::CUDA)
+          throw pybind11::attribute_error("Cannot get __array_interface__ when the StorageView "
+                                          "is viewing a CUDA array");
+        return get_array_interface(_view);
+      }
+
+      py::dict cuda_array_interface() const {
+        if (_view.device() == Device::CPU)
+          throw pybind11::attribute_error("Cannot get __cuda_array_interface__ when the StorageView "
+                                          "is viewing a CPU array");
+        return get_array_interface(_view);
+      }
+
+      std::string str() const {
+        std::ostringstream stream;
+        stream << _view;
+        return stream.str();
+      }
+
+    private:
+      py::object _data_owner;
+      StorageView _view;
+    };
+
+    void register_storage_view(py::module& m) {
+      py::class_<StorageViewWrapper>(
+        m, "StorageView",
+        R"pbdoc(
+            An allocated buffer with shape information.
+
+            The object implements the
+            `Array Interface <https://numpy.org/doc/stable/reference/arrays.interface.html>`_
+            and the
+            `CUDA Array Interface <https://numba.readthedocs.io/en/stable/cuda/cuda_array_interface.html>`_
+            so that it can be passed to Numpy or PyTorch without copy.
+
+            Example:
+
+                >>> x = np.ones((2, 4), dtype=np.int32)
+                >>> y = ctranslate2.StorageView.from_array(x)
+                >>> print(y)
+                 1 1 1 ... 1 1 1
+                [cpu:0 int32 storage viewed as 2x4]
+                >>> z = np.array(y)
+        )pbdoc")
+
+        .def_static("from_array", &StorageViewWrapper::from_array, py::arg("array"),
+                    R"pbdoc(
+                        Creates a ``StorageView`` from an object implementing the array interface.
+
+                        Arguments:
+                          array: An object implementing the array interface (e.g. a Numpy array
+                          or a PyTorch Tensor).
+
+                        Returns:
+                          A new ``StorageView`` instance sharing the same data as the input array.
+
+                        Raises:
+                          ValueError: if the object does not implement the array interface or
+                            uses an unsupported array specification.
+                    )pbdoc")
+
+        .def_property_readonly("__array_interface__", &StorageViewWrapper::array_interface)
+        .def_property_readonly("__cuda_array_interface__", &StorageViewWrapper::cuda_array_interface)
+
+        .def("__str__", &StorageViewWrapper::str)
+        ;
+    }
+
+  }
+}

--- a/python/cpp/storage_view.cc
+++ b/python/cpp/storage_view.cc
@@ -172,7 +172,7 @@ namespace ctranslate2 {
 
                         Arguments:
                           array: An object implementing the array interface (e.g. a Numpy array
-                          or a PyTorch Tensor).
+                            or a PyTorch Tensor).
 
                         Returns:
                           A new ``StorageView`` instance sharing the same data as the input array.

--- a/python/ctranslate2/__init__.py
+++ b/python/ctranslate2/__init__.py
@@ -24,6 +24,7 @@ try:
         GenerationResult,
         Generator,
         ScoringResult,
+        StorageView,
         TranslationResult,
         TranslationStats,
         Translator,

--- a/python/tests/test_spec.py
+++ b/python/tests/test_spec.py
@@ -1,15 +1,12 @@
 import numpy as np
 import pytest
+import test_utils
 
 import ctranslate2
 
 from ctranslate2.converters import utils as conversion_utils
 from ctranslate2.specs import common_spec, transformer_spec
 from ctranslate2.specs.model_spec import OPTIONAL, index_spec
-
-
-def _array_equal(a, b):
-    return a.dtype == b.dtype and np.array_equal(a, b)
 
 
 def test_layer_spec_validate():
@@ -34,8 +31,10 @@ def test_layer_spec_validate():
     assert spec.c.dtype == np.int32
     assert spec.d == OPTIONAL
     assert spec.e.a.dtype == np.float16
-    assert _array_equal(spec.f, np.int8(1))
-    assert _array_equal(spec.g, np.array([104, 101, 108, 108, 111], dtype=np.int8))
+    assert test_utils.array_equal(spec.f, np.int8(1))
+    assert test_utils.array_equal(
+        spec.g, np.array([104, 101, 108, 108, 111], dtype=np.int8)
+    )
 
     with pytest.raises(AttributeError, match="Attribute z does not exist"):
         spec.z = True
@@ -83,10 +82,12 @@ def test_int8_quantization():
 
     spec = Spec()
     spec.optimize(quantization="int8")
-    assert _array_equal(
+    assert test_utils.array_equal(
         spec.weight, np.array([[-127, -38, 64, 25], [0, 0, 0, 0]], dtype=np.int8)
     )
-    assert _array_equal(spec.weight_scale, np.array([12.7, 1], dtype=np.float32))
+    assert test_utils.array_equal(
+        spec.weight_scale, np.array([12.7, 1], dtype=np.float32)
+    )
 
 
 @pytest.mark.parametrize(
@@ -140,8 +141,8 @@ def test_fp16_weights(
     spec.validate()
     spec.optimize(quantization=quantization)
 
-    assert _array_equal(spec.weight, expected_weight)
-    assert _array_equal(spec.bias, expected_bias)
+    assert test_utils.array_equal(spec.weight, expected_weight)
+    assert test_utils.array_equal(spec.bias, expected_bias)
 
     # Check the weights were not copied or converted.
     if quantization == "float16":
@@ -153,7 +154,7 @@ def test_fp16_weights(
     if expected_weight_scale is None:
         assert spec.weight_scale == OPTIONAL
     else:
-        assert _array_equal(spec.weight_scale, expected_weight_scale)
+        assert test_utils.array_equal(spec.weight_scale, expected_weight_scale)
 
 
 def test_index_spec():
@@ -182,6 +183,6 @@ def test_fuse_linear_no_bias():
     spec = common_spec.LinearSpec()
     layers[1].bias = np.ones([64], dtype=np.float32)
     conversion_utils.fuse_linear(spec, layers)
-    assert _array_equal(spec.bias[:64], np.zeros([64], dtype=np.float32))
-    assert _array_equal(spec.bias[64:128], np.ones([64], dtype=np.float32))
-    assert _array_equal(spec.bias[128:], np.zeros([64], dtype=np.float32))
+    assert test_utils.array_equal(spec.bias[:64], np.zeros([64], dtype=np.float32))
+    assert test_utils.array_equal(spec.bias[64:128], np.ones([64], dtype=np.float32))
+    assert test_utils.array_equal(spec.bias[128:], np.zeros([64], dtype=np.float32))

--- a/python/tests/test_storage_view.py
+++ b/python/tests/test_storage_view.py
@@ -1,0 +1,88 @@
+import sys
+
+import numpy as np
+import pytest
+import test_utils
+import torch
+
+import ctranslate2
+
+
+def _assert_same_array(a, b):
+    assert a["shape"] == b["shape"]
+    assert a["data"] == b["data"]
+    assert a["typestr"] == b["typestr"]
+
+
+@pytest.mark.parametrize(
+    "dtype,name",
+    [
+        (np.int8, "int8"),
+        (np.int16, "int16"),
+        (np.int32, "int32"),
+        (np.float16, "float16"),
+        (np.float32, "float"),
+    ],
+)
+def test_storageview_cpu(dtype, name):
+    x = np.ones((2, 4), dtype=dtype)
+    s = ctranslate2.StorageView.from_array(x)
+
+    _assert_same_array(s.__array_interface__, x.__array_interface__)
+
+    with pytest.raises(AttributeError, match="CPU"):
+        s.__cuda_array_interface__
+
+    assert str(s) == " 1 1 1 ... 1 1 1\n[cpu:0 %s storage viewed as 2x4]" % name
+
+    x[0][2] = 3
+    x[1][3] = 8
+    assert str(s) == " 1 1 3 ... 1 1 8\n[cpu:0 %s storage viewed as 2x4]" % name
+
+    y = np.array(x)
+    assert test_utils.array_equal(x, y)
+
+
+@test_utils.require_cuda
+def test_storageview_cuda():
+    x = torch.ones((2, 4), device="cuda")
+    s = ctranslate2.StorageView.from_array(x)
+
+    _assert_same_array(s.__cuda_array_interface__, x.__cuda_array_interface__)
+
+    with pytest.raises(AttributeError, match="CUDA"):
+        s.__array_interface__
+
+    assert str(s) == " 1 1 1 ... 1 1 1\n[cuda:0 float storage viewed as 2x4]"
+
+    x[0][2] = 3
+    x[1][3] = 8
+    assert str(s) == " 1 1 3 ... 1 1 8\n[cuda:0 float storage viewed as 2x4]"
+
+    y = torch.as_tensor(s, device="cuda")
+    _assert_same_array(s.__cuda_array_interface__, y.__cuda_array_interface__)
+
+
+def test_storageview_strides():
+    x = np.ones((2, 4), dtype=np.float32)
+    x_t = x.transpose()
+    with pytest.raises(ValueError, match="contiguous"):
+        ctranslate2.StorageView.from_array(x_t)
+
+
+def test_storageview_readonly():
+    x = np.ones((2, 4), dtype=np.float32)
+    x.flags.writeable = False
+    with pytest.raises(ValueError, match="read-only"):
+        ctranslate2.StorageView.from_array(x)
+
+
+def test_storageview_reference():
+    x = np.ones((2, 4), dtype=np.float32)
+    refcount_before = sys.getrefcount(x)
+    s = ctranslate2.StorageView.from_array(x)
+    refcount_after = sys.getrefcount(x)
+    assert refcount_after == refcount_before + 1
+    del s
+    refcount_after_del = sys.getrefcount(x)
+    assert refcount_after_del == refcount_before

--- a/python/tests/test_storage_view.py
+++ b/python/tests/test_storage_view.py
@@ -3,7 +3,6 @@ import sys
 import numpy as np
 import pytest
 import test_utils
-import torch
 
 import ctranslate2
 
@@ -45,6 +44,8 @@ def test_storageview_cpu(dtype, name):
 
 @test_utils.require_cuda
 def test_storageview_cuda():
+    import torch
+
     x = torch.ones((2, 4), device="cuda")
     s = ctranslate2.StorageView.from_array(x)
 

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -1,7 +1,10 @@
 import os
 import sys
 
+import numpy as np
 import pytest
+
+import ctranslate2
 
 
 def get_data_dir():
@@ -24,10 +27,18 @@ def write_tokens(batch_tokens, path):
             f.write("\n")
 
 
+def array_equal(a, b):
+    return a.dtype == b.dtype and np.array_equal(a, b)
+
+
 skip_on_windows = pytest.mark.skipif(
     sys.platform == "win32", reason="Test case disabled on Windows"
 )
 
 only_on_linux = pytest.mark.skipif(
     sys.platform != "linux", reason="Test case only running on Linux"
+)
+
+require_cuda = pytest.mark.skipif(
+    ctranslate2.get_cuda_device_count() == 0, reason="Test case requires a CUDA device"
 )

--- a/src/storage_view.cc
+++ b/src/storage_view.cc
@@ -364,6 +364,11 @@ namespace ctranslate2 {
     return reshape(std::move(shape));
   }
 
+  StorageView& StorageView::view(void* data, Shape shape) {
+    TYPE_DISPATCH(_dtype, view(reinterpret_cast<T*>(data), std::move(shape)));
+    return *this;
+  }
+
   template <typename T>
   StorageView& StorageView::fill(T value) {
     DEVICE_DISPATCH(_device, primitives<D>::fill(data<T>(), value, _size));


### PR DESCRIPTION
This class implements the [Array Interface](https://numpy.org/doc/stable/reference/arrays.interface.html) and the [CUDA Array Interface](https://numba.readthedocs.io/en/stable/cuda/cuda_array_interface.html) which enable interoperability with other libraries like Numpy and PyTorch. Arrays can be passed to another library without copying the data.