### PR TITLE
Add flag to disable the true FP16 GEMM

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -24,6 +24,12 @@ Allocating memory on the GPU with `cudaMalloc` is costly and is best avoided in 
 
 Allow using FP16 computation on GPU even if the device does not have efficient FP16 support.
 
+## `CT2_CUDA_TRUE_FP16_GEMM`
+
+Allow using true FP16 computation in GEMM operations. When disabled, the computation or accumulation may use FP32 instead.
+
+This flag is enabled by default, but some models may automatically disable it when they are known to work better with the increased precision.
+
 ## `CT2_CUDA_CACHING_ALLOCATOR_CONFIG`
 
 The `cub_caching` allocator can be configured to tradeoff memory usage and speed. By default, CTranslate2 uses the following values which have been selected experimentally:

--- a/src/cuda/primitives.cu
+++ b/src/cuda/primitives.cu
@@ -465,17 +465,27 @@ namespace ctranslate2 {
     const __half alpha_h = alpha;
     const __half beta_h = beta;
 
+    const void* alpha_ptr = &alpha_h;
+    const void* beta_ptr = &beta_h;
+    cudaDataType_t compute_type = CUDA_R_16F;
+
+    if (!cuda::use_true_fp16_gemm()) {
+      alpha_ptr = &alpha;
+      beta_ptr = &beta;
+      compute_type = CUDA_R_32F;
+    }
+
     // cuBLAS assumes column-major storage, so swap a and b accordingly.
     CUBLAS_CHECK(cublasGemmEx(cuda::get_cublas_handle(),
                               transpose_b ? CUBLAS_OP_T : CUBLAS_OP_N,
                               transpose_a ? CUBLAS_OP_T : CUBLAS_OP_N,
                               n, m, k,
-                              &alpha_h,
+                              alpha_ptr,
                               b, CUDA_R_16F, ldb,
                               a, CUDA_R_16F, lda,
-                              &beta_h,
+                              beta_ptr,
                               c, CUDA_R_16F, ldc,
-                              CUDA_R_16F,
+                              compute_type,
                               CUBLAS_GEMM_DEFAULT_TENSOR_OP));
   }
 
@@ -543,18 +553,28 @@ namespace ctranslate2 {
     const __half alpha_h = alpha;
     const __half beta_h = beta;
 
+    const void* alpha_ptr = &alpha_h;
+    const void* beta_ptr = &beta_h;
+    cudaDataType_t compute_type = CUDA_R_16F;
+
+    if (!cuda::use_true_fp16_gemm()) {
+      alpha_ptr = &alpha;
+      beta_ptr = &beta;
+      compute_type = CUDA_R_32F;
+    }
+
     // cuBLAS assumes column-major storage, so swap a and b accordingly.
     CUBLAS_CHECK(cublasGemmStridedBatchedEx(cuda::get_cublas_handle(),
                                             transpose_b ? CUBLAS_OP_T : CUBLAS_OP_N,
                                             transpose_a ? CUBLAS_OP_T : CUBLAS_OP_N,
                                             n, m, k,
-                                            &alpha_h,
+                                            alpha_ptr,
                                             b, CUDA_R_16F, ldb, strideb,
                                             a, CUDA_R_16F, lda, stridea,
-                                            &beta_h,
+                                            beta_ptr,
                                             c, CUDA_R_16F, ldc, stridec,
                                             batch_size,
-                                            CUDA_R_16F,
+                                            compute_type,
                                             CUBLAS_GEMM_DEFAULT_TENSOR_OP));
   }
 

--- a/src/cuda/utils.cc
+++ b/src/cuda/utils.cc
@@ -8,6 +8,8 @@
 
 #include "ctranslate2/utils.h"
 
+#include "env.h"
+
 namespace ctranslate2 {
   namespace cuda {
 
@@ -208,6 +210,16 @@ namespace ctranslate2 {
       }
 
       return true;
+    }
+
+    static thread_local bool true_fp16_gemm = read_bool_from_env("CT2_CUDA_TRUE_FP16_GEMM", true);
+
+    bool use_true_fp16_gemm() {
+      return true_fp16_gemm;
+    }
+
+    void use_true_fp16_gemm(bool use) {
+      true_fp16_gemm = use;
     }
 
   }

--- a/src/cuda/utils.h
+++ b/src/cuda/utils.h
@@ -57,6 +57,27 @@ namespace ctranslate2 {
     bool gpu_has_fp16_tensor_cores(int device = -1);
     bool have_same_compute_capability(const std::vector<int>& devices);
 
+    bool use_true_fp16_gemm();
+    void use_true_fp16_gemm(bool use);
+
+    class UseTrueFp16GemmInScope {
+    public:
+      UseTrueFp16GemmInScope(const bool use)
+        : _previous_value(use_true_fp16_gemm())
+        , _scope_value(use)
+      {
+        use_true_fp16_gemm(_scope_value);
+      }
+
+      ~UseTrueFp16GemmInScope() {
+        use_true_fp16_gemm(_previous_value);
+      }
+
+    private:
+      const bool _previous_value;
+      const bool _scope_value;
+    };
+
 // Convenience macro to call Thrust functions with a default execution policy.
 #define THRUST_CALL(FUN, ...) FUN(thrust::cuda::par_nosync.on(ctranslate2::cuda::get_cuda_stream()), __VA_ARGS__)
 

--- a/src/models/whisper.cc
+++ b/src/models/whisper.cc
@@ -7,6 +7,10 @@
 
 #include "dispatch.h"
 
+#ifdef CT2_WITH_CUDA
+#  include "cuda/utils.h"
+#endif
+
 namespace ctranslate2 {
   namespace models {
 
@@ -201,6 +205,10 @@ namespace ctranslate2 {
       if (prompts.empty())
         return {};
 
+#ifdef CT2_WITH_CUDA
+      const cuda::UseTrueFp16GemmInScope use_true_fp16_gemm(false);
+#endif
+
       size_t sot_index = 0;
       size_t prompt_length = 0;  // Length of the prompt before the text tokens.
       check_prompts(prompts, _sot_id, _no_timestamps_id, sot_index, prompt_length);
@@ -323,6 +331,10 @@ namespace ctranslate2 {
         throw std::runtime_error("detect_language can only be called on multilingual models");
 
       PROFILE("WhisperReplica::detect_language");
+
+#ifdef CT2_WITH_CUDA
+      const cuda::UseTrueFp16GemmInScope use_true_fp16_gemm(false);
+#endif
 
       const auto scoped_device_setter = _model->get_scoped_device_setter();
       const auto& vocabulary = _model->get_vocabulary();


### PR DESCRIPTION
The cuBLAS GEMM functions have a `computeType` argument. Currently we always set it to FP16, but I found that other frameworks usually set FP32 by default:

* PyTorch: https://github.com/pytorch/pytorch/blob/bac33ea8b64307c65d246fb7001d5aed55c9af40/aten/src/ATen/cuda/CUDABlas.cpp#L445
* TensorFlow: https://github.com/tensorflow/tensorflow/blob/ff459137c2716a2a60f7d441b855fcb466d778cb/tensorflow/compiler/xla/stream_executor/cuda/cuda_blas.cc#L1521

This PR is adding an environment variable to control this behavior.

The default behavior is unchanged but Whisper models will use FP32 as this fixes some incorrect outputs. The performance does not seem impacted.