### PR TITLE
Add a converter for GPTBigCode

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -537,6 +537,96 @@ class OPTLoader(BartLoader):
         return tokens
 
 
+@register_loader("GPTBigCodeConfig")
+class GPTBigCodeMHA(ModelLoader):
+
+    @property
+    def architecture_name(self):
+        return "GPTBigCodeForCausalLM"
+
+    def get_model_spec(self, model):
+        spec = transformer_spec.TransformerDecoderModelSpec.from_config(
+            model.config.n_layer,
+            model.config.n_head,
+            pre_norm=True,
+            activation=_SUPPORTED_ACTIVATIONS[model.config.activation_function],
+        )
+
+        self.set_decoder(
+            spec.decoder,
+            model.transformer,
+            embed_dim=model.config.n_embd,
+            n_head=model.config.n_head,
+        )
+        self.set_linear(spec.decoder.projection, model.lm_head)
+        return spec
+
+    def set_vocabulary(self, spec, tokens):
+        spec.register_vocabulary(tokens)
+    
+    def get_vocabulary(self, model, tokenizer):
+        tokens = super().get_vocabulary(model, tokenizer)
+
+        extra_ids = model.config.vocab_size - len(tokens)
+        for i in range(extra_ids):
+            tokens.append("<extra_id_%d>" % i)
+
+        return tokens
+
+
+    def set_config(self, config, model, tokenizer):
+        config.bos_token = tokenizer.bos_token
+        config.eos_token = tokenizer.eos_token
+        config.unk_token = tokenizer.unk_token
+
+    def set_decoder(self, spec, module, embed_dim, n_head):
+        spec.scale_embeddings = False
+        self.set_embeddings(spec.embeddings, module.wte)
+        self.set_position_encodings(spec.position_encodings, module.wpe)
+        self.set_layer_norm(spec.layer_norm, module.ln_f)
+
+        head_dim = embed_dim // n_head
+
+        for layer_spec, layer in zip(spec.layer, module.h):
+            self.set_layer_norm(layer_spec.self_attention.layer_norm, layer.ln_1)
+            # start fix: MQA (GPTBigCode) by expanding to MHA (GPT-2)
+            # layer_spec.self_attention.linear[0] in GPT-2
+            # should be                (3* n_heads * head_dim,              embed_dim),
+            # but layer.attn.c_attn is ((n_heads * head_dim + 2 * head_dim) ,  embed_dim)
+            c_attn_w = self._expand_mqa_mha(layer.attn.c_attn.weight.numpy(), n_head=n_head, head_dim=head_dim)
+            c_attn_b = self._expand_mqa_mha(layer.attn.c_attn.bias.numpy(), n_head=n_head, head_dim=head_dim)
+            layer_spec.self_attention.linear[0].weight = c_attn_w
+            layer_spec.self_attention.linear[0].bias = c_attn_b
+            # end fix: rest works as in GPT-2
+            self.set_linear(layer_spec.self_attention.linear[1], layer.attn.c_proj)
+            self.set_layer_norm(layer_spec.ffn.layer_norm, layer.ln_2)
+            self.set_linear(layer_spec.ffn.linear_0, layer.mlp.c_fc)
+            self.set_linear(layer_spec.ffn.linear_1, layer.mlp.c_proj)
+    
+    @staticmethod
+    def _expand_mqa_mha(qkv_array, n_head, head_dim):
+        """manipulates along axis=0 from MQA to MHA
+        inputs: qkv_array.shape=((n_heads + 2) * head_dim, hidden_dim)
+            with n_heads for q, then 1 for k, 1 for 1 v, times head dim
+        return: qkv_array.shape=(3 * n_heads * head_dim, hidden_dim)
+        """
+        dims_q = n_head * head_dim         
+        q, k, v = np.split(
+            qkv_array, (dims_q, dims_q + head_dim), axis=0
+        )
+        # q is fine, but k & v have not replicated shape along the first axis
+        # as long as MQA is not nativly supported, increase memory and replicated 
+        # (head_dim, hidden_dim) to (n_heads * head_dim, hidden_dim)
+        if k.ndim == 2 and v.ndim == 2:
+            replication = (n_head, 1)  # weights
+        else:
+            replication = n_head  # biases
+        # replicate n_head times for q, v
+        k, v = np.tile(k, replication), np.tile(v, replication)
+        # concat q, k, v along the first axis (n_heads * head_dim, hidden_dim)
+        # to (3 * n_heads * head_dim, hidden_dim)
+        return np.concatenate((q, k, v), axis=0)
+
 @register_loader("GPT2Config")
 class GPT2Loader(ModelLoader):
     @property
