### PR TITLE
Adding support for transformers - Salesforce/CodeGen architecture

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -116,9 +116,7 @@ class TransformersConverter(Converter):
             spec = loader(model, tokenizer)
 
             if self._activation_scales:
-                activation_scales = torch.load(
-                    self._activation_scales, map_location="cpu"
-                )
+                activation_scales = torch.load(self._activation_scales, map_location="cpu")
                 loader.smooth_activation(spec, activation_scales)
 
             if self._copy_files:
@@ -148,8 +146,7 @@ class TransformersConverter(Converter):
 
         if path is None or not os.path.isfile(path):
             raise ValueError(
-                "File %s does not exist in model %s"
-                % (filename, self._model_name_or_path)
+                "File %s does not exist in model %s" % (filename, self._model_name_or_path)
             )
 
         return path
@@ -177,10 +174,7 @@ class ModelLoader(abc.ABC):
 
     def get_vocabulary(self, model, tokenizer):
         return [
-            token
-            for token, _ in sorted(
-                tokenizer.get_vocab().items(), key=lambda item: item[1]
-            )
+            token for token, _ in sorted(tokenizer.get_vocab().items(), key=lambda item: item[1])
         ]
 
     def set_vocabulary(self, spec, tokens):
@@ -212,9 +206,7 @@ class ModelLoader(abc.ABC):
             spec.encodings = spec.encodings[offset:]
 
     def smooth_activation(self, spec, activation_scales):
-        raise NotImplementedError(
-            "No activation smoothing logic is defined for this model"
-        )
+        raise NotImplementedError("No activation smoothing logic is defined for this model")
 
 
 @register_loader("BartConfig")
@@ -325,9 +317,7 @@ class BartLoader(ModelLoader):
         spec.scale_embeddings = module.embed_scale
         self.set_position_encodings(spec.position_encodings, module.embed_positions)
         self.set_embeddings(
-            spec.embeddings[0]
-            if isinstance(spec.embeddings, list)
-            else spec.embeddings,
+            spec.embeddings[0] if isinstance(spec.embeddings, list) else spec.embeddings,
             module.embed_tokens,
         )
 
@@ -763,12 +753,8 @@ class GPTNeoXLoader(ModelLoader):
                     layer_spec.post_attention_layer_norm, layer.post_attention_layernorm
                 )
             else:
-                self.set_layer_norm(
-                    layer_spec.self_attention.layer_norm, layer.input_layernorm
-                )
-                self.set_layer_norm(
-                    layer_spec.ffn.layer_norm, layer.post_attention_layernorm
-                )
+                self.set_layer_norm(layer_spec.self_attention.layer_norm, layer.input_layernorm)
+                self.set_layer_norm(layer_spec.ffn.layer_norm, layer.post_attention_layernorm)
 
             qkv_w = layer.attention.query_key_value.weight.numpy()
             qkv_b = layer.attention.query_key_value.bias.numpy()
@@ -828,10 +814,7 @@ class WhisperLoader(BartLoader):
         tokens = super().get_vocabulary(model, tokenizer)
 
         # Add timestamp tokens.
-        tokens.extend(
-            "<|%.2f|>" % (i * 0.02)
-            for i in range(model.config.vocab_size - len(tokens))
-        )
+        tokens.extend("<|%.2f|>" % (i * 0.02) for i in range(model.config.vocab_size - len(tokens)))
 
         return tokens
 
@@ -904,9 +887,7 @@ class T5Loader(ModelLoader):
     def set_stack(self, spec, module, is_decoder=False):
         self.set_layer_norm(spec.layer_norm, module.final_layer_norm)
         self.set_embeddings(
-            spec.embeddings[0]
-            if isinstance(spec.embeddings, list)
-            else spec.embeddings,
+            spec.embeddings[0] if isinstance(spec.embeddings, list) else spec.embeddings,
             module.embed_tokens,
         )
 
@@ -965,9 +946,7 @@ class T5Loader(ModelLoader):
         self.set_linear(spec.linear[-1], attention.o)
 
         if attention.has_relative_attention_bias:
-            spec.relative_attention_bias = (
-                attention.relative_attention_bias.weight.numpy()
-            )
+            spec.relative_attention_bias = attention.relative_attention_bias.weight.numpy()
             spec.relative_attention_max_distance = np.dtype("int32").type(
                 attention.relative_attention_max_distance
             )
@@ -1027,21 +1006,15 @@ class BloomLoader(ModelLoader):
         self.set_layer_norm(spec.layer_norm, module.ln_f)
 
         for layer_spec, layer in zip(spec.layer, module.h):
