### PR TITLE
Also include the EOS in Whisper greedy search

### DIFF
--- a/src/models/whisper.cc
+++ b/src/models/whisper.cc
@@ -273,7 +273,7 @@ namespace ctranslate2 {
       decoding_options.sampling_temperature = options.sampling_temperature;
       decoding_options.num_hypotheses = options.num_hypotheses;
       decoding_options.return_scores = options.return_scores;
-      decoding_options.include_eos_in_scores = options.beam_size > 1;
+      decoding_options.include_eos_in_scores = true;
       decoding_options.include_eos_in_hypotheses = false;
       for (const auto& id : _model->config["suppress_ids"])
         decoding_options.disable_ids.push_back(id);


### PR DESCRIPTION
In this line:

https://github.com/openai/whisper/blob/7858aa9c08d98f75575035ecd6481f462d66ca27/whisper/decoding.py#L262

it seems the score of EOS is excluded, but `tokens` refers to the tokens that are already generated.