### PR TITLE
Implement variants of the GELU activation

### DIFF
--- a/include/ctranslate2/ops/activation.h
+++ b/include/ctranslate2/ops/activation.h
@@ -8,8 +8,10 @@ namespace ctranslate2 {
     // This enum order should remain fixed.
     enum class ActivationType {
       ReLU,
-      GELU,
+      GELUTanh,
       Swish,
+      GELU,
+      GELUSigmoid,
     };
 
     const UnaryOp& get_activation_op(ActivationType type);

--- a/include/ctranslate2/ops/gelu.h
+++ b/include/ctranslate2/ops/gelu.h
@@ -7,14 +7,33 @@ namespace ctranslate2 {
 
     class GELU : public UnaryOp {
     public:
+      enum class Approximation {
+        None,
+        Tanh,
+        Sigmoid,
+      };
+
+      GELU(const Approximation approximation = Approximation::None);
+
       void operator()(const StorageView& x, StorageView& y) const override;
 
     private:
       template <Device D, typename T>
       void compute(const StorageView& x, StorageView& y) const {
-        y.resize_as(x);
-        primitives<D>::gelu(x.data<T>(), y.data<T>(), x.size());
+        switch (_approximation) {
+        case Approximation::None:
+          primitives<D>::gelu(x.data<T>(), y.data<T>(), x.size());
+          break;
+        case Approximation::Tanh:
+          primitives<D>::gelu_tanh(x.data<T>(), y.data<T>(), x.size());
+          break;
+        case Approximation::Sigmoid:
+          primitives<D>::gelu_sigmoid(x.data<T>(), y.data<T>(), x.size());
+          break;
+        }
       }
+
+      const Approximation _approximation;
     };
 
   }

--- a/include/ctranslate2/primitives.h
+++ b/include/ctranslate2/primitives.h
@@ -173,6 +173,10 @@ namespace ctranslate2 {
     template <typename T>
     static void gelu(const T* x, T* y, dim_t size);
     template <typename T>
+    static void gelu_tanh(const T* x, T* y, dim_t size);
+    template <typename T>
+    static void gelu_sigmoid(const T* x, T* y, dim_t size);
+    template <typename T>
     static void swish(const T* x, T* y, dim_t size);
 
     static void compute_u8_compensation(const int8_t* b,

--- a/python/ctranslate2/converters/fairseq.py
+++ b/python/ctranslate2/converters/fairseq.py
@@ -18,8 +18,8 @@ _SUPPORTED_MODELS = {
 
 _SUPPORTED_ACTIVATIONS = {
     "gelu": common_spec.Activation.GELU,
-    "gelu_accurate": common_spec.Activation.GELU,
-    "gelu_fast": common_spec.Activation.GELU,
+    "gelu_accurate": common_spec.Activation.GELUTanh,
+    "gelu_fast": common_spec.Activation.GELUTanh,
     "relu": common_spec.Activation.RELU,
     "swish": common_spec.Activation.SWISH,
 }

--- a/python/ctranslate2/converters/marian.py
+++ b/python/ctranslate2/converters/marian.py
@@ -11,7 +11,7 @@ from ctranslate2.converters.converter import Converter
 from ctranslate2.specs import common_spec, transformer_spec
 
 _SUPPORTED_ACTIVATIONS = {
-    "gelu": common_spec.Activation.GELU,
+    "gelu": common_spec.Activation.GELUSigmoid,
     "relu": common_spec.Activation.RELU,
     "swish": common_spec.Activation.SWISH,
 }

--- a/python/ctranslate2/converters/openai_gpt2.py
+++ b/python/ctranslate2/converters/openai_gpt2.py
@@ -39,7 +39,7 @@ class OpenAIGPT2Converter(Converter):
             hparams["n_layer"],
             hparams["n_head"],
             pre_norm=True,
-            activation=common_spec.Activation.GELU,
+            activation=common_spec.Activation.GELUTanh,
         )
         set_decoder(spec.decoder, weights, "model")
         spec.unk_token = "<|endoftext|>"

--- a/python/ctranslate2/converters/opennmt_py.py
+++ b/python/ctranslate2/converters/opennmt_py.py
@@ -6,7 +6,7 @@ from ctranslate2.specs import common_spec, transformer_spec
 
 _SUPPORTED_ACTIVATIONS = {
     "gelu": common_spec.Activation.GELU,
-    "fast_gelu": common_spec.Activation.GELU,
+    "fast_gelu": common_spec.Activation.GELUTanh,
     "relu": common_spec.Activation.RELU,
 }
 

--- a/python/ctranslate2/converters/opennmt_tf.py
+++ b/python/ctranslate2/converters/opennmt_tf.py
@@ -9,7 +9,7 @@ from ctranslate2.converters.converter import Converter
 from ctranslate2.specs import common_spec, transformer_spec
 
 _SUPPORTED_ACTIVATIONS = {
-    "gelu": common_spec.Activation.GELU,
+    "gelu": common_spec.Activation.GELUTanh,
     "relu": common_spec.Activation.RELU,
     "swish": common_spec.Activation.SWISH,
 }

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -11,10 +11,11 @@ from ctranslate2.specs import common_spec, model_spec, transformer_spec, whisper
 
 _SUPPORTED_ACTIVATIONS = {
     "gelu": common_spec.Activation.GELU,
-    "gelu_fast": common_spec.Activation.GELU,
-    "gelu_new": common_spec.Activation.GELU,
+    "gelu_fast": common_spec.Activation.GELUTanh,
+    "gelu_new": common_spec.Activation.GELUTanh,
     "gelu_python": common_spec.Activation.GELU,
-    "quick_gelu": common_spec.Activation.GELU,
+    "gelu_pytorch_tanh": common_spec.Activation.GELUTanh,
+    "quick_gelu": common_spec.Activation.GELUSigmoid,
     "relu": common_spec.Activation.RELU,
     "silu": common_spec.Activation.SWISH,
     "swish": common_spec.Activation.SWISH,

--- a/python/ctranslate2/specs/common_spec.py
+++ b/python/ctranslate2/specs/common_spec.py
@@ -10,8 +10,10 @@ class Activation(enum.IntEnum):
     """Activation type."""
 
     RELU = 0
-    GELU = 1
+    GELUTanh = 1
     SWISH = 2
+    GELU = 3
+    GELUSigmoid = 4
 
 
 # This enum should match the C++ equivalent in include/ctranslate2/layers/common.h.

--- a/python/ctranslate2/specs/transformer_spec.py
+++ b/python/ctranslate2/specs/transformer_spec.py
@@ -300,7 +300,7 @@ class TransformerSpec(model_spec.SequenceToSequenceModelSpec):
 
     @property
     def revision(self):
-        return 6
+        return 7
 
     def get_source_vocabulary_size(self):
         return [spec.weight.shape[0] for spec in self.encoder.embeddings]
@@ -369,7 +369,7 @@ class TransformerDecoderModelSpec(model_spec.LanguageModelSpec):
 
     @property
     def revision(self):
-        return 2
+        return 3
 
     def get_vocabulary_size(self):
         return self.decoder.embeddings.weight.shape[0]

--- a/python/ctranslate2/specs/whisper_spec.py
+++ b/python/ctranslate2/specs/whisper_spec.py
@@ -44,7 +44,7 @@ class WhisperSpec(model_spec.LanguageModelSpec):
 
     @property
     def revision(self):
-        return 2
+        return 3
 
     def get_default_config(self):
         return WhisperConfig()

--- a/python/tests/test_transformers.py
+++ b/python/tests/test_transformers.py
@@ -376,7 +376,7 @@ def test_transformers_generator_suppress_sequences(tmpdir):
                 " ask what you can do for your country.",
             ],
             [
-                pytest.approx(0.002247905358672142, abs=1e-5),
+                pytest.approx(0.0022832120303064585, abs=1e-4),
                 pytest.approx(0.06885894387960434, abs=1e-3),
             ],
         ),
@@ -392,7 +392,7 @@ def test_transformers_generator_suppress_sequences(tmpdir):
                 " ask what you can do for your country.",
             ],
             [
-                pytest.approx(0.002247905358672142, abs=1e-5),
+                pytest.approx(0.0022832120303064585, abs=1e-4),
                 pytest.approx(0.06885894387960434, abs=1e-3),
             ],
         ),
