### PR TITLE
Remove duplicated relative attention bias for T5 models

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -979,16 +979,6 @@ class T5Loader(ModelLoader):
         for i, (layer_spec, block) in enumerate(zip(spec.layer, module.block)):
             self.set_self_attention(layer_spec.self_attention, block.layer[0])
 
-            if i > 0:
-                # Reuse relative attention bias from the first layer.
-                first_self_attention = spec.layer[0].self_attention
-                layer_spec.self_attention.relative_attention_bias = (
-                    first_self_attention.relative_attention_bias
-                )
-                layer_spec.self_attention.relative_attention_max_distance = (
-                    first_self_attention.relative_attention_max_distance
-                )
-
             if is_decoder:
                 self.set_cross_attention(layer_spec.attention, block.layer[1])
 

--- a/python/ctranslate2/specs/transformer_spec.py
+++ b/python/ctranslate2/specs/transformer_spec.py
@@ -62,12 +62,12 @@ class TransformerEncoderSpec(model_spec.LayerSpec):
         self.layer = [
             TransformerEncoderLayerSpec(
                 relative_position=relative_position,
-                relative_attention_bias=relative_attention_bias,
+                relative_attention_bias=relative_attention_bias if i == 0 else False,
                 ffn_glu=ffn_glu,
                 rms_norm=rms_norm,
                 num_heads_kv=1 if multi_query_attention else None,
             )
-            for _ in range(num_layers)
+            for i in range(num_layers)
         ]
 
 
@@ -176,7 +176,7 @@ class TransformerDecoderSpec(model_spec.LayerSpec):
             TransformerDecoderLayerSpec(
                 with_encoder_attention=with_encoder_attention,
                 relative_position=relative_position,
-                relative_attention_bias=relative_attention_bias,
+                relative_attention_bias=relative_attention_bias if i == 0 else False,
                 ffn_glu=ffn_glu,
                 rms_norm=rms_norm,
                 rotary_dim=rotary_dim,
@@ -185,7 +185,7 @@ class TransformerDecoderSpec(model_spec.LayerSpec):
                 shared_layer_norm=shared_layer_norm,
                 num_heads_kv=num_heads_kv,
             )
-            for _ in range(num_layers)
+            for i in range(num_layers)
         ]
         self.start_from_zero_embedding = False
 


### PR DESCRIPTION
Saving the relative attention bias in every layers is no longer needed since https://github.com/OpenNMT/CTranslate2/pull/1335.

This change also makes the conversion code more consistent with the original implementation.