### PR TITLE
Increase the default beam size for the Whisper model

### DIFF
--- a/include/ctranslate2/models/whisper.h
+++ b/include/ctranslate2/models/whisper.h
@@ -11,7 +11,7 @@ namespace ctranslate2 {
 
     struct WhisperOptions {
       // Beam size to use for beam search (set 1 to run greedy search).
-      size_t beam_size = 1;
+      size_t beam_size = 5;
 
       // Exponential penalty applied to the length during beam search.
       float length_penalty = 1;

--- a/python/cpp/whisper.cc
+++ b/python/cpp/whisper.cc
@@ -100,7 +100,7 @@ namespace ctranslate2 {
              py::arg("prompts"),
              py::kw_only(),
              py::arg("asynchronous")=false,
-             py::arg("beam_size")=1,
+             py::arg("beam_size")=5,
              py::arg("num_hypotheses")=1,
              py::arg("length_penalty")=1,
              py::arg("repetition_penalty")=1,


### PR DESCRIPTION
Use the same default value as in openai/whisper.

Related to #995.