@@ -572,85 +662,6 @@ class GPT2Loader(ModelLoader):
         for layer_spec, layer in zip(spec.layer, module.h):
             self.set_layer_norm(layer_spec.self_attention.layer_norm, layer.ln_1)
             self.set_linear(layer_spec.self_attention.linear[0], layer.attn.c_attn)
-            self.set_linear(layer_spec.self_attention.linear[1], layer.attn.c_proj)
-            self.set_layer_norm(layer_spec.ffn.layer_norm, layer.ln_2)
-            self.set_linear(layer_spec.ffn.linear_0, layer.mlp.c_fc)
-            self.set_linear(layer_spec.ffn.linear_1, layer.mlp.c_proj)
-
-
-@register_loader("GPTBigCodeConfig")
-class GPTBigCodeMHA(ModelLoader):
-    """copyright Michael Feil"""
-
-    @property
-    def architecture_name(self):
-        return "GPTBigCodeForCausalLM"
-
-    def get_model_spec(self, model):
-        spec = transformer_spec.TransformerDecoderModelSpec.from_config(
-            model.config.n_layer,
-            model.config.n_head,
-            pre_norm=True,
-            activation=_SUPPORTED_ACTIVATIONS[model.config.activation_function],
-        )
-
-        self.set_decoder(
-            spec.decoder,
-            model.transformer,
-            embed_dim=model.config.n_embd,
-            n_head=model.config.n_head,
-        )
-        self.set_linear(spec.decoder.projection, model.lm_head)
-        return spec
-
-    def set_vocabulary(self, spec, tokens):
-        spec.register_vocabulary(tokens)
-
-    def set_config(self, config, model, tokenizer):
-        config.bos_token = tokenizer.bos_token
-        config.eos_token = tokenizer.eos_token
-        config.unk_token = tokenizer.unk_token
-
-    def set_decoder(self, spec, module, embed_dim, n_head):
-        spec.scale_embeddings = False
-        self.set_embeddings(spec.embeddings, module.wte)
-        self.set_position_encodings(spec.position_encodings, module.wpe)
-        self.set_layer_norm(spec.layer_norm, module.ln_f)
-
-        head_dim = embed_dim // n_head
-
-        def _expand_mqa_mha(qkv_array):
-            """manipulates along axis=0 from MQA to MHA
-            inputs: qkv_array.shape=((n_heads + 2) * head_dim, hidden_dim)
-            return: qkv_array.shape=(3 * n_heads * head_dim, hidden_dim)
-            """
-            q, k, v = np.split(
-                qkv_array, (n_head * head_dim, (n_head + 1) * head_dim), axis=0
-            )
-            # q is fine, but k & v have not replicated shape along the first axis
-            # as long as MQA is not nativly supported, increase memory and replicated 
-            # (head_dim, hidden_dim) -> (n_heads * head_dim, hidden_dim)
-            if k.ndim == 2 and v.ndim == 2:
-                replication = (n_head, 1)  # weights
-            else:
-                replication = n_head  # biases
-            # replicate n_head times for q, v
-            k, v = np.tile(k, replication), np.tile(v, replication)
-            # concat q, k, v along the first axis (n_heads * head_dim, hidden_dim)
-            # -> (3 * n_heads * head_dim, hidden_dim)
-            return np.concatenate((q, k, v), axis=0)
-
-        for layer_spec, layer in zip(spec.layer, module.h):
-            self.set_layer_norm(layer_spec.self_attention.layer_norm, layer.ln_1)
-            # start fix: MQA (GPTBigCode) by expanding to MHA (GPT-2)
-            # layer_spec.self_attention.linear[0] in GPT-2
-            # should be                (3* n_heads * head_dim,              embed_dim),
-            # but layer.attn.c_attn is ((n_heads * head_dim + 2 * head_dim) ,  embed_dim)
-            c_attn_w = _expand_mqa_mha(layer.attn.c_attn.weight.numpy())
-            c_attn_b = _expand_mqa_mha(layer.attn.c_attn.bias.numpy())
-            layer_spec.self_attention.linear[0].weight = c_attn_w
-            layer_spec.self_attention.linear[0].bias = c_attn_b
-            # end fix: rest works as in GPT-2
             self.set_linear(layer_spec.self_attention.linear[1], layer.attn.c_proj)
             self.set_layer_norm(layer_spec.ffn.layer_norm, layer.ln_2)
             self.set_linear(layer_spec.ffn.linear_0, layer.mlp.c_fc)

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -578,6 +578,85 @@ class GPT2Loader(ModelLoader):
             self.set_linear(layer_spec.ffn.linear_1, layer.mlp.c_proj)
 
 
