### PR TITLE
remove upper bound on python_requires

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -107,7 +107,7 @@ setup(
     packages=find_packages(exclude=["bin"]),
     package_data=package_data,
     ext_modules=[ctranslate2_module],
-    python_requires=">=3.7,<3.12",
+    python_requires=">=3.7",
     install_requires=[
         "numpy",
         "pyyaml>=5.3,<7",


### PR DESCRIPTION
Closes https://github.com/OpenNMT/CTranslate2/issues/1070

Python dependency managers Poetry and PDM (and perhaps others) tend to automatically set an upper bound of 4.0 for the required-python variable. This prevents CTranslate2 from getting installed, without much detail provided on exactly why - especially if CTranslate2 is a dependency of the actual package being installed (https://github.com/argosopentech/argos-translate/issues/169). This PR removes the upper bound, which tends not to be used by most other packages.