-            self.set_layer_norm(
-                layer_spec.self_attention.layer_norm, layer.input_layernorm
-            )
+            self.set_layer_norm(layer_spec.self_attention.layer_norm, layer.input_layernorm)
             self.set_qkv_linear(
                 layer_spec.self_attention.linear[0],
                 layer.self_attention.query_key_value,
                 layer.self_attention.num_heads,
             )
-            self.set_linear(
-                layer_spec.self_attention.linear[1], layer.self_attention.dense
-            )
+            self.set_linear(layer_spec.self_attention.linear[1], layer.self_attention.dense)
 
-            self.set_layer_norm(
-                layer_spec.ffn.layer_norm, layer.post_attention_layernorm
-            )
+            self.set_layer_norm(layer_spec.ffn.layer_norm, layer.post_attention_layernorm)
             self.set_linear(layer_spec.ffn.linear_0, layer.mlp.dense_h_to_4h)
             self.set_linear(layer_spec.ffn.linear_1, layer.mlp.dense_4h_to_h)
 
@@ -1061,9 +1034,7 @@ class BloomLoader(ModelLoader):
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
-    )
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         "--model",
         required=True,

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -626,6 +626,96 @@ class GPTJLoader(ModelLoader):
             self.set_linear(layer_spec.ffn.linear_0, layer.mlp.fc_in)
             self.set_linear(layer_spec.ffn.linear_1, layer.mlp.fc_out)
 
+@register_loader("CodeGenConfig")
+class CodeGenLoader(ModelLoader):
+    @property
+    def architecture_name(self):
+        return "CodeGenForCausalLM"
+
+    def get_model_spec(self, model):
+        spec = transformer_spec.TransformerDecoderModelSpec.from_config(
+            model.config.n_layer,
+            model.config.n_head,
+            pre_norm=True,
+            activation=_SUPPORTED_ACTIVATIONS[model.config.activation_function],
+            rotary_dim=model.config.rotary_dim,
+            rotary_interleave=False,
+            parallel_residual=True,
+            shared_layer_norm=True,
+        )
+
+        self.set_decoder(
+            spec.decoder,
+            model.transformer,
+            model.config.rotary_dim,
+            model.config.n_head,
+            model.config.n_embd # added arg compared to GPT-J
+        )
+        self.set_linear(spec.decoder.projection, model.lm_head)
+        return spec
+
+    def get_vocabulary(self, model, tokenizer):
+        tokens = super().get_vocabulary(model, tokenizer)
+
+        extra_ids = model.config.vocab_size - len(tokens)
+        for i in range(extra_ids):
+            # fix from GPTNeoX Converter.
+            tokens.append("<extra_id_%d>" % i)
+
+        return tokens
+
+    def set_vocabulary(self, spec, tokens):
+        spec.register_vocabulary(tokens)
+
+    def set_config(self, config, model, tokenizer):
+        config.bos_token = tokenizer.bos_token
+        config.eos_token = tokenizer.eos_token
+        config.unk_token = tokenizer.unk_token
+
+    def set_decoder(self, spec, module, rotary_dim, num_heads, embed_dim):
+        spec.scale_embeddings = False
+        self.set_embeddings(spec.embeddings, module.wte)
+        self.set_layer_norm(spec.layer_norm, module.ln_f)
+
+        for layer_spec, layer in zip(spec.layer, module.h):
+            self.set_layer_norm(layer_spec.shared_layer_norm, layer.ln_1)
+            ### convert CodeGen to GPT-J: 
+            # numpy conversion, adapted from torch code in 
+            # see https://github.com/fauxpilot/fauxpilot/blob/fb4073a9078dd001ebeb7dfefb8cb2ecc8a88f4b/converter/codegen_gptj_convert.py # noqa
+            qkv_proj = layer.attn.qkv_proj.weight
+            mp_num = 4  # number hardcoded in CodeGen from TPU
+            local_dim = embed_dim // mp_num
+            # GPT-J and CodeGen slice up the qkv projection slightly differently.
+            # After a great deal of pain, I figured out that this permutation on
+            # the weights of the qkv_proj fixes it.
+            base_permutation = [0, 3, 6, 9, 1, 4, 7, 10, 2, 5, 8, 11]
+            # permutation = torch.cat([torch.arange(i * local_dim, (i + 1) * local_dim) for i in base_permutation])
+            permutation_np = np.concatenate([np.arange(i * local_dim, (i + 1) * local_dim) for i in base_permutation])
+            # NB: we permute the *rows* here because the computation is xA.T
+            # new_qkv_proj = qkv_proj[permutation, :]
+            new_qkv_proj_np = qkv_proj.numpy()[permutation_np, :]
+            # NB: the name QKV is misleading here; they are actually stored in
+            #     the order QVK
+            # qw, vw, kw = torch.split(new_qkv_proj, embed_dim, dim=0)
+            qw, vw, kw = np.array_split(new_qkv_proj_np, 3, axis=0)
+            ### 
+            # qw = qw.numpy()
+            # kw = kw.numpy()
+            # vw = vw.numpy()
+            # np.testing.assert_equal(qw,qwn)
+            # np.testing.assert_equal(kw,kwn)
+            # np.testing.assert_equal(vw,vwn)
+
+            qw = utils.permute_for_sliced_rotary(qw, num_heads, rotary_dim)
+            kw = utils.permute_for_sliced_rotary(kw, num_heads, rotary_dim)
+
+            layer_spec.self_attention.linear[0].weight = np.concatenate((qw, kw, vw))
+            self.set_linear(layer_spec.self_attention.linear[1], layer.attn.out_proj)
+
+            self.set_linear(layer_spec.ffn.linear_0, layer.mlp.fc_in)
+            self.set_linear(layer_spec.ffn.linear_1, layer.mlp.fc_out)
+
+
 
 @register_loader("GPTNeoXConfig")
 class GPTNeoXLoader(ModelLoader):

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -646,9 +646,7 @@ class CodeGenLoader(ModelLoader):
         )
 
         mp_num = 4
