### PR TITLE
Support Trust Remote Code for Tokenizer as well

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -109,9 +109,13 @@ class TransformersConverter(Converter):
                 kwargs["trust_remote_code"] = self._trust_remote_code
 
             model = self.load_model(model_class, self._model_name_or_path, **kwargs)
+            
+            tokenizer_kwargs = {}
+            if self._trust_remote_code:
+                tokenizer_kwargs["trust_remote_code"] = self._trust_remote_code
 
             tokenizer = self.load_tokenizer(
-                tokenizer_class, self._model_name_or_path, **kwargs
+                tokenizer_class, self._model_name_or_path, **tokenizer_kwargs
             )
 
             spec = loader(model, tokenizer)

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -113,6 +113,7 @@ class TransformersConverter(Converter):
             tokenizer = self.load_tokenizer(
                 tokenizer_class,
                 self._model_name_or_path,
+                **kwargs
             )
 
             spec = loader(model, tokenizer)

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -109,7 +109,7 @@ class TransformersConverter(Converter):
                 kwargs["trust_remote_code"] = self._trust_remote_code
 
             model = self.load_model(model_class, self._model_name_or_path, **kwargs)
-            
+
             tokenizer_kwargs = {}
             if self._trust_remote_code:
                 tokenizer_kwargs["trust_remote_code"] = self._trust_remote_code

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -111,9 +111,7 @@ class TransformersConverter(Converter):
             model = self.load_model(model_class, self._model_name_or_path, **kwargs)
 
             tokenizer = self.load_tokenizer(
-                tokenizer_class,
-                self._model_name_or_path,
-                **kwargs
+                tokenizer_class, self._model_name_or_path, **kwargs
             )
 
             spec = loader(model, tokenizer)


### PR DESCRIPTION
Closes the issue https://github.com/OpenNMT/CTranslate2/issues/1334

This fixes an problem, due to which custom tokenizers where not being loaded . 
As Trust_remote_code was not being passed into the load_tokenizer call. 

Not being able to support models that implement custom tokenizer
Mainly the salesforce xgen and codegen series of models that are quite popular now

Thanks 