@@ -418,7 +418,7 @@ def test_transformers_generator_suppress_sequences(tmpdir):
                 " ask what you can do for your country.",
             ],
             [
-                pytest.approx(0.002247905358672142, abs=1e-5),
+                pytest.approx(0.0022832120303064585, abs=1e-4),
                 pytest.approx(0.06885894387960434, abs=1e-2),
             ],
         ),

--- a/src/cpu/kernels.cc
+++ b/src/cpu/kernels.cc
@@ -192,8 +192,7 @@ namespace ctranslate2 {
         x, y, size,
         [](vec_type<float, TARGET_ISA> v) {
           auto u = VecType::mul(VecType::mul(v, v), v);
-          u = VecType::mul(VecType::load(0.044715f), u);
-          u = VecType::add(v, u);
+          u = VecType::mul_add(VecType::load(0.044715f), u, v);
           u = VecType::mul(VecType::load(0.7978845608028654f), u);
           u = VecType::tanh(u);
           u = VecType::add(VecType::load(1.f), u);

--- a/src/cpu/kernels.cc
+++ b/src/cpu/kernels.cc
@@ -177,6 +177,20 @@ namespace ctranslate2 {
       vectorized_unary_transform<TARGET_ISA>(
         x, y, size,
         [](vec_type<float, TARGET_ISA> v) {
+          auto u = VecType::mul(VecType::load(0.7071067811865475f), v);
+          u = VecType::add(VecType::load(1.f), VecType::erf(u));
+          u = VecType::mul(v, u);
+          u = VecType::mul(VecType::load(0.5f), u);
+          return u;
+        });
+    }
+
+    template<>
+    void gelu_tanh<TARGET_ISA>(const float* x, float* y, dim_t size) {
+      using VecType = Vec<float, TARGET_ISA>;
+      vectorized_unary_transform<TARGET_ISA>(
+        x, y, size,
+        [](vec_type<float, TARGET_ISA> v) {
           auto u = VecType::mul(VecType::mul(v, v), v);
           u = VecType::mul(VecType::load(0.044715f), u);
           u = VecType::add(v, u);
@@ -186,6 +200,17 @@ namespace ctranslate2 {
           u = VecType::mul(v, u);
           u = VecType::mul(VecType::load(0.5f), u);
           return u;
+        });
+    }
+
+    template<>
+    void gelu_sigmoid<TARGET_ISA>(const float* x, float* y, dim_t size) {
+      using VecType = Vec<float, TARGET_ISA>;
+      vectorized_unary_transform<TARGET_ISA>(
+        x, y, size,
+        [](vec_type<float, TARGET_ISA> v) {
+          return VecType::div(v, VecType::add(VecType::load(1.f),
+                                              VecType::exp(VecType::mul(VecType::load(-1.702f), v))));
         });
     }
 

--- a/src/cpu/kernels.h
+++ b/src/cpu/kernels.h
@@ -22,6 +22,10 @@ namespace ctranslate2 {
     template <CpuIsa ISA>
     void gelu(const float* x, float* y, dim_t size);
     template <CpuIsa ISA>
+    void gelu_tanh(const float* x, float* y, dim_t size);
+    template <CpuIsa ISA>
+    void gelu_sigmoid(const float* x, float* y, dim_t size);
+    template <CpuIsa ISA>
     void swish(const float* x, float* y, dim_t size);
 
     template <CpuIsa ISA, typename T>

--- a/src/cpu/primitives.cc
+++ b/src/cpu/primitives.cc
@@ -293,6 +293,24 @@ namespace ctranslate2 {
 
   template<>
   template<>
+  void primitives<Device::CPU>::gelu_tanh(const float* x, float* y, dim_t size) {
+    cpu::parallel_for(0, size, /*grain_size=*/512,
+                      [x, y](dim_t begin, dim_t end) {
+                        CPU_ISA_DISPATCH((cpu::gelu_tanh<ISA>(x + begin, y + begin, end - begin)));
+                      });
+  }
+
+  template<>
+  template<>
+  void primitives<Device::CPU>::gelu_sigmoid(const float* x, float* y, dim_t size) {
+    cpu::parallel_for(0, size, /*grain_size=*/512,
+                      [x, y](dim_t begin, dim_t end) {
+                        CPU_ISA_DISPATCH((cpu::gelu_sigmoid<ISA>(x + begin, y + begin, end - begin)));
+                      });
+  }
+
+  template<>
+  template<>
   void primitives<Device::CPU>::swish(const float* x, float* y, dim_t size) {
     cpu::parallel_for(0, size, cpu::GRAIN_SIZE / 10,
                       [x, y](dim_t begin, dim_t end) {

--- a/src/cpu/vec_avx.h
+++ b/src/cpu/vec_avx.h
@@ -72,6 +72,14 @@ namespace ctranslate2 {
         }
       }
 
+      static inline value_type bit_and(value_type a, value_type b) {
+        return _mm256_and_ps(a, b);
+      }
+
+      static inline value_type bit_xor(value_type a, value_type b) {
+        return _mm256_xor_ps(a, b);
+      }
+
       static inline value_type lt(value_type a, value_type b) {
         return _mm256_cmp_ps(a, b, _CMP_LT_OQ);
       }
@@ -111,6 +119,10 @@ namespace ctranslate2 {
 
       static inline value_type tanh(value_type a) {
         return vec_tanh<TARGET_ISA>(a);
+      }
+
+      static inline value_type erf(value_type a) {
+        return vec_erf<TARGET_ISA>(a);
       }
 
       static inline value_type max(value_type a, value_type b) {

--- a/src/cpu/vec_neon.h
+++ b/src/cpu/vec_neon.h
@@ -54,6 +54,14 @@ namespace ctranslate2 {
         }
       }
 
+      static inline value_type bit_and(value_type a, value_type b) {
+        return vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(a), vreinterpretq_u32_f32(b)));
+      }
+
+      static inline value_type bit_xor(value_type a, value_type b) {
+        return vreinterpretq_f32_u32(veorq_u32(vreinterpretq_u32_f32(a), vreinterpretq_u32_f32(b)));
+      }
+
       static inline mask_type lt(value_type a, value_type b) {
         return vcltq_f32(a, b);
       }
@@ -92,6 +100,10 @@ namespace ctranslate2 {
 
       static inline value_type tanh(value_type a) {
         return vec_tanh<TARGET_ISA>(a);
+      }
+
+      static inline value_type erf(value_type a) {
+        return vec_erf<TARGET_ISA>(a);
       }
 
       static inline value_type max(value_type a, value_type b) {

--- a/src/cuda/helpers.h
+++ b/src/cuda/helpers.h
@@ -224,7 +224,23 @@ namespace ctranslate2 {
     struct gelu_func {
       // Implicitly promote half to float in this function.
       __device__ float operator()(float x) const {
+        return 0.5f * x * (1 + erff(0.7071067811865475f * x));
+      }
+    };
+
+    template <typename T>
+    struct gelu_tanh_func {
+      // Implicitly promote half to float in this function.
+      __device__ float operator()(float x) const {
         return 0.5f * x * (1.f + tanhf(0.7978845608028654f * (x + 0.044715f * powf(x, 3.f))));
+      }
+    };
+
+    template <typename T>
+    struct gelu_sigmoid_func {
+      // Implicitly promote half to float in this function.
+      __device__ float operator()(float x) const {
+        return x / (1.f + expf(-1.702f * x));
       }
     };
 

--- a/src/cuda/primitives.cu
+++ b/src/cuda/primitives.cu
@@ -193,6 +193,24 @@ namespace ctranslate2 {
 
   template<>
   template <typename T>
+  void primitives<Device::CUDA>::gelu_tanh(const T* x, T* y, dim_t size) {
+    cuda::unary_transform(x, y, size, cuda::gelu_tanh_func<cuda::device_type<T>>());
+  }
+
+  template void primitives<Device::CUDA>::gelu_tanh(const float*, float*, dim_t);
+  template void primitives<Device::CUDA>::gelu_tanh(const float16_t*, float16_t*, dim_t);
+
+  template<>
+  template <typename T>
+  void primitives<Device::CUDA>::gelu_sigmoid(const T* x, T* y, dim_t size) {
+    cuda::unary_transform(x, y, size, cuda::gelu_sigmoid_func<cuda::device_type<T>>());
+  }
+
+  template void primitives<Device::CUDA>::gelu_sigmoid(const float*, float*, dim_t);
+  template void primitives<Device::CUDA>::gelu_sigmoid(const float16_t*, float16_t*, dim_t);
+
+  template<>
+  template <typename T>
   void primitives<Device::CUDA>::swish(const T* x, T* y, dim_t size) {
     cuda::unary_transform(x, y, size, cuda::swish_func<cuda::device_type<T>>());
   }

--- a/src/models/transformer.cc
+++ b/src/models/transformer.cc
@@ -45,7 +45,7 @@ namespace ctranslate2 {
     }
 
     size_t TransformerModel::current_spec_revision() const {
-      return 6;
+      return 7;
     }
 
     bool TransformerModel::is_linear_weight(const std::string& variable_name) const {
@@ -104,7 +104,7 @@ namespace ctranslate2 {
     static auto register_decoder = register_model<TransformerDecoderModel>("TransformerDecoderSpec");
 
     size_t TransformerDecoderModel::current_spec_revision() const {
-      return 2;
+      return 3;
     }
 
     void TransformerDecoderModel::initialize(ModelReader& model_reader) {

--- a/src/models/whisper.cc
+++ b/src/models/whisper.cc
@@ -17,7 +17,7 @@ namespace ctranslate2 {
     }
 
     size_t WhisperModel::current_spec_revision() const {
-      return 2;
+      return 3;
     }
 
     void WhisperModel::initialize(ModelReader& model_reader) {

--- a/src/ops/activation.cc
+++ b/src/ops/activation.cc
@@ -17,6 +17,14 @@ namespace ctranslate2 {
         static const GELU gelu;
         return gelu;
       }
+      case ActivationType::GELUTanh: {
+        static const GELU gelu(GELU::Approximation::Tanh);
+        return gelu;
+      }
+      case ActivationType::GELUSigmoid: {
+        static const GELU gelu(GELU::Approximation::Sigmoid);
+        return gelu;
+      }
       case ActivationType::Swish: {
         static const Swish swish;
         return swish;

--- a/src/ops/bias_add_gpu.cu
+++ b/src/ops/bias_add_gpu.cu
@@ -51,6 +51,16 @@ namespace ctranslate2 {
             x, b, y, depth, cuda::plus<DeviceT>(), cuda::gelu_func<DeviceT>());
           break;
 
+        case ActivationType::GELUTanh:
+          bias_add_kernel<<<blocks, threads, 0, cuda::get_cuda_stream()>>>(
+            x, b, y, depth, cuda::plus<DeviceT>(), cuda::gelu_tanh_func<DeviceT>());
+          break;
+
+        case ActivationType::GELUSigmoid:
+          bias_add_kernel<<<blocks, threads, 0, cuda::get_cuda_stream()>>>(
+            x, b, y, depth, cuda::plus<DeviceT>(), cuda::gelu_sigmoid_func<DeviceT>());
+          break;
+
         case ActivationType::Swish:
           bias_add_kernel<<<blocks, threads, 0, cuda::get_cuda_stream()>>>(
             x, b, y, depth, cuda::plus<DeviceT>(), cuda::swish_func<DeviceT>());

--- a/src/ops/dequantize_gpu.cu
+++ b/src/ops/dequantize_gpu.cu
@@ -95,6 +95,18 @@ namespace ctranslate2 {
           break;
         }
 
+        case ActivationType::GELUTanh: {
+          dequantize_gemm_output_kernel<<<blocks, threads, 0, cuda::get_cuda_stream()>>>(
+            c, a_scales, b_scales, transpose_a, transpose_b, bias, cuda::gelu_tanh_func<T>(), y, depth);
+          break;
+        }
+
+        case ActivationType::GELUSigmoid: {
+          dequantize_gemm_output_kernel<<<blocks, threads, 0, cuda::get_cuda_stream()>>>(
+            c, a_scales, b_scales, transpose_a, transpose_b, bias, cuda::gelu_sigmoid_func<T>(), y, depth);
+          break;
+        }
+
         case ActivationType::Swish: {
           dequantize_gemm_output_kernel<<<blocks, threads, 0, cuda::get_cuda_stream()>>>(
             c, a_scales, b_scales, transpose_a, transpose_b, bias, cuda::swish_func<T>(), y, depth);

--- a/src/ops/gelu.cc
+++ b/src/ops/gelu.cc
@@ -5,8 +5,16 @@
 namespace ctranslate2 {
   namespace ops {
 
+    GELU::GELU(const Approximation approximation)
+      : _approximation(approximation)
+    {
+    }
+
     void GELU::operator()(const StorageView& x, StorageView& y) const {
       PROFILE("GELU");
+
+      y.resize_as(x);
+
       switch (x.dtype()) {
       case DataType::FLOAT: {
         DEVICE_DISPATCH(x.device(), (compute<D, float>(x, y)));

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -787,7 +787,8 @@ TEST_P(OpDeviceFPTest, GELUTanh) {
   StorageView input({2}, std::vector<float>{0.2, -1.3}, device);
   StorageView expected({2}, std::vector<float>{0.11585142463445663, -0.1260710209608078}, device);
   StorageView output(dtype, device);
-  ops::GELU(ops::GELU::Approximation::Tanh)(input.to(dtype), output);
+  const ops::GELU gelu_op(ops::GELU::Approximation::Tanh);
+  gelu_op(input.to(dtype), output);
   expect_storage_eq(output.to_float(), expected, 1e-4);
 }
 
@@ -797,7 +798,8 @@ TEST_P(OpDeviceFPTest, GELUSigmoid) {
   StorageView input({2}, std::vector<float>{0.2, -1.3}, device);
   StorageView expected({2}, std::vector<float>{0.11685754358768463, -0.128212109208107}, device);
   StorageView output(dtype, device);
-  ops::GELU(ops::GELU::Approximation::Sigmoid)(input.to(dtype), output);
+  const ops::GELU gelu_op(ops::GELU::Approximation::Sigmoid);
+  gelu_op(input.to(dtype), output);
   expect_storage_eq(output.to_float(), expected, 1e-4);
 }
 

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -775,10 +775,30 @@ TEST_P(OpDeviceFPTest, GELU) {
   const Device device = GetParam().first;
   const DataType dtype = GetParam().second;
   StorageView input({2}, std::vector<float>{0.2, -1.3}, device);
-  StorageView expected({2}, std::vector<float>{0.11585142, -0.12607098}, device);
+  StorageView expected({2}, std::vector<float>{0.11585195362567902, -0.1258406937122345}, device);
   StorageView output(dtype, device);
   ops::GELU()(input.to(dtype), output);
-  expect_storage_eq(output.to_float(), expected, 1e-3);
+  expect_storage_eq(output.to_float(), expected, 1e-4);
+}
+
+TEST_P(OpDeviceFPTest, GELUTanh) {
+  const Device device = GetParam().first;
+  const DataType dtype = GetParam().second;
+  StorageView input({2}, std::vector<float>{0.2, -1.3}, device);
+  StorageView expected({2}, std::vector<float>{0.11585142463445663, -0.1260710209608078}, device);
+  StorageView output(dtype, device);
+  ops::GELU(ops::GELU::Approximation::Tanh)(input.to(dtype), output);
+  expect_storage_eq(output.to_float(), expected, 1e-4);
+}
+
+TEST_P(OpDeviceFPTest, GELUSigmoid) {
+  const Device device = GetParam().first;
+  const DataType dtype = GetParam().second;
+  StorageView input({2}, std::vector<float>{0.2, -1.3}, device);
+  StorageView expected({2}, std::vector<float>{0.11685754358768463, -0.128212109208107}, device);
+  StorageView output(dtype, device);
+  ops::GELU(ops::GELU::Approximation::Sigmoid)(input.to(dtype), output);
+  expect_storage_eq(output.to_float(), expected, 1e-4);
 }
 
 TEST_P(OpDeviceFPTest, Swish) {


### PR DESCRIPTION
The current implementation is using the tanh approximation. This PR adds 2 new variants:

* the original formula based on the CDF
* the sigmoid approximation