### PR TITLE
Fix std::move on captures in lambda functions

### DIFF
--- a/include/ctranslate2/replica_pool.h
+++ b/include/ctranslate2/replica_pool.h
@@ -57,7 +57,7 @@ namespace ctranslate2 {
     // The function must have the signature: Result(Replica&)
     template <typename Result, typename Func>
     std::future<Result> post(Func func) {
-      auto batched_func = [func = std::move(func)](Replica& replica) {
+      auto batched_func = [func = std::move(func)](Replica& replica) mutable {
         std::vector<Result> results;
         results.reserve(1);
         results.emplace_back(func(replica));
@@ -87,7 +87,7 @@ namespace ctranslate2 {
     // Same as above, but taking the list of promises directly.
     template <typename Result, typename Func>
     void post_batch(Func func, std::vector<std::promise<Result>> promises) {
-      auto wrapped_func = [func = std::move(func)]() {
+      auto wrapped_func = [func = std::move(func)]() mutable {
         return func(get_thread_replica());
       };
 
@@ -292,7 +292,7 @@ namespace ctranslate2 {
 
     private:
       std::vector<std::promise<Result>> _promises;
-      const Func _func;
+      Func _func;
     };
 
   };

--- a/src/models/whisper.cc
+++ b/src/models/whisper.cc
@@ -643,9 +643,10 @@ namespace ctranslate2 {
     }
 
     std::future<StorageView> Whisper::encode(const StorageView& features, const bool to_cpu) {
-      return post<StorageView>([features = features.sync_copy(), to_cpu](WhisperReplica& replica) {
-        return replica.encode(std::move(features), to_cpu);
-      });
+      return post<StorageView>(
+        [features = features.sync_copy(), to_cpu](WhisperReplica& replica) mutable {
+          return replica.encode(std::move(features), to_cpu);
+        });
     }
 
     std::vector<std::future<WhisperGenerationResult>>
@@ -655,7 +656,7 @@ namespace ctranslate2 {
       const size_t batch_size = features.dim(0);
       return post_batch<WhisperGenerationResult>(
         [features = features.sync_copy(), prompts = std::move(prompts), options]
-        (WhisperReplica& replica) {
+        (WhisperReplica& replica) mutable {
           return replica.generate(std::move(features), prompts, options);
         },
         batch_size);
@@ -668,7 +669,7 @@ namespace ctranslate2 {
       const size_t batch_size = features.dim(0);
       return post_batch<WhisperGenerationResult>(
         [features = features.sync_copy(), prompts = std::move(prompts), options]
-        (WhisperReplica& replica) {
+        (WhisperReplica& replica) mutable {
           return replica.generate(std::move(features), prompts, options);
         },
         batch_size);
@@ -678,7 +679,7 @@ namespace ctranslate2 {
     Whisper::detect_language(const StorageView& features) {
       const size_t batch_size = features.dim(0);
       return post_batch<std::vector<std::pair<std::string, float>>>(
-        [features = features.sync_copy()](WhisperReplica& replica) {
+        [features = features.sync_copy()](WhisperReplica& replica) mutable {
           return replica.detect_language(std::move(features));
         },
         batch_size);


### PR DESCRIPTION
Variables captured by value are const by default, so the `std::move` had no effect.

The fix should save one unnecessary copy in Whisper methods.