+@register_loader("GPTBigCodeConfig")
+class GPTBigCodeMHA(ModelLoader):
+    """copyright Michael Feil"""
+
+    @property
+    def architecture_name(self):
+        return "GPTBigCodeForCausalLM"
+
+    def get_model_spec(self, model):
+        spec = transformer_spec.TransformerDecoderModelSpec.from_config(
+            model.config.n_layer,
+            model.config.n_head,
+            pre_norm=True,
+            activation=_SUPPORTED_ACTIVATIONS[model.config.activation_function],
+        )
+
+        self.set_decoder(
+            spec.decoder,
+            model.transformer,
+            embed_dim=model.config.n_embd,
+            n_head=model.config.n_head,
+        )
+        self.set_linear(spec.decoder.projection, model.lm_head)
+        return spec
+
+    def set_vocabulary(self, spec, tokens):
+        spec.register_vocabulary(tokens)
+
+    def set_config(self, config, model, tokenizer):
+        config.bos_token = tokenizer.bos_token
+        config.eos_token = tokenizer.eos_token
+        config.unk_token = tokenizer.unk_token
+
+    def set_decoder(self, spec, module, embed_dim, n_head):
+        spec.scale_embeddings = False
+        self.set_embeddings(spec.embeddings, module.wte)
+        self.set_position_encodings(spec.position_encodings, module.wpe)
+        self.set_layer_norm(spec.layer_norm, module.ln_f)
+
+        head_dim = embed_dim // n_head
+
+        def _expand_mqa_mha(qkv_array):
+            """manipulates along axis=0 from MQA to MHA
+            inputs: qkv_array.shape=((n_heads + 2) * head_dim, hidden_dim)
+            return: qkv_array.shape=(3 * n_heads * head_dim, hidden_dim)
+            """
+            q, k, v = np.split(
+                qkv_array, (n_head * head_dim, (n_head + 1) * head_dim), axis=0
+            )
+            # q is fine, but k & v have not replicated shape along the first axis
+            # as long as MQA is not nativly supported, increase memory and replicated 
+            # (head_dim, hidden_dim) -> (n_heads * head_dim, hidden_dim)
+            if k.ndim == 2 and v.ndim == 2:
+                replication = (n_head, 1)  # weights
+            else:
+                replication = n_head  # biases
+            # replicate n_head times for q, v
+            k, v = np.tile(k, replication), np.tile(v, replication)
+            # concat q, k, v along the first axis (n_heads * head_dim, hidden_dim)
+            # -> (3 * n_heads * head_dim, hidden_dim)
+            return np.concatenate((q, k, v), axis=0)
+
+        for layer_spec, layer in zip(spec.layer, module.h):
+            self.set_layer_norm(layer_spec.self_attention.layer_norm, layer.ln_1)
+            # start fix: MQA (GPTBigCode) by expanding to MHA (GPT-2)
+            # layer_spec.self_attention.linear[0] in GPT-2
+            # should be                (3* n_heads * head_dim,              embed_dim),
+            # but layer.attn.c_attn is ((n_heads * head_dim + 2 * head_dim) ,  embed_dim)
+            c_attn_w = _expand_mqa_mha(layer.attn.c_attn.weight.numpy())
+            c_attn_b = _expand_mqa_mha(layer.attn.c_attn.bias.numpy())
+            layer_spec.self_attention.linear[0].weight = c_attn_w
+            layer_spec.self_attention.linear[0].bias = c_attn_b
+            # end fix: rest works as in GPT-2
+            self.set_linear(layer_spec.self_attention.linear[1], layer.attn.c_proj)
+            self.set_layer_norm(layer_spec.ffn.layer_norm, layer.ln_2)
+            self.set_linear(layer_spec.ffn.linear_0, layer.mlp.c_fc)
+            self.set_linear(layer_spec.ffn.linear_1, layer.mlp.c_proj)
+
+
 @register_loader("GPTJConfig")
 class GPTJLoader(ModelLoader):
     @property


