### PR TITLE
Update benchmark scripts and results for version 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,49 +71,49 @@ The benchmark reports the number of target tokens generated per second (higher i
 | | Tokens per second | Max. memory | BLEU |
 | --- | --- | --- | --- |
 | **OpenNMT-tf WMT14 model** | | | |
-| OpenNMT-tf 2.26.1 (with TensorFlow 2.9.0) | 283.0 | 3475MB | 26.93 |
+| OpenNMT-tf 2.31.0 (with TensorFlow 2.11.0) | 209.2 | 2653MB | 26.93 |
 | **OpenNMT-py WMT14 model** | | | |
-| OpenNMT-py 2.2.0 (with PyTorch 1.11.0) | 474.2 | 1543MB | 26.77 |
-| - int8 | 510.6 | 1455MB | 26.72 |
-| CTranslate2 2.17.0 | 1220.2 | 1072MB | 26.77 |
-| - int16 | 1534.8 | 920MB | 26.82 |
-| - int8 | 1737.5 | 771MB | 26.89 |
-| - int8 + vmap | 2122.4 | 666MB | 26.62 |
+| OpenNMT-py 3.0.4 (with PyTorch 1.13.1) | 275.8 | 2012MB | 26.77 |
+| - int8 | 323.3 | 1359MB | 26.72 |
+| CTranslate2 3.6.0 | 658.8 | 849MB | 26.77 |
+| - int16 | 733.0 | 672MB | 26.82 |
+| - int8 | 860.2 | 529MB | 26.78 |
+| - int8 + vmap | 1126.2 | 598MB | 26.64 |
 | **OPUS-MT model** | | | |
-| Transformers 4.19.2 | 230.1 | 2840MB | 27.92 |
-| Marian 1.11.0 | 756.6 | 13819MB | 27.93 |
-| - int16 | 718.4 | 10395MB | 27.65 |
-| - int8 | 853.3 | 8166MB | 27.27 |
-| CTranslate2 2.17.0 | 988.0 | 995MB | 27.92 |
-| - int16 | 1285.7 | 847MB | 27.51 |
-| - int8 | 1469.1 | 847MB | 27.71 |
+| Transformers 4.26.1 (with PyTorch 1.13.1) | 147.3 | 2332MB | 27.90 |
+| Marian 1.11.0 | 344.5 | 7605MB | 27.93 |
+| - int16 | 330.2 | 5901MB | 27.65 |
+| - int8 | 355.8 | 4763MB | 27.27 |
+| CTranslate2 3.6.0 | 525.0 | 721MB | 27.92 |
+| - int16 | 596.1 | 660MB | 27.53 |
+| - int8 | 696.1 | 516MB | 27.65 |
 
-Executed with 8 threads on a [*c5.metal*](https://aws.amazon.com/ec2/instance-types/c5/) Amazon EC2 instance equipped with an Intel(R) Xeon(R) Platinum 8275CL CPU.
+Executed with 4 threads on a [*c5.2xlarge*](https://aws.amazon.com/ec2/instance-types/c5/) Amazon EC2 instance equipped with an Intel(R) Xeon(R) Platinum 8275CL CPU.
 
 #### GPU
 
 | | Tokens per second | Max. GPU memory | Max. CPU memory | BLEU |
 | --- | --- | --- | --- | --- |
 | **OpenNMT-tf WMT14 model** | | | | |
-| OpenNMT-tf 2.26.1 (with TensorFlow 2.9.0) | 1289.3 | 2667MB | 2407MB | 26.93 |
+| OpenNMT-tf 2.31.0 (with TensorFlow 2.11.0) | 1483.5 | 3031MB | 3122MB | 26.94 |
 | **OpenNMT-py WMT14 model** | | | | |
-| OpenNMT-py 2.2.0 (with PyTorch 1.11.0) | 1271.4 | 2993MB | 3553MB | 26.77 |
-| FasterTransformer 4.0 | 2941.3 | 5869MB | 2327MB | 26.77 |
-| - float16 | 6497.4 | 3917MB | 2325MB | 26.83 |
-| CTranslate2 2.17.0 | 3644.1 | 1231MB | 646MB | 26.77 |
-| - int8 | 5393.6 | 975MB | 522MB | 26.83 |
-| - float16 | 5454.7 | 815MB | 550MB | 26.78 |
-| - int8 + float16 | 6158.6 | 687MB | 523MB | 26.80 |
+| OpenNMT-py 3.0.4 (with PyTorch 1.13.1) | 1795.2 | 2973MB | 3099MB | 26.77 |
+| FasterTransformer 5.3 | 6979.0 | 2402MB | 1131MB | 26.77 |
+| - float16 | 8592.5 | 1360MB | 1135MB | 26.80 |
+| CTranslate2 3.6.0 | 6634.7 | 1261MB | 953MB | 26.77 |
+| - int8 | 8567.2 | 1005MB | 807MB | 26.85 |
+| - float16 | 10990.7 | 941MB | 807MB | 26.77 |
+| - int8 + float16 | 8725.4 | 813MB | 800MB | 26.83 |
 | **OPUS-MT model** | | | | |
-| Transformers 4.19.2 | 811.1 | 4013MB | 3044MB | 27.92 |
-| Marian 1.11.0 | 2172.9 | 3127MB | 1869MB | 27.92 |
-| - float16 | 2722.0 | 2985MB | 1715MB | 27.93 |
-| CTranslate2 2.17.0 | 3042.5 | 1167MB | 486MB | 27.92 |
-| - int8 | 4573.1 | 1007MB | 511MB | 27.89 |
-| - float16 | 4718.4 | 783MB | 552MB | 27.85 |
-| - int8 + float16 | 5300.5 | 687MB | 508MB | 27.81 |
+| Transformers 4.26.1 (with PyTorch 1.13.1) | 1022.9 | 4097MB | 2109MB | 27.90 |
+| Marian 1.11.0 | 3241.0 | 3381MB | 2156MB | 27.92 |
+| - float16 | 3962.4 | 3239MB | 1976MB | 27.94 |
+| CTranslate2 3.6.0 | 5876.4 | 1197MB | 754MB | 27.92 |
+| - int8 | 7521.9 | 1005MB | 792MB | 27.79 |
+| - float16 | 9296.7 | 909MB | 814MB | 27.90 |
+| - int8 + float16 | 8362.7 | 813MB | 766MB | 27.90 |
 
-Executed with CUDA 11 on a [*g4dn.xlarge*](https://aws.amazon.com/ec2/instance-types/g4/) Amazon EC2 instance equipped with a NVIDIA T4 GPU (driver version: 510.47.03).
+Executed with CUDA 11 on a [*g5.xlarge*](https://aws.amazon.com/ec2/instance-types/g5/) Amazon EC2 instance equipped with a NVIDIA A10G GPU (driver version: 510.47.03).
 
 ## Additional resources
 

--- a/tools/benchmark/benchmark_all.py
+++ b/tools/benchmark/benchmark_all.py
@@ -2,6 +2,8 @@ import os
 import sys
 import docker
 import sacrebleu
+import tempfile
+import json
 
 from benchmark import benchmark_image
 
@@ -9,29 +11,43 @@ from benchmark import benchmark_image
 device = sys.argv[1].lower()
 gpu = device == "gpu"
 client = docker.from_env()
+api_client = docker.APIClient()
 current_dir = os.path.dirname(os.path.realpath(__file__))
+debug_mode = os.environ.get("DEBUG", "0") == "1"
+if debug_mode:
+    print("(debug mode)")
 
 
 # Benchmark configuration
 test_set = "wmt14"
 langpair = "en-de"
-num_cpus = 8
-num_samples = 5 if gpu else 3
+num_cpus = 4
 
-
-print("Downloading the test files...")
-source_file = sacrebleu.get_source_file(test_set, langpair=langpair)
-target_file = sacrebleu.get_reference_files(test_set, langpair=langpair)[0]
+if debug_mode:
+    num_samples = 1
+else:
+    num_samples = 5 if gpu else 3
 
 
 class Image:
     def __init__(self, rel_path, runs):
         self.runs = [env for run_device, env in runs if run_device == device]
         if self.runs:
+            print("")
             print("Building image %s..." % rel_path)
-            self.image, _ = client.images.build(
-                path=os.path.join(current_dir, rel_path), tag=rel_path
+
+            build_logs = api_client.build(
+                path=os.path.join(current_dir, rel_path), tag=rel_path, rm=True
             )
+
+            for log in build_logs:
+                log = json.loads(log)
+                if "error" in log:
+                    raise RuntimeError(log["error"])
+                if "stream" in log:
+                    print(log["stream"], end="")
+
+            self.image = client.images.get(rel_path)
         else:
             self.image = None
 
@@ -121,40 +137,71 @@ images = [
     ),
 ]
 
+
+print("Downloading the test files...")
+source_file = sacrebleu.get_source_file(test_set, langpair=langpair)
+target_file = sacrebleu.get_reference_files(test_set, langpair=langpair)[0]
+
+if debug_mode:
+
+    def _shorten_file(path, num_lines=64):
+        fd, new_path = tempfile.mkstemp()
+        os.close(fd)
+        with open(path) as src, open(new_path, "w") as dst:
+            for i, line in enumerate(src):
+                dst.write(line)
+                if i + 1 == num_lines:
+                    break
+        return new_path
+
+    source_file = _shorten_file(source_file)
+    target_file = _shorten_file(target_file)
+
+
 print("Running the benchmark...")
 print("")
 
-first = True
-for image in images:
-    for run_name, result in image.run():
-        tokens_per_sec = result.num_tokens / result.translation_time
+try:
 
-        if gpu:
-            if first:
-                print("| | Tokens per second | Max. GPU memory | Max. CPU memory | BLEU |")
-                print("| --- | --- | --- | --- | --- |")
-            print(
-                "| %s | %.1f | %dMB | %dMB | %.2f |"
-                % (
-                    run_name,
-                    tokens_per_sec,
-                    int(result.max_gpu_mem),
-                    int(result.max_cpu_mem),
-                    result.bleu_score,
-                )
-            )
-        else:
-            if first:
-                print("| | Tokens per second | Max. memory | BLEU |")
-                print("| --- | --- | --- | --- |")
-            print(
-                "| %s | %.1f | %dMB | %.2f |"
-                % (
-                    run_name,
-                    tokens_per_sec,
-                    int(result.max_cpu_mem),
-                    result.bleu_score,
-                )
-            )
+    first = True
+    for image in images:
+        for run_name, result in image.run():
+            tokens_per_sec = result.num_tokens / result.translation_time
 
-        first = False
+            if gpu:
+                if first:
+                    print(
+                        "| | Tokens per second | Max. GPU memory | Max. CPU memory | BLEU |"
+                    )
+                    print("| --- | --- | --- | --- | --- |")
+                print(
+                    "| %s | %.1f | %dMB | %dMB | %.2f |"
+                    % (
+                        run_name,
+                        tokens_per_sec,
+                        int(result.max_gpu_mem),
+                        int(result.max_cpu_mem),
+                        result.bleu_score,
+                    )
+                )
+            else:
+                if first:
+                    print("| | Tokens per second | Max. memory | BLEU |")
+                    print("| --- | --- | --- | --- |")
+                print(
+                    "| %s | %.1f | %dMB | %.2f |"
+                    % (
+                        run_name,
+                        tokens_per_sec,
+                        int(result.max_cpu_mem),
+                        result.bleu_score,
+                    )
+                )
+
+            first = False
+
+finally:
+
+    if debug_mode:
+        os.remove(source_file)
+        os.remove(target_file)

--- a/tools/benchmark/opennmt_ende_wmt14/ctranslate2/Dockerfile
+++ b/tools/benchmark/opennmt_ende_wmt14/ctranslate2/Dockerfile
@@ -1,4 +1,4 @@
-FROM opennmt/ctranslate2:2.17.0-ubuntu20.04-cuda11.2 as model_converter
+FROM opennmt/ctranslate2:3.6.0-ubuntu20.04-cuda11.2 as model_converter
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN ct2-opennmt-py-converter --model_path averaged-10-epoch.pt --output_dir /mod
 RUN wget -q -P /model https://opennmt-models.s3.amazonaws.com/vmap.txt
 RUN cp sentencepiece.model /model
 
-FROM opennmt/ctranslate2:2.17.0-ubuntu20.04-cuda11.2
+FROM opennmt/ctranslate2:3.6.0-ubuntu20.04-cuda11.2
 
 COPY --from=model_converter /model /model
 

--- a/tools/benchmark/opennmt_ende_wmt14/ctranslate2/translate
+++ b/tools/benchmark/opennmt_ende_wmt14/ctranslate2/translate
@@ -8,4 +8,4 @@ if [ ${USE_VMAP:-0} = "1" ]; then
     EXTRA_ARGS+=" --use_vmap"
 fi
 
-/opt/ctranslate2/bin/translate --model /model --src $SOURCE_FILE --out $OUTPUT_FILE --device auto --batch_size 32 --beam_size 4 --compute_type ${COMPUTE_TYPE:-default} $EXTRA_ARGS
+/opt/ctranslate2/bin/ct2-translator --model /model --src $SOURCE_FILE --out $OUTPUT_FILE --device auto --batch_size 32 --beam_size 4 --length_penalty 0 --compute_type ${COMPUTE_TYPE:-default} $EXTRA_ARGS

--- a/tools/benchmark/opennmt_ende_wmt14/fastertransformer/Dockerfile
+++ b/tools/benchmark/opennmt_ende_wmt14/fastertransformer/Dockerfile
@@ -1,6 +1,6 @@
-FROM nvcr.io/nvidia/pytorch:21.09-py3
+FROM nvcr.io/nvidia/pytorch:22.09-py3
 
-RUN git clone --branch v5.0 https://github.com/NVIDIA/FasterTransformer.git && \
+RUN git clone --branch v5.3 https://github.com/NVIDIA/FasterTransformer.git && \
     cd FasterTransformer && \
     mkdir build && \
     cd build && \

--- a/tools/benchmark/opennmt_ende_wmt14/opennmt_py/Dockerfile
+++ b/tools/benchmark/opennmt_ende_wmt14/opennmt_py/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.11.0-cuda11.3-cudnn8-runtime
+FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -7,10 +7,14 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+ENV VERSION=3.0.4
+RUN pip install --no-cache-dir OpenNMT-py==$VERSION
+
+ADD convertv2_v3.py .
 RUN wget -q https://opennmt-models.s3.amazonaws.com/transformer-ende-wmt-pyOnmt.tar.gz && \
     tar xf *.tar.gz && \
-    rm *.tar.gz
-
-RUN pip install --no-cache-dir OpenNMT-py==2.2.0
+    rm *.tar.gz && \
+    python3 convertv2_v3.py -v2model averaged-10-epoch.pt -v3model averaged-10-epoch-v3.pt && \
+    rm averaged-10-epoch.pt
 
 COPY tokenize detokenize translate /

--- a/tools/benchmark/opennmt_ende_wmt14/opennmt_py/convertv2_v3.py
+++ b/tools/benchmark/opennmt_ende_wmt14/opennmt_py/convertv2_v3.py
@@ -1,0 +1,88 @@
+import torch
+import imp
+import argparse
+import pyonmttok
+from onmt.constants import DefaultTokens
+from onmt.inputters.inputter import vocabs_to_dict
+
+# with the two module = imp.load_source() below
+# we ghost the old torchtext.data.field and depercated
+# onmt.inputters.text_dataset
+# however this require some functions / classes to be
+# monkey patched for loading the old field/vocab objects.
+
+
+def _feature_tokenize():
+    return 0
+
+
+class RawField(object):
+    def __init__(self):
+        pass
+
+
+class TextMultiField(RawField):
+    def __init__(self):
+        pass
+
+
+class Field(RawField):
+    def __init__(self):
+        pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v2model",
+        type=str,
+        required=True,
+        help="Source OpenNMT-py v2.x model to be converted in v3.x",
+    )
+    parser.add_argument(
+        "-v3model",
+        type=str,
+        required=True,
+        help="Target model to be used by OpenNMT-py v3.x",
+    )
+
+    opt = parser.parse_args()
+    print(opt)
+    module1 = imp.load_source("torchtext.data.field", "convertv2_v3.py")
+    module2 = imp.load_source("onmt.inputters.text_dataset", "convertv2_v3.py")
+    checkpoint = torch.load(opt.v2model, map_location="cpu")
+    vocabs = {}
+    multifield = checkpoint["vocab"]["src"]
+    multifields = multifield.fields
+    _, fields = multifields[0]
+    voc = fields.vocab.__dict__["itos"]
+    src_vocab = pyonmttok.build_vocab_from_tokens(
+        voc, maximum_size=0, minimum_frequency=1
+    )
+    src_vocab.default_id = src_vocab[DefaultTokens.UNK]
+    vocabs["src"] = src_vocab
+    print("Source vocab size is:", len(src_vocab))
+    multifield = checkpoint["vocab"]["tgt"]
+    multifields = multifield.fields
+    _, fields = multifields[0]
+    voc = fields.vocab.__dict__["itos"]
+    tgt_vocab = pyonmttok.build_vocab_from_tokens(
+        voc, maximum_size=0, minimum_frequency=1
+    )
+    tgt_vocab.default_id = src_vocab[DefaultTokens.UNK]
+    vocabs["tgt"] = tgt_vocab
+    print("Target vocab size is:", len(tgt_vocab))
+    if hasattr(checkpoint["opt"], "data_task"):
+        print("Model is type:", checkpoint["opt"].data_task)
+        vocabs["data_task"] = checkpoint["opt"].data_task
+    else:
+        vocabs["data_task"] = "seq2seq"
+    checkpoint["vocab"] = vocabs_to_dict(vocabs)
+
+    checkpoint["opt"].__dict__["hidden_size"] = checkpoint["opt"].__dict__.pop(
+        "rnn_size"
+    )
+
+    checkpoint["opt"].__dict__["add_qkvbias"] = True
+
+    torch.save(checkpoint, opt.v3model)

--- a/tools/benchmark/opennmt_ende_wmt14/opennmt_py/translate
+++ b/tools/benchmark/opennmt_ende_wmt14/opennmt_py/translate
@@ -12,5 +12,5 @@ if [ ${INT8:-0} = "1" ]; then
     EXTRA_ARGS+=" -int8"
 fi
 
-onmt_translate -model /workspace/averaged-10-epoch.pt -src $SOURCE_FILE -out $OUTPUT_FILE \
-               -batch_size 32 -beam_size 4 $EXTRA_ARGS
+onmt_translate -model /workspace/averaged-10-epoch-v3.pt -src $SOURCE_FILE -out $OUTPUT_FILE \
+               -batch_size 32 -beam_size 4 -length_penalty none $EXTRA_ARGS

--- a/tools/benchmark/opennmt_ende_wmt14/opennmt_tf/Dockerfile
+++ b/tools/benchmark/opennmt_ende_wmt14/opennmt_tf/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.9.0-gpu
+FROM tensorflow/tensorflow:2.11.0-gpu
 
 RUN curl -O https://opennmt-models.s3.amazonaws.com/averaged-ende-ckpt500k-v2.tar.gz && \
     tar xf *.tar.gz && \
@@ -6,7 +6,7 @@ RUN curl -O https://opennmt-models.s3.amazonaws.com/averaged-ende-ckpt500k-v2.ta
 RUN cd averaged-ende-ckpt500k-v2 && \
     curl -O https://opennmt-trainingdata.s3.amazonaws.com/wmtende.model
 
-RUN python3 -m pip install --no-cache-dir OpenNMT-tf==2.26.*
+RUN python3 -m pip install --no-cache-dir OpenNMT-tf==2.31.*
 
 COPY *.yml /
 COPY tokenize detokenize translate /

--- a/tools/benchmark/opennmt_ende_wmt14/opennmt_tf/translate
+++ b/tools/benchmark/opennmt_ende_wmt14/opennmt_tf/translate
@@ -7,5 +7,6 @@ onmt-main --model_dir /averaged-ende-ckpt500k-v2 \
           --model_type Transformer \
           --config /config.yml \
           --gpu_allow_growth \
+          --intra_op_parallelism_threads $OMP_NUM_THREADS \
           infer \
           --features_file $SOURCE_FILE --predictions_file $OUTPUT_FILE

--- a/tools/benchmark/opus_mt_ende/ctranslate2/Dockerfile
+++ b/tools/benchmark/opus_mt_ende/ctranslate2/Dockerfile
@@ -1,4 +1,4 @@
-FROM opennmt/ctranslate2:2.17.0-ubuntu20.04-cuda11.2
+FROM opennmt/ctranslate2:3.6.0-ubuntu20.04-cuda11.2
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/tools/benchmark/opus_mt_ende/ctranslate2/translate
+++ b/tools/benchmark/opus_mt_ende/ctranslate2/translate
@@ -3,4 +3,4 @@
 SOURCE_FILE=$2
 OUTPUT_FILE=$3
 
-/opt/ctranslate2/bin/translate --model /model --src $SOURCE_FILE --out $OUTPUT_FILE --device auto --batch_size 32 --beam_size 4 --compute_type ${COMPUTE_TYPE:-default}
+/opt/ctranslate2/bin/ct2-translator --model /model --src $SOURCE_FILE --out $OUTPUT_FILE --device auto --batch_size 32 --beam_size 4 --length_penalty 0 --compute_type ${COMPUTE_TYPE:-default}

--- a/tools/benchmark/opus_mt_ende/transformers/Dockerfile
+++ b/tools/benchmark/opus_mt_ende/transformers/Dockerfile
@@ -1,5 +1,10 @@
-FROM huggingface/transformers-pytorch-gpu:4.19.2
+FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
 
 ENV MODEL_NAME="Helsinki-NLP/opus-mt-en-de"
 
+RUN python3 -m pip install --no-cache-dir transformers==4.26.* sentencepiece sacremoses
+
 COPY tokenize detokenize translate /
+
+# Call translate once to download and cache the model.
+RUN touch /tmp/input.txt && /translate CPU /tmp/input.txt /tmp/output.txt && rm /tmp/input.txt

--- a/tools/benchmark/opus_mt_ende/transformers/translate
+++ b/tools/benchmark/opus_mt_ende/transformers/translate
@@ -20,31 +20,31 @@ batch_size = 32
 beam_size = 4
 
 
+def to_tensor(batch):
+    max_length = max(len(ids) for ids in batch)
+    batch = [ids + [tokenizer.pad_token_id] * (max_length - len(ids)) for ids in batch]
+    return torch.tensor(batch, device=model.device)
+
+
 def batch_iter(lines):
     batch = []
     for line in lines:
         ids = list(map(int, line.strip().split()))
-        tensor = torch.tensor(ids, device=model.device)
-        batch.append(tensor)
+        batch.append(ids)
         if len(batch) == batch_size:
-            yield batch
+            yield to_tensor(batch)
             batch = []
     if batch:
-        yield batch
+        yield to_tensor(batch)
 
 
 with open(input_path) as input_file, open(output_path, "w") as output_file:
     for batch in batch_iter(input_file):
-        batch = torch.nn.utils.rnn.pad_sequence(
-            batch,
-            batch_first=True,
-            padding_value=tokenizer.pad_token_id,
-        )
-
         outputs = model.generate(
             input_ids=batch,
             num_beams=beam_size,
             length_penalty=0,
+            early_stopping=True,
         )
 
         for tokens in outputs.tolist():


### PR DESCRIPTION
Changes to the scripts:

* Update all frameworks to their latest version
* Show the Docker build logs
* Correctly show the error message when a framework fails with an error
* Add a debug mode

Changes to the benchmark condition:

* CPU benchmark was run on a smaller C5 instance and only with 4 threads so the throughput appears worse for all frameworks
* GPU benchmark was run on a G5 instance with a A10G GPU (Ampere)