### PR TITLE
Workaround the incorrect <unk> ID in M2M100Tokenizer.get_vocab

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -344,6 +344,10 @@ class M2M100Loader(BartLoader):
     def get_vocabulary(self, model, tokenizer):
         tokens = super().get_vocabulary(model, tokenizer)
 
+        # Workaround for issue https://github.com/OpenNMT/CTranslate2/issues/1039.
+        if tokens[-1] == tokenizer.unk_token:
+            tokens.insert(tokenizer.unk_token_id, tokens.pop())
+
         for token in tokenizer.additional_special_tokens:
             if token not in tokens:
                 tokens.append(token)

--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -1,4 +1,4 @@
-transformers==4.23.*;platform_system=='Linux'
+transformers==4.25.*;platform_system=='Linux'
 fairseq==0.12.2;platform_system=='Linux' or platform_system=='Darwin'
 OpenNMT-py==2.2.*;platform_system=='Linux' or platform_system=='Darwin'
 OpenNMT-tf==2.30.*


### PR DESCRIPTION
Fixes #1039.