### PR TITLE
Use FP32 compute type for FP16 convolutions

### DIFF
--- a/src/ops/conv1d_gpu.cu
+++ b/src/ops/conv1d_gpu.cu
@@ -50,7 +50,11 @@ namespace ctranslate2 {
                                                   /*stride_h=*/1, /*stride_w=*/_stride,
                                                   /*dilation_h=*/1, /*dilation_w=*/_dilation,
                                                   CUDNN_CROSS_CORRELATION,
-                                                  data_type));
+                                                  CUDNN_DATA_FLOAT));
+
+      CUDNN_CHECK(cudnnSetConvolutionMathType(conv_desc, CUDNN_DEFAULT_MATH));
+      if (data_type == CUDNN_DATA_HALF)
+        CUDNN_CHECK(cudnnSetConvolutionMathType(conv_desc, CUDNN_TENSOR_OP_MATH));
 
       cudnnHandle_t handle = cuda::get_cudnn_handle();
 


### PR DESCRIPTION
This matches the PyTorch behavior and accuracy:

https://github.com/pytorch/pytorch/blob/a4238976a8f42f259371c1c83ff6be835960ac48/aten/src/ATen/cudnn/Descriptors.h#L188-L190

Fixes #1111.