### PR TITLE
Return multiple random hypotheses from greedy search with num_hypotheses

### DIFF
--- a/docs/decoding.md
+++ b/docs/decoding.md
@@ -143,17 +143,18 @@ The parameter `min_alternative_expansion_prob` can be used to filter out alterna
 
 ## Random sampling
 
-This decoding mode randomly samples tokens from the model output distribution. This strategy is frequently used in back-translation techniques ([Edunov et al. 2018](https://www.aclweb.org/anthology/D18-1045/)). The example below restricts the sampling to the best 10 candidates at each timestep:
+This decoding mode randomly samples tokens from the model output distribution. This strategy is frequently used in back-translation techniques ([Edunov et al. 2018](https://www.aclweb.org/anthology/D18-1045/)). The example below restricts the sampling to the best 10 candidates at each timestep and returns 3 random hypotheses:
 
 ```python
-all_results = [
-    translator.translate_batch([tokenize(input)], beam_size=1, sampling_topk=10),
-    translator.translate_batch([tokenize(input)], beam_size=1, sampling_topk=10),
-    translator.translate_batch([tokenize(input)], beam_size=1, sampling_topk=10),
-]
+results = translator.translate_batch(
+    [tokenize(input)],
+    beam_size=1,
+    sampling_topk=10,
+    num_hypotheses=3,
+)
 
-for results in all_results:
-    print(detokenize(results[0].hypotheses[0]))
+for hypothesis in results[0].hypotheses:
+    print(detokenize(hypothesis))
 ```
 
 > Dieses Programm ist auf eine effiziente Bedienung von Standard-Übersetzungsmodellen ausgerichtet und ermöglicht gleichzeitig einen Einsatzort für Experimente rund um die Modellkompression oder das Beschleunigen der Schlussfolgerung.

--- a/include/ctranslate2/generation.h
+++ b/include/ctranslate2/generation.h
@@ -29,8 +29,7 @@ namespace ctranslate2 {
     // High temperature increase randomness.
     float sampling_temperature = 1;
 
-    // Number of hypotheses to include in the result (should be smaller than beam_size unless
-    // return_alternatives is set).
+    // Number of hypotheses to include in the result.
     size_t num_hypotheses = 1;
 
     // Include scores in the result.

--- a/include/ctranslate2/translation.h
+++ b/include/ctranslate2/translation.h
@@ -45,8 +45,7 @@ namespace ctranslate2 {
     // Allow using the vocabulary map included in the model directory, if it exists.
     bool use_vmap = false;
 
-    // Number of hypotheses to store in the TranslationResult class (should be smaller than
-    // beam_size unless return_alternatives is set).
+    // Number of hypotheses to store in the TranslationResult class.
     size_t num_hypotheses = 1;
 
     // Store scores in the TranslationResult class.

--- a/include/ctranslate2/utils.h
+++ b/include/ctranslate2/utils.h
@@ -45,6 +45,17 @@ namespace ctranslate2 {
     return new_v;
   }
 
+  template <typename T>
+  std::vector<T> repeat_vector(const std::vector<T>& v, size_t repeats) {
+    std::vector<T> new_v;
+    new_v.reserve(v.size() * repeats);
+    for (const T& e : v) {
+      for (size_t i = 0; i < repeats; ++i)
+        new_v.emplace_back(e);
+    }
+    return new_v;
+  }
+
   // Helper function to only run the model on inputs without an immediate result.
   template <typename Result, typename SkipRun, typename GetBatchResults>
   std::vector<Result>

--- a/python/cpp/generator.cc
+++ b/python/cpp/generator.cc
@@ -178,8 +178,7 @@ namespace ctranslate2 {
                    batch_type: Whether :obj:`max_batch_size` is the number of "examples" or "tokens".
                    asynchronous: Run the generation asynchronously.
                    beam_size: Beam size (1 for greedy search).
-                   num_hypotheses: Number of hypotheses to return (should be <= :obj:`beam_size`
-                     unless :obj:`return_alternatives` is set).
+                   num_hypotheses: Number of hypotheses to return.
                    length_penalty: Exponential penalty applied to the length during beam search.
                    repetition_penalty: Penalty applied to the score of previously generated tokens
                      (set > 1 to penalize).

--- a/python/cpp/translator.cc
+++ b/python/cpp/translator.cc
@@ -426,8 +426,7 @@ namespace ctranslate2 {
                    batch_type: Whether :obj:`max_batch_size` is the number of "examples" or "tokens".
                    asynchronous: Run the translation asynchronously.
                    beam_size: Beam size (1 for greedy search).
-                   num_hypotheses: Number of hypotheses to return (should be <= :obj:`beam_size`
-                     unless :obj:`return_alternatives` is set).
+                   num_hypotheses: Number of hypotheses to return.
                    length_penalty: Exponential penalty applied to the length during beam search.
                    coverage_penalty: Coverage penalty weight applied during beam search.
                    repetition_penalty: Penalty applied to the score of previously generated tokens
@@ -498,7 +497,7 @@ namespace ctranslate2 {
                      numbers of "examples" or "tokens".
                    asynchronous: Run the translation asynchronously.
                    beam_size: Beam size (1 for greedy search).
-                   num_hypotheses: Number of hypotheses to return (should be <= :obj:`beam_size`).
+                   num_hypotheses: Number of hypotheses to return.
                    length_penalty: Exponential penalty applied to the length during beam search.
                    coverage_penalty: Coverage penalty weight applied during beam search.
                    repetition_penalty: Penalty applied to the score of previously generated tokens

--- a/python/cpp/whisper.cc
+++ b/python/cpp/whisper.cc
@@ -146,7 +146,7 @@ namespace ctranslate2 {
                    prompts: Batch of initial string tokens or token IDs.
                    asynchronous: Run the model asynchronously.
                    beam_size: Beam size (1 for greedy search).
-                   num_hypotheses: Number of hypotheses to return (must be <= :obj:`beam_size`).
+                   num_hypotheses: Number of hypotheses to return.
                    length_penalty: Exponential penalty applied to the length during beam search.
                    repetition_penalty: Penalty applied to the score of previously generated tokens
                      (set > 1 to penalize).

--- a/python/tests/test_translator.py
+++ b/python/tests/test_translator.py
@@ -506,9 +506,19 @@ def test_random_sampling():
     ctranslate2.set_random_seed(46)
     translator = _get_transliterator()
     output = translator.translate_batch(
-        [["آ", "ت", "ز", "م", "و", "ن"]], beam_size=1, sampling_topk=0
+        [["آ", "ت", "ز", "م", "و", "ن"]],
+        beam_size=1,
+        sampling_topk=0,
+        num_hypotheses=5,
+        return_scores=True,
     )
-    assert output[0].hypotheses[0] == ["a", "t", "z", "m", "u", "n"]
+
+    assert len(output[0].hypotheses) == 5
+    assert output[0].hypotheses[0] == ["a", "t", "z", "u", "m", "u", "n"]
+    assert output[0].hypotheses[1] == ["a", "t", "z", "i", "m", "o", "n"]
+
+    assert len(output[0].scores) == 5
+    assert output[0].scores == list(sorted(output[0].scores, reverse=True))
 
 
 def test_score_api(tmpdir):


### PR DESCRIPTION
We checked that `num_hypotheses` <= `beam_size`, but for random sampling with `beam_size=1` it could be useful to return multiple random hypotheses for each batch.