### PR DESCRIPTION
Related issue:
- https://github.com/OpenNMT/CTranslate2/issues/1231

```python
import ctranslate2
from transformers import AutoTokenizer, AutoModelForCausalLM
from timeit import default_timer as timer
model_ct2 = ctranslate2.Generator(
    # gpt_bigcode-santacoder
    "./ct2_santacoder",
    device="cpu",
    compute_type="int8",
)
name_hf = 'bigcode/gpt_bigcode-santacoder'
model_hf = AutoModelForCausalLM.from_pretrained(name_hf, trust_remote_code=True)
tokenizer =  AutoTokenizer.from_pretrained(name_hf, device="cpu", trust_remote_code=True)

text = "# this code print('hello', name) in python3 \n\ndef hello_name(name: "

def inference_ct2(text: str):
    tokens_in = tokenizer.convert_ids_to_tokens(tokenizer.encode(text))
    s = timer()
    tokens_out = model_ct2.generate_batch([tokens_in], max_length=32, min_length=32)
    total_ct2 = timer() - s
    text_out = tokenizer.decode(tokens_out[0].sequences_ids[0])
    return total_ct2, text_out

def inference_hf(text: str):
    inputs = tokenizer.encode(text, return_tensors="pt")
    s = timer()
    outputs = model_hf.generate(inputs, max_length=32, min_length=32, pad_token_id=50256)
    total_hf = timer() - s
    text_out2 = tokenizer.batch_decode(outputs)[0]
    return total_hf, text_out2


_, _ = inference_ct2("warm up")
_, _ = inference_hf("warm up")

total_ct2, text_out_ct2 = inference_ct2(text)
total_hf, text_out_hf = inference_hf(text)

print("hf\n",text_out_hf, "\nct2\n",text_out_ct2)
print(f"time for ct2={total_ct2} time for hf={total_hf}")
assert text_out_ct2[:len(text_out_hf)] == text_out_hf # same, ct2 generates +1 token compared to HF
print("done")
```
Out:
```python
hf
 # this code print('hello', name) in python3 

def hello_name(name:  str):
    print('hello', name)
 
ct2
 # this code print('hello', name) in python3 

def hello_name(name:  str) -> None:
    print('hello', name
time for ct2=2.1102427009900566 time for hf=2.6105566439800896
```