### PR TITLE
Fix/falcon renaming

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -1322,7 +1322,8 @@ class FalconLoader(ModelLoader):
                     layer.self_attention.query_key_value,
                     layer.self_attention.num_heads,
                     layer.self_attention.num_kv_heads
-                    if layer.self_attention.num_kv_heads < layer.self_attention.num_heads
+                    if layer.self_attention.num_kv_heads
+                    < layer.self_attention.num_heads
                     else None,
                 )
 

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -1255,11 +1255,11 @@ class FalconLoader(ModelLoader):
         if getattr(model.config, "multi_query", False):
             num_heads_kv = 1
         else:
-            num_heads_kv = getattr(model.config, "n_head_kv", None)
+            num_heads_kv = getattr(model.config, "num_kv_heads", None)
 
         spec = transformer_spec.TransformerDecoderModelSpec.from_config(
-            model.config.n_layer,
-            model.config.n_head,
+            model.config.num_hidden_layers,
+            model.config.num_attention_heads,
             pre_norm=True,
             activation=common_spec.Activation.GELU,
             alibi=model.config.alibi,
@@ -1311,7 +1311,7 @@ class FalconLoader(ModelLoader):
                     layer_spec.ffn.layer_norm, layer.post_attention_layernorm
                 )
 
-            if layer.self_attention.num_kv == 1:
+            if layer.self_attention.num_kv_heads == 1:
                 self.set_linear(
                     layer_spec.self_attention.linear[0],
                     layer.self_attention.query_key_value,
@@ -1321,8 +1321,8 @@ class FalconLoader(ModelLoader):
                     layer_spec.self_attention.linear[0],
                     layer.self_attention.query_key_value,
                     layer.self_attention.num_heads,
-                    layer.self_attention.num_kv
-                    if layer.self_attention.num_kv < layer.self_attention.num_heads
+                    layer.self_attention.num_kv_heads
+                    if layer.self_attention.num_kv_heads < layer.self_attention.num_heads
                     else None,
                 )
 
@@ -1333,26 +1333,26 @@ class FalconLoader(ModelLoader):
             self.set_linear(layer_spec.ffn.linear_0, layer.mlp.dense_h_to_4h)
             self.set_linear(layer_spec.ffn.linear_1, layer.mlp.dense_4h_to_h)
 
-    def set_qkv_linear(self, spec, module, num_heads, num_kv=None):
+    def set_qkv_linear(self, spec, module, num_heads, num_kv_heads=None):
         import torch
 
         weight = module.weight
 
-        if num_kv is None:
+        if num_kv_heads is None:
             weight = weight.reshape(num_heads, 3, -1, weight.shape[-1])
             weight = weight.transpose(0, 1)
             weight = weight.reshape(-1, weight.shape[-1])
         else:
-            head_dim = weight.shape[0] // (num_heads + num_kv * 2)
+            head_dim = weight.shape[0] // (num_heads + num_kv_heads * 2)
             weight = weight.reshape(
-                -1, num_heads // num_kv + 2, head_dim, weight.shape[-1]
+                -1, num_heads // num_kv_heads + 2, head_dim, weight.shape[-1]
             )
-            q, k, v = weight.split([num_heads // num_kv, 1, 1], dim=1)
+            q, k, v = weight.split([num_heads // num_kv_heads, 1, 1], dim=1)
             weight = torch.cat(
                 [
                     q.reshape(num_heads * head_dim, -1),
-                    k.reshape(num_kv * head_dim, -1),
-                    v.reshape(num_kv * head_dim, -1),
+                    k.reshape(num_kv_heads * head_dim, -1),
+                    v.reshape(num_kv_heads * head_dim, -1),
                 ]
             )
 
@@ -1361,18 +1361,18 @@ class FalconLoader(ModelLoader):
         if module.bias is not None:
             bias = module.bias
 
-            if num_kv is None:
+            if num_kv_heads is None:
                 bias = bias.reshape(num_heads, 3, -1)
                 bias = bias.transpose(0, 1)
                 bias = bias.reshape(-1)
             else:
-                bias = bias.reshape(-1, num_heads // num_kv + 2, head_dim)
-                q, k, v = bias.split([num_heads // num_kv, 1, 1], dim=1)
+                bias = bias.reshape(-1, num_heads // num_kv_heads + 2, head_dim)
+                q, k, v = bias.split([num_heads // num_kv_heads, 1, 1], dim=1)
                 bias = torch.cat(
                     [
                         q.reshape(num_heads * head_dim),
-                        k.reshape(num_kv * head_dim),
-                        v.reshape(num_kv * head_dim),
+                        k.reshape(num_kv_heads * head_dim),
+                        v.reshape(num_kv_heads * head_dim),
                     ]
                 )
 

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -1245,8 +1245,8 @@ class LlamaLoader(ModelLoader):
             gc.collect()
 
 
-@register_loader("RWConfig")
-class RWLoader(ModelLoader):
+@register_loader("FalconConfig")
+class FalconLoader(ModelLoader):
     @property
     def architecture_name(self):
         return "AutoModelForCausalLM"


### PR DESCRIPTION
# Description

Falcon model in Huggingface has updated its configuration file from RW to Falcon. For more details, please check https://huggingface.co/tiiuae/falcon-7b-instruct/tree/main

So this causes the issue that CT2 will not pick up RW_config since all naming has been changed, which now all falcon models would fail during conversion.

This PR renames to the latest one with HF Repo and updates all variable names. 

I have tested Falcon-7b and falcon-7b-instruct and it works right now. 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
