### PR TITLE
Skip equality check when the first value is different

### DIFF
--- a/python/ctranslate2/specs/model_spec.py
+++ b/python/ctranslate2/specs/model_spec.py
@@ -154,6 +154,8 @@ class LayerSpec(FrozenAttr, metaclass=FrozenMeta):
                 if (
                     not np.isscalar(value)
                     and value.dtype == other_value.dtype
+                    and value.shape == other_value.shape
+                    and value.flat[0] == other_value.flat[0]
                     and np.array_equal(value, other_value)
                 ):
                     # Replace variable value by the alias name.


### PR DESCRIPTION
The conversion code uses an equality check to resolve shared weights. Comparing the complete array is wasteful if the first element is different, which is almost always the case when comparing 2 different non-shared weights.

This reduces the conversion time for large models.