### PR TITLE
Support conversion of OpenNMT-py V3 checkpoints

### DIFF
--- a/docs/guides/opennmt_py.md
+++ b/docs/guides/opennmt_py.md
@@ -3,7 +3,7 @@
 CTranslate2 supports Transformer models trained with [OpenNMT-py](https://github.com/OpenNMT/OpenNMT-py). The conversion simply requires the PyTorch model path, e.g.:
 
 ```bash
-pip install OpenNMT-py
+pip install OpenNMT-py==2.*
 ct2-opennmt-py-converter --model_path model.pt --output_dir ct2_model
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ Start using CTranslate2 by converting a pretrained model and running your first 
 **1\. Install the Python packages**
 
 ```bash
-pip install ctranslate2 OpenNMT-py sentencepiece
+pip install ctranslate2 OpenNMT-py==2.* sentencepiece
 ```
 
 **2\. Download the English-German Transformer model trained with OpenNMT-py**

--- a/python/ctranslate2/converters/opennmt_py.py
+++ b/python/ctranslate2/converters/opennmt_py.py
@@ -117,8 +117,16 @@ def _get_model_spec_lm(opt, variables, src_vocabs, tgt_vocabs, num_source_embedd
 
 def get_vocabs(vocab):
     if isinstance(vocab, dict) and "src" in vocab:
-        src_vocabs = [field[1].vocab.itos for field in vocab["src"].fields]
-        tgt_vocabs = [field[1].vocab.itos for field in vocab["tgt"].fields]
+        if isinstance(vocab["src"], list):
+            src_vocabs = [vocab["src"]]
+            tgt_vocabs = [vocab["tgt"]]
+
+            src_feats = vocab.get("src_feats")
+            if src_feats is not None:
+                src_vocabs.extend(src_feats.values())
+        else:
+            src_vocabs = [field[1].vocab.itos for field in vocab["src"].fields]
+            tgt_vocabs = [field[1].vocab.itos for field in vocab["tgt"].fields]
     else:
         # Compatibility with older models.
         src_vocabs = [vocab[0][1].itos]


### PR DESCRIPTION
For now we still use OpenNMT-py V2 in the test and documentation as it can convert both V2 and V3 checkpoints.