### PR TITLE
Representing non-ASCII characters using ASCII

### DIFF
--- a/include/ctranslate2/utils.h
+++ b/include/ctranslate2/utils.h
@@ -29,7 +29,7 @@ namespace ctranslate2 {
   std::vector<std::vector<std::vector<std::string>>>
   extract_features(std::vector<std::vector<std::string>> batch,
                    size_t num_features,
-                   const std::string& features_separator = "￨");
+                   const std::string& features_separator = "\uFFE8");
 
   template <typename T, typename I>
   static std::vector<T> index_vector(const std::vector<T>& v,


### PR DESCRIPTION
The file contains Non-ASCII string. If the compiler's default encoding is anything other than UTF-8, it may lead to compilation errors if compiled manually.
`include\ctranslate2\utils.h`  line 30
```
  extract_features(std::vector<std::vector<std::string>> batch,
                   size_t num_features,
                   const std::string& features_separator = "￨");
```