### PR TITLE
Load default tokenizer during conversion

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -110,17 +110,10 @@ class TransformersConverter(Converter):
 
             model = self.load_model(model_class, self._model_name_or_path, **kwargs)
 
-            try:
-                tokenizer = self.load_tokenizer(
-                    tokenizer_class,
-                    self._model_name_or_path,
-                    use_fast=False,
-                )
-            except ValueError:
-                tokenizer = self.load_tokenizer(
-                    tokenizer_class,
-                    self._model_name_or_path,
-                )
+            tokenizer = self.load_tokenizer(
+                tokenizer_class,
+                self._model_name_or_path,
+            )
 
             spec = loader(model, tokenizer)
 


### PR DESCRIPTION
`use_fast=False` will cause an error if e.g. sentencepiece is not available or if the model only has the fast version of the tokenizer uploaded. If we omit this argument, `transformers` will handle loading the slow or fast version depending on what's available.