-        if (
-            hasattr(model.config, "head_dim") and model.config.head_dim in [128,256]
-        ):
+        if hasattr(model.config, "head_dim") and model.config.head_dim in [128, 256]:
             # models forked from "Salesforce/codegen2-1B" and "Salesforce/codegen2-3_7B"
             # use a special setting of mp_num=8, all other using 4
             # these model.config's use a special setting of head_dim

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -698,49 +698,9 @@ class CodeGenLoader(ModelLoader):
                 # setting mp_num=8, while transformers using
                 # mp_num=4
                 mp_num = 8  # number hardcoded in CodeGen-2 from TPU
-                base_permutation = [
-                    0,
-                    3,
-                    6,
-                    9,
-                    12,
-                    15,
-                    18,
-                    21,
-                    1,
-                    4,
-                    7,
-                    10,
-                    13,
-                    16,
-                    19,
-                    22,
-                    2,
-                    5,
-                    8,
-                    11,
-                    14,
-                    17,
-                    20,
-                    23,
-                ]
             else:
                 mp_num = 4  # number hardcoded in CodeGen(1) from TPU
-                base_permutation = [
-                    0,
-                    3,
-                    6,
-                    9,
-                    1,
-                    4,
-                    7,
-                    10,
-                    2,
-                    5,
-                    8,
-                    11,
-                ]
-            # base_permutation == np.arange(0,mp_num*3).reshape(-1,3).T.flatten()
+            base_permutation = np.arange(0,mp_num*3).reshape(-1,3).T.flatten().tolist()
             # equals embed_dim:= (self.head_dim * self.num_attention_heads) from Codegen code
             local_dim = embed_dim // mp_num
             permutation_np = np.concatenate(

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -646,7 +646,10 @@ class CodeGenLoader(ModelLoader):
         )
 
         mp_num = 4
-        if "Salesforce/codegen2-1B" in model.name_or_path or "Salesforce/codegen2-3_7B" in model.name_or_path:
+        if (
+            "Salesforce/codegen2-1B" in model.name_or_path
+            or "Salesforce/codegen2-3_7B" in model.name_or_path
+        ):
             # consider mp_num=8 for smaller codegen2 series.
             mp_num = 8
 

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -116,7 +116,9 @@ class TransformersConverter(Converter):
             spec = loader(model, tokenizer)
 
             if self._activation_scales:
-                activation_scales = torch.load(self._activation_scales, map_location="cpu")
+                activation_scales = torch.load(
+                    self._activation_scales, map_location="cpu"
+                )
                 loader.smooth_activation(spec, activation_scales)
 
             if self._copy_files:
@@ -146,7 +148,8 @@ class TransformersConverter(Converter):
 
         if path is None or not os.path.isfile(path):
             raise ValueError(
-                "File %s does not exist in model %s" % (filename, self._model_name_or_path)
+                "File %s does not exist in model %s"
+                % (filename, self._model_name_or_path)
             )
 
         return path
