### PR TITLE
Rename client translate to ct2-translator

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -4,17 +4,19 @@ if (NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/cxxopts/include
     "by calling \"git submodule update --init --recursive\"")
 endif()
 
-add_executable(translate
-  translate.cc
+add_executable(translator
+  translator.cc
   )
-target_include_directories(translate
+target_include_directories(translator
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/cxxopts/include
   )
-target_link_libraries(translate
+target_link_libraries(translator
   PRIVATE ${PROJECT_NAME}
-  )
+)
+
+set_target_properties(translator PROPERTIES OUTPUT_NAME ct2-translator)
 
 install(
-  TARGETS translate
+  TARGETS translator
   DESTINATION ${CMAKE_INSTALL_BINDIR}
   )

--- a/cli/translator.cc
+++ b/cli/translator.cc
@@ -10,7 +10,7 @@
 #include <ctranslate2/profiler.h>
 
 int main(int argc, char* argv[]) {
-  cxxopts::Options cmd_options("translate", "CTranslate2 translation client");
+  cxxopts::Options cmd_options("ct2-translator", "CTranslate2 translator client");
   cmd_options.custom_help("--model <directory> [OPTIONS]");
 
   cmd_options.add_options("General")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,4 +88,4 @@ COPY --from=builder $CTRANSLATE2_ROOT $CTRANSLATE2_ROOT
 RUN python3 -m pip --no-cache-dir install $CTRANSLATE2_ROOT/*.whl && \
     rm $CTRANSLATE2_ROOT/*.whl
 
-ENTRYPOINT ["/opt/ctranslate2/bin/translate"]
+ENTRYPOINT ["/opt/ctranslate2/bin/ct2-translator"]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,7 +32,7 @@ The images include:
 
 * the C++ library installed in `/opt/ctranslate2`
 * the Python module installed in the Python system packages
-* the translation executable, which is the image entrypoint:
+* the translator executable, which is the image entrypoint:
 
 ```bash
 docker run --rm opennmt/ctranslate2:latest-ubuntu20.04-cuda11.2 --help


### PR DESCRIPTION
* The client can also run scoring so avoid using the verb "translate"
* Add prefix "ct2" to avoid conflict with other binaries installed on the system