### PR TITLE
Improve application of {min,max}_length when using include_prompt_in_result=False

### DIFF
--- a/python/tests/test_transformers.py
+++ b/python/tests/test_transformers.py
@@ -500,6 +500,31 @@ class TestGeneration:
         assert cum_score_wo_prompt == pytest.approx(cum_score_w_prompt, abs=1e-4)
 
     @test_utils.only_on_linux
+    @pytest.mark.parametrize("beam_size", [1, 2])
+    def test_transformers_generator_ignore_prompt_batch(self, tmp_dir, beam_size):
+        converter = ctranslate2.converters.TransformersConverter("gpt2")
+        output_dir = str(tmp_dir.join("ctranslate2_model"))
+        output_dir = converter.convert(output_dir)
+        generator = ctranslate2.Generator(output_dir)
+
+        new_tokens = 2
+        prompt = [
+            "Ċ The Ġfirst Ġtime ĠI".split(),
+            "Ċ The Ġfirst".split(),
+        ]
+
+        results = generator.generate_batch(
+            prompt,
+            beam_size=beam_size,
+            min_length=new_tokens,
+            max_length=new_tokens,
+            include_prompt_in_result=False,
+        )
+
+        for tokens, result in zip(prompt, results):
+            assert len(result.sequences[0]) == new_tokens
+
+    @test_utils.only_on_linux
     def test_transformers_generator_static_prompt(self, tmp_dir):
         converter = ctranslate2.converters.TransformersConverter("gpt2")
         output_dir = str(tmp_dir.join("ctranslate2_model"))

--- a/src/decoding.cc
+++ b/src/decoding.cc
@@ -328,6 +328,57 @@ namespace ctranslate2 {
     return std::round(float(beam_size) * patience);
   }
 