@@ -174,7 +177,10 @@ class ModelLoader(abc.ABC):
 
     def get_vocabulary(self, model, tokenizer):
         return [
-            token for token, _ in sorted(tokenizer.get_vocab().items(), key=lambda item: item[1])
+            token
+            for token, _ in sorted(
+                tokenizer.get_vocab().items(), key=lambda item: item[1]
+            )
         ]
 
     def set_vocabulary(self, spec, tokens):
@@ -206,7 +212,9 @@ class ModelLoader(abc.ABC):
             spec.encodings = spec.encodings[offset:]
 
     def smooth_activation(self, spec, activation_scales):
-        raise NotImplementedError("No activation smoothing logic is defined for this model")
+        raise NotImplementedError(
+            "No activation smoothing logic is defined for this model"
+        )
 
 
 @register_loader("BartConfig")
@@ -317,7 +325,9 @@ class BartLoader(ModelLoader):
         spec.scale_embeddings = module.embed_scale
         self.set_position_encodings(spec.position_encodings, module.embed_positions)
         self.set_embeddings(
-            spec.embeddings[0] if isinstance(spec.embeddings, list) else spec.embeddings,
+            spec.embeddings[0]
+            if isinstance(spec.embeddings, list)
+            else spec.embeddings,
             module.embed_tokens,
         )
 
@@ -681,7 +691,10 @@ class CodeGenLoader(ModelLoader):
             # the weights of the qkv_proj fixes it.
             base_permutation = [0, 3, 6, 9, 1, 4, 7, 10, 2, 5, 8, 11]
             permutation_np = np.concatenate(
-                [np.arange(i * local_dim, (i + 1) * local_dim) for i in base_permutation]
+                [
+                    np.arange(i * local_dim, (i + 1) * local_dim)
+                    for i in base_permutation
+                ]
             )
             # we permute the *rows* here because the computation is xA.T
             new_qkv_proj_np = qkv_proj[permutation_np, :]
@@ -753,8 +766,12 @@ class GPTNeoXLoader(ModelLoader):
                     layer_spec.post_attention_layer_norm, layer.post_attention_layernorm
                 )
             else:
-                self.set_layer_norm(layer_spec.self_attention.layer_norm, layer.input_layernorm)
-                self.set_layer_norm(layer_spec.ffn.layer_norm, layer.post_attention_layernorm)
+                self.set_layer_norm(
+                    layer_spec.self_attention.layer_norm, layer.input_layernorm
+                )
+                self.set_layer_norm(
+                    layer_spec.ffn.layer_norm, layer.post_attention_layernorm
+                )
 
             qkv_w = layer.attention.query_key_value.weight.numpy()
             qkv_b = layer.attention.query_key_value.bias.numpy()
@@ -814,7 +831,10 @@ class WhisperLoader(BartLoader):
         tokens = super().get_vocabulary(model, tokenizer)
 
         # Add timestamp tokens.
-        tokens.extend("<|%.2f|>" % (i * 0.02) for i in range(model.config.vocab_size - len(tokens)))
+        tokens.extend(
+            "<|%.2f|>" % (i * 0.02)
+            for i in range(model.config.vocab_size - len(tokens))
+        )
 
         return tokens
 
@@ -887,7 +907,9 @@ class T5Loader(ModelLoader):
     def set_stack(self, spec, module, is_decoder=False):
         self.set_layer_norm(spec.layer_norm, module.final_layer_norm)
         self.set_embeddings(
-            spec.embeddings[0] if isinstance(spec.embeddings, list) else spec.embeddings,
+            spec.embeddings[0]
+            if isinstance(spec.embeddings, list)
+            else spec.embeddings,
             module.embed_tokens,
         )
 
@@ -946,7 +968,9 @@ class T5Loader(ModelLoader):
         self.set_linear(spec.linear[-1], attention.o)
 
         if attention.has_relative_attention_bias:
-            spec.relative_attention_bias = attention.relative_attention_bias.weight.numpy()
+            spec.relative_attention_bias = (
+                attention.relative_attention_bias.weight.numpy()
+            )
             spec.relative_attention_max_distance = np.dtype("int32").type(
                 attention.relative_attention_max_distance
             )
@@ -1006,15 +1030,21 @@ class BloomLoader(ModelLoader):
         self.set_layer_norm(spec.layer_norm, module.ln_f)
 
         for layer_spec, layer in zip(spec.layer, module.h):
-            self.set_layer_norm(layer_spec.self_attention.layer_norm, layer.input_layernorm)
+            self.set_layer_norm(
+                layer_spec.self_attention.layer_norm, layer.input_layernorm
+            )
             self.set_qkv_linear(
                 layer_spec.self_attention.linear[0],
                 layer.self_attention.query_key_value,
                 layer.self_attention.num_heads,
             )
