### PR TITLE
Fix synchronization issue when the model input is a CUDA storage

### DIFF
--- a/include/ctranslate2/models/whisper.h
+++ b/include/ctranslate2/models/whisper.h
@@ -148,23 +148,23 @@ namespace ctranslate2 {
 
       bool is_multilingual() const;
 
-      std::future<StorageView> encode(StorageView features, const bool to_cpu);
+      std::future<StorageView> encode(const StorageView& features, const bool to_cpu);
 
       std::vector<std::future<WhisperGenerationResult>>
-      generate(StorageView features,
+      generate(const StorageView& features,
                std::vector<std::vector<std::string>> prompts,
                WhisperOptions options = {});
 
       std::vector<std::future<WhisperGenerationResult>>
-      generate(StorageView features,
+      generate(const StorageView& features,
                std::vector<std::vector<size_t>> prompts,
                WhisperOptions options = {});
 
       std::vector<std::future<std::vector<std::pair<std::string, float>>>>
-      detect_language(StorageView features);
+      detect_language(const StorageView& features);
 
       std::vector<std::future<WhisperAlignmentResult>>
-      align(StorageView features,
+      align(const StorageView& features,
             std::vector<size_t> start_sequence,
             std::vector<std::vector<size_t>> text_tokens,
             dim_t num_frames,

--- a/include/ctranslate2/storage_view.h
+++ b/include/ctranslate2/storage_view.h
@@ -74,7 +74,7 @@ namespace ctranslate2 {
     StorageView(Shape shape, T* data, Device device = Device::CPU);
 
     // Copy constructor.
-    StorageView(const StorageView& other);
+    StorageView(const StorageView& other, bool synchronous = false);
     // Move constructor (swap of each attribute).
     StorageView(StorageView&& other) noexcept;
     ~StorageView();
@@ -169,6 +169,7 @@ namespace ctranslate2 {
     StorageView& operator=(StorageView&& other) noexcept;
 
     StorageView& shallow_copy(StorageView& other);
+    StorageView sync_copy() const;
 
     void* buffer();
     const void* buffer() const;
@@ -230,10 +231,10 @@ namespace ctranslate2 {
     StorageView& fill(T value);
     StorageView& zero();
 
-    StorageView& copy_from(const StorageView& other);
+    StorageView& copy_from(const StorageView& other, bool synchronous = false);
 
     template <typename T>
-    StorageView& copy_from(const T* data, dim_t size, Device device);
+    StorageView& copy_from(const T* data, dim_t size, Device device, bool synchronous = false);
 
     friend std::ostream& operator<<(std::ostream& os, const StorageView& storage);
 

--- a/src/models/whisper.cc
+++ b/src/models/whisper.cc
@@ -576,19 +576,19 @@ namespace ctranslate2 {
       return replica.is_multilingual();
     }
 
-    std::future<StorageView> Whisper::encode(StorageView features, const bool to_cpu) {
-      return post<StorageView>([features = std::move(features), to_cpu](WhisperReplica& replica) {
+    std::future<StorageView> Whisper::encode(const StorageView& features, const bool to_cpu) {
+      return post<StorageView>([features = features.sync_copy(), to_cpu](WhisperReplica& replica) {
         return replica.encode(std::move(features), to_cpu);
       });
     }
 
     std::vector<std::future<WhisperGenerationResult>>
-    Whisper::generate(StorageView features,
+    Whisper::generate(const StorageView& features,
                       std::vector<std::vector<std::string>> prompts,
                       WhisperOptions options) {
       const size_t batch_size = features.dim(0);
       return post_batch<WhisperGenerationResult>(
-        [features = std::move(features), prompts = std::move(prompts), options]
+        [features = features.sync_copy(), prompts = std::move(prompts), options]
         (WhisperReplica& replica) {
           return replica.generate(std::move(features), prompts, options);
         },
@@ -596,12 +596,12 @@ namespace ctranslate2 {
     }
 
     std::vector<std::future<WhisperGenerationResult>>
-    Whisper::generate(StorageView features,
+    Whisper::generate(const StorageView& features,
                       std::vector<std::vector<size_t>> prompts,
                       WhisperOptions options) {
       const size_t batch_size = features.dim(0);
       return post_batch<WhisperGenerationResult>(
-        [features = std::move(features), prompts = std::move(prompts), options]
+        [features = features.sync_copy(), prompts = std::move(prompts), options]
         (WhisperReplica& replica) {
           return replica.generate(std::move(features), prompts, options);
         },
@@ -609,24 +609,24 @@ namespace ctranslate2 {
     }
 
     std::vector<std::future<std::vector<std::pair<std::string, float>>>>
-    Whisper::detect_language(StorageView features) {
+    Whisper::detect_language(const StorageView& features) {
       const size_t batch_size = features.dim(0);
       return post_batch<std::vector<std::pair<std::string, float>>>(
-        [features = std::move(features)](WhisperReplica& replica) {
+        [features = features.sync_copy()](WhisperReplica& replica) {
           return replica.detect_language(std::move(features));
         },
         batch_size);
     }
 
     std::vector<std::future<WhisperAlignmentResult>>
-    Whisper::align(StorageView features,
+    Whisper::align(const StorageView& features,
                    std::vector<size_t> start_sequence,
                    std::vector<std::vector<size_t>> text_tokens,
                    dim_t num_frames,
                    dim_t median_filter_width) {
       const size_t batch_size = features.dim(0);
       return post_batch<WhisperAlignmentResult>(
-        [features = std::move(features),
+        [features = features.sync_copy(),
          start_sequence = std::move(start_sequence),
          text_tokens = std::move(text_tokens),
          num_frames,


### PR DESCRIPTION
These model methods are asynchronous so the input storage must be copied in the job to ensure its lifetime. However, when the input storage is on the GPU the copy is running on a different CUDA stream than the one used by the model worker. Consequently the model worker may work on invalid data in some cases.

The copy must be synchronous for these storages.