### PR TITLE
Avoid running initialization code with unused static variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ set(SOURCES
   src/logging.cc
   src/models/language_model.cc
   src/models/model.cc
+  src/models/model_factory.cc
   src/models/model_reader.cc
   src/models/sequence_to_sequence.cc
   src/models/transformer.cc

--- a/include/ctranslate2/logging.h
+++ b/include/ctranslate2/logging.h
@@ -12,6 +12,7 @@ namespace ctranslate2 {
     Trace = 3,
   };
 
+  void init_logger();
   void set_log_level(const LogLevel level);
   LogLevel get_log_level();
 

--- a/include/ctranslate2/models/model_factory.h
+++ b/include/ctranslate2/models/model_factory.h
@@ -37,9 +37,7 @@ namespace ctranslate2 {
       return ModelFactory::get_instance().register_model<Model>(name, std::forward<Args>(args)...);
     }
 
-    inline std::shared_ptr<Model> create_model(const std::string& name) {
-      return ModelFactory::get_instance().create_model(name);
-    }
+    std::shared_ptr<Model> create_model(const std::string& name);
 
   }
 }

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -62,7 +62,7 @@ namespace ctranslate2 {
   }
 
   void init_logger() {
-    std::once_flag initialized;
+    static std::once_flag initialized;
     std::call_once(initialized, []() {
       auto logger = spdlog::stderr_logger_mt("ctranslate2");
       logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%n] [thread %t] [%l] %v");

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -59,19 +59,12 @@ namespace ctranslate2 {
     return static_cast<LogLevel>(level);
   }
 
-  static void init_logger() {
+  void init_logger() {
     auto logger = spdlog::stderr_logger_mt("ctranslate2");
     logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%n] [thread %t] [%l] %v");
     spdlog::set_default_logger(logger);
     set_log_level(get_default_level());
   }
-
-  // Initialize the global logger on program start.
-  static struct LoggerInit {
-    LoggerInit() {
-      init_logger();
-    }
-  } logger_init;
 
   void set_log_level(const LogLevel level) {
     spdlog::set_level(to_spdlog_level(level));

--- a/src/models/model_factory.cc
+++ b/src/models/model_factory.cc
@@ -1,0 +1,31 @@
+#include "ctranslate2/models/model_factory.h"
+
+#include <mutex>
+
+#include "ctranslate2/models/whisper.h"
+#include "ctranslate2/models/transformer.h"
+
+namespace ctranslate2 {
+  namespace models {
+
+    static void register_supported_models() {
+      // Empty spec name, TransformerBase, and TransformerBig are there for backward compatibility.
+      register_model<TransformerModel>("", /*num_heads=*/8);
+      register_model<TransformerModel>("TransformerBase", /*num_heads=*/8);
+      register_model<TransformerModel>("TransformerBig", /*num_heads=*/16);
+      register_model<TransformerModel>("TransformerSpec");
+
+      register_model<TransformerDecoderModel>("TransformerDecoderSpec");
+
+      register_model<WhisperModel>("WhisperSpec");
+    }
+
+    std::shared_ptr<Model> create_model(const std::string& name) {
+      static std::once_flag init_flag;
+      std::call_once(init_flag, register_supported_models);
+
+      return ModelFactory::get_instance().create_model(name);
+    }
+
+  }
+}

--- a/src/models/transformer.cc
+++ b/src/models/transformer.cc
@@ -1,6 +1,5 @@
 #include "ctranslate2/models/transformer.h"
 
-#include "ctranslate2/models/model_factory.h"
 #include "ctranslate2/layers/transformer.h"
 
 namespace ctranslate2 {
@@ -33,12 +32,6 @@ namespace ctranslate2 {
       return name;
     }
 
-
-    // Empty spec name, TransformerBase, and TransformerBig are there for backward compatibility.
-    static auto register_empty = register_model<TransformerModel>("", /*num_heads=*/8);
-    static auto register_base = register_model<TransformerModel>("TransformerBase", /*num_heads=*/8);
-    static auto register_big = register_model<TransformerModel>("TransformerBig", /*num_heads=*/16);
-    static auto register_generic = register_model<TransformerModel>("TransformerSpec");
 
     TransformerModel::TransformerModel(size_t num_heads)
       : _num_heads(num_heads) {
@@ -100,8 +93,6 @@ namespace ctranslate2 {
       return std::make_unique<TransformerModel>(*this);
     }
 
-
-    static auto register_decoder = register_model<TransformerDecoderModel>("TransformerDecoderSpec");
 
     size_t TransformerDecoderModel::current_spec_revision() const {
       return 5;

--- a/src/models/whisper.cc
+++ b/src/models/whisper.cc
@@ -3,7 +3,6 @@
 #include <algorithm>
 
 #include "ctranslate2/decoding.h"
-#include "ctranslate2/models/model_factory.h"
 
 #include "dispatch.h"
 #include "dtw.h"
@@ -14,8 +13,6 @@
 
 namespace ctranslate2 {
   namespace models {
-
-    static auto register_whisper = register_model<WhisperModel>("WhisperSpec");
 
     const Vocabulary& WhisperModel::get_vocabulary() const {
       return *_vocabulary;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -11,6 +11,7 @@
 #include <spdlog/spdlog.h>
 
 #include "ctranslate2/devices.h"
+#include "ctranslate2/logging.h"
 
 #include "cpu/backend.h"
 #include "cpu/cpu_info.h"
@@ -25,6 +26,8 @@ namespace ctranslate2 {
   }
 
   void log_system_config() {
+    init_logger();
+
     if (!spdlog::should_log(spdlog::level::info))
       return;
 


### PR DESCRIPTION
These variables are ignored when static linking without "whole archive".

Closes #1205.