### PR TITLE
Remove unused decoding option include_eos_in_scores

### DIFF
--- a/include/ctranslate2/decoding.h
+++ b/include/ctranslate2/decoding.h
@@ -30,7 +30,6 @@ namespace ctranslate2 {
            const bool return_scores = false,
            const bool return_attention = false,
            const size_t num_hypotheses = 1,
-           const bool include_eos_in_scores = true,
            const bool include_eos_in_hypotheses = true,
            const std::vector<std::shared_ptr<LogitsProcessor>>& logits_processors = {},
            const std::vector<std::vector<size_t>>* prefix_ids = nullptr) const = 0;
@@ -56,7 +55,6 @@ namespace ctranslate2 {
            const bool return_scores = false,
            const bool return_attention = false,
            const size_t num_hypotheses = 1,
-           const bool include_eos_in_scores = true,
            const bool include_eos_in_hypotheses = true,
            const std::vector<std::shared_ptr<LogitsProcessor>>& logits_processors = {},
            const std::vector<std::vector<size_t>>* prefix_ids = nullptr) const override;
@@ -105,7 +103,6 @@ namespace ctranslate2 {
            const bool return_scores = false,
            const bool return_attention = false,
            const size_t num_hypotheses = 1,
-           const bool include_eos_in_scores = true,
            const bool include_eos_in_hypotheses = true,
            const std::vector<std::shared_ptr<LogitsProcessor>>& logits_processors = {},
            const std::vector<std::vector<size_t>>* prefix_ids = nullptr) const override;
@@ -130,7 +127,6 @@ namespace ctranslate2 {
     size_t sampling_topk = 1;
     float sampling_temperature = 1;
     size_t num_hypotheses = 1;
-    bool include_eos_in_scores = true;
     bool include_eos_in_hypotheses = true;
     bool return_scores = false;
     bool return_attention = false;

--- a/src/models/whisper.cc
+++ b/src/models/whisper.cc
@@ -273,7 +273,6 @@ namespace ctranslate2 {
       decoding_options.sampling_temperature = options.sampling_temperature;
       decoding_options.num_hypotheses = options.num_hypotheses;
       decoding_options.return_scores = options.return_scores;
-      decoding_options.include_eos_in_scores = true;
       decoding_options.include_eos_in_hypotheses = false;
       for (const auto& id : _model->config["suppress_ids"])
         decoding_options.disable_ids.push_back(id);


### PR DESCRIPTION
This option was initially added to match the decoding from openai/whisper, but it was actually a wrong understanding of the implementation. Now this option is no longer used so let's remove it.