-            self.set_linear(layer_spec.self_attention.linear[1], layer.self_attention.dense)
+            self.set_linear(
+                layer_spec.self_attention.linear[1], layer.self_attention.dense
+            )
 
-            self.set_layer_norm(layer_spec.ffn.layer_norm, layer.post_attention_layernorm)
+            self.set_layer_norm(
+                layer_spec.ffn.layer_norm, layer.post_attention_layernorm
+            )
             self.set_linear(layer_spec.ffn.linear_0, layer.mlp.dense_h_to_4h)
             self.set_linear(layer_spec.ffn.linear_1, layer.mlp.dense_4h_to_h)
 
@@ -1034,7 +1064,9 @@ class BloomLoader(ModelLoader):
 
 
 def main():
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
     parser.add_argument(
         "--model",
         required=True,

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -645,14 +645,18 @@ class CodeGenLoader(ModelLoader):
             shared_layer_norm=True,
         )
 
+        mp_num = 4
+        if "Salesforce/codegen2-1B" in model.name_or_path or "Salesforce/codegen2-3_7B" in model.name_or_path:
+            # consider mp_num=8 for smaller codegen2 series.
+            mp_num = 8
+
         self.set_decoder(
             spec.decoder,
             model.transformer,
             model.config.rotary_dim,
             model.config.n_head,
             model.config.n_embd,
-            # consider mp_num-8 for codegen2 series.
-            mp_num=8 if "Salesforce/codegen2-" in model.name_or_path else 4,
+            mp_num=mp_num,
         )
         self.set_linear(spec.decoder.projection, model.lm_head)
         return spec


### PR DESCRIPTION
This PR aims to integrate some converters for Coding Models, primary for [transformers Salesforce/CodeGen](
https://huggingface.co/docs/transformers/model_doc/codegen)

For CodeGen, the converter adds support in similar fashion to how transformers->ctranslate2 conversion is done for GPT-J, by bringing CodeGen qkv_proj to GPT-J format in similar fashion to https://github.com/fauxpilot/fauxpilot/tree/main
@moyix FYI: Integrating your code here, which is also first published under MIT License, might be a fast alternative to Triton with FasterTransformer backend.

```python
import ctranslate2
from transformers import AutoTokenizer, AutoModelForCausalLM
from timeit import default_timer as timer
model_ct2 = ctranslate2.Generator(
    # converted Salesforce/codegen-350M-multi
    "./ct2_codegen",
    device="cuda",
    compute_type="int8_float16",
)
model_hf = AutoModelForCausalLM.from_pretrained("Salesforce/codegen-350M-multi")
tokenizer =  AutoTokenizer.from_pretrained("Salesforce/codegen-350M-multi")

text = "# this code print('hello', name) in python3 \n\ndef hello_name(name: "

def inference_ct2(text: str):
    tokens_in = tokenizer.convert_ids_to_tokens(tokenizer.encode(text))
    s = timer()
    tokens_out = model_ct2.generate_batch([tokens_in], max_length=32, min_length=32)
    total_ct2 = timer() - s
    text_out = tokenizer.decode(tokens_out[0].sequences_ids[0])
    return total_ct2, text_out

def inference_hf(text: str):
    inputs = tokenizer.encode(text, return_tensors="pt")
    s = timer()
    outputs = model_hf.generate(inputs, max_length=32, min_length=32, pad_token_id=50256)
    total_hf = timer() - s
    text_out2 = tokenizer.batch_decode(outputs)[0]
    return total_hf, text_out2


_, _ = inference_ct2("warm up")
_, _ = inference_hf("warm up")

total_ct2, text_out_ct2 = inference_ct2(text)
total_hf, text_out_hf = inference_hf(text)

print("hf\n",text_out_hf, "\nct2\n",text_out_ct2)
print(f"time for ct2={total_ct2} time for hf={total_hf}")
assert text_out_ct2[:len(text_out_hf)] == text_out_hf # same, ct2 generates +1 token compared to HF
print("done")
```
stdout
```bash
hf
 # this code print('hello', name) in python3 

def hello_name(name: 
    "hello"
    ):
 
ct2
 # this code print('hello', name) in python3 

def hello_name(name: 
    "hello"
    ):
    
time for ct2=0.38880249700014247 time for hf=0.837739734999559
done
```


On a related note.  If you have a idea how to convert from transformers, let me know: 
- codet5p-2B (codegen-1 encoder-decoder)
- starcoder/santacoder (gpt-2 with MHA)