+  static dim_t get_max_step(const dim_t max_length,
+                            const bool return_prefix,
+                            const std::vector<std::vector<size_t>>* prefix_ids) {
+    dim_t max_step = 0;
+
+    if (prefix_ids && !return_prefix) {
+      for (const auto& ids : *prefix_ids) {
+        const dim_t prefix_length = ids.size();
+        max_step = std::max(max_step, prefix_length + max_length);
+      }
+
+    } else {
+      max_step = max_length;
+    }
+
+    return max_step;
+  }
+
+  static inline bool is_last_step(const dim_t step,
+                                  const dim_t max_length,
+                                  const dim_t prefix_length,
+                                  const bool return_prefix) {
+    return step + 1 == max_length + (return_prefix ? 0 : prefix_length);
+  }
+
+  static void apply_min_length(const dim_t step,
+                               const dim_t min_length,
+                               const std::vector<size_t>& end_ids,
+                               DisableTokens& disable_tokens,
+                               const std::vector<dim_t>& batch_offset,
+                               const bool return_prefix,
+                               const std::vector<std::vector<size_t>>* prefix_ids) {
+    if (prefix_ids && !return_prefix) {
+      const size_t batch_size = batch_offset.size();
+
+      for (size_t i = 0; i < batch_size; ++i) {
+        const dim_t batch_id = batch_offset[i];
+        const dim_t prefix_length = prefix_ids[batch_id].size();
+
+        if (step < prefix_length + min_length) {
+          for (const size_t end_id : end_ids)
+            disable_tokens.add(i, end_id);
+        }
+      }
+
+    } else if (step < min_length) {
+      for (const size_t end_id : end_ids)
+        disable_tokens.add(end_id);
+    }
+  }
+
 
   BeamSearch::BeamSearch(const dim_t beam_size,
                          const float length_penalty,
@@ -406,7 +457,11 @@ namespace ctranslate2 {
     StorageView alive_seq(topk_ids.dtype());
     StorageView alive_attention;
 
-    for (dim_t step = 0; step < max_length; ++step) {
+    const dim_t max_step = get_max_step(max_length,
+                                        return_prefix,
+                                        use_hard_prefix ? prefix_ids : nullptr);
+
+    for (dim_t step = 0; step < max_step; ++step) {
       const bool is_expanded = (!expand_after_first_step || step > 0);
 
       // Compute log probs for the current step.
@@ -423,10 +478,13 @@ namespace ctranslate2 {
       DisableTokens disable_tokens(logits);
 
       // Prevent the generation of end_ids until the minimum length is reached.
-      if (step < min_length) {
-        for (const size_t end_id : end_ids)
-          disable_tokens.add(end_id);
-      }
+      apply_min_length(step,
+                       min_length,
+                       end_ids,
+                       disable_tokens,
+                       batch_offset,
+                       return_prefix,
+                       prefix_ids);
 
       if (!logits_processors.empty()) {
         if (alive_seq)
@@ -510,15 +568,20 @@ namespace ctranslate2 {
 
       for (dim_t i = 0; i < cur_batch_size; ++i) {
         const dim_t batch_id = batch_offset[i];
+        const dim_t prefix_length = use_hard_prefix ? prefix_ids->at(batch_id).size() : 0;
+        const bool is_last_step_for_batch = is_last_step(step,
+                                                         max_length,
+                                                         prefix_length,
+                                                         return_prefix);
+
         auto& result = results[batch_id];
         dim_t secondary_candidates_offset = _beam_size;
 
         for (dim_t k = 0; k < _beam_size; ++k) {
           const size_t last_id = topk_ids.at<int32_t>({i, k});
-          const dim_t prefix_length = use_hard_prefix ? prefix_ids->at(batch_id).size() : 0;
           dim_t next_beam_id = k;
 
-          if ((is_eos(last_id, end_ids) && step >= prefix_length) || step + 1 == max_length) {
+          if ((is_eos(last_id, end_ids) && step >= prefix_length) || is_last_step_for_batch) {
             if (k == 0)
               top_beam_finished[i] = true;
 
@@ -547,7 +610,7 @@ namespace ctranslate2 {
         }
 
         bool is_finished = false;
-        if (step + 1 == max_length)
+        if (is_last_step_for_batch)
           is_finished = true;
         else if (allow_early_exit)
           is_finished = top_beam_finished[i] && result.hypotheses.size() >= num_hypotheses;
@@ -717,7 +780,9 @@ namespace ctranslate2 {
     StorageView attention_step;
     StorageView attention_step_device(dtype, device);
 
-    for (dim_t step = 0; step < max_length; ++step) {
+    const dim_t max_step = get_max_step(max_length, return_prefix, prefix_ids);
+
+    for (dim_t step = 0; step < max_step; ++step) {
       convert_to_original_word_ids(decoder, sample_from);
       decoder(start_step + step,
               sample_from.to(device),
@@ -728,10 +793,13 @@ namespace ctranslate2 {
       DisableTokens disable_tokens(logits);
 
       // Prevent the generation of end_id until the minimum length is reached.
-      if (step < min_length) {
-        for (const size_t end_id : end_ids)
-          disable_tokens.add(end_id);
-      }
+      apply_min_length(step,
+                       min_length,
+                       end_ids,
+                       disable_tokens,
+                       batch_offset,
+                       return_prefix,
+                       prefix_ids);
 
       for (const auto& logits_processor : logits_processors)
         logits_processor->apply(step, logits, disable_tokens, alive_seq, batch_offset, prefix_ids);
@@ -782,7 +850,7 @@ namespace ctranslate2 {
           results[batch_id].scores[0] += score;
 
         bool is_finished = ((is_eos(word_id, end_ids) && step >= prefix_length)
-                            || (step + 1 == max_length));
+                            || (is_last_step(step, max_length, prefix_length, return_prefix)));
 
         if (_callback && (return_prefix || step >= prefix_length)) {
           DecodingStepResult step_result;


### PR DESCRIPTION
In this case we want the length constraint to apply to the generated tokens after the prompt.

Closes #1291.