### PR TITLE
Support dtype conversion for the StorageView Python class

### DIFF
--- a/python/cpp/module.cc
+++ b/python/cpp/module.cc
@@ -34,6 +34,9 @@ get_supported_compute_types(const std::string& device_str, const int device_inde
 
 PYBIND11_MODULE(_ext, m)
 {
+  py::options options;
+  options.disable_enum_members_docstring();
+
   m.def("contains_model", &ctranslate2::models::contains_model, py::arg("path"),
         "Helper function to check if a directory seems to contain a CTranslate2 model.");
 

--- a/python/cpp/storage_view.cc
+++ b/python/cpp/storage_view.cc
@@ -48,7 +48,10 @@ namespace ctranslate2 {
       case DataType::INT32:
         return "<i4";
       default:
-        return "";
+        throw std::runtime_error("Data type " + dtype_name(dtype) + " is not supported in the array "
+                                 "interface. You should first convert this storage to a supported "
+                                 "type, for example with "
+                                 "`storage = storage.to(ctranslate2.DataType.float32)`");
       }
     }
 
@@ -94,6 +97,15 @@ namespace ctranslate2 {
     }
 
     void register_storage_view(py::module& m) {
+      py::enum_<DataType>(m, "DataType")
+        .value("float32", DataType::FLOAT32)
+        .value("float16", DataType::FLOAT16)
+        .value("bfloat16", DataType::BFLOAT16)
+        .value("int8", DataType::INT8)
+        .value("int16", DataType::INT16)
+        .value("int32", DataType::INT32)
+        ;
+
       py::class_<StorageView>(
         m, "StorageView",
         R"pbdoc(
@@ -140,6 +152,9 @@ namespace ctranslate2 {
                             uses an unsupported array specification.
                     )pbdoc")
 
+        .def_property_readonly("dtype", &StorageView::dtype,
+                               "Data type used by the storage.")
+
         .def_property_readonly("__array_interface__", [](const StorageView& view) {
           if (view.device() == Device::CUDA)
             throw py::attribute_error("Cannot get __array_interface__ when the StorageView "
@@ -159,6 +174,25 @@ namespace ctranslate2 {
           stream << view;
           return stream.str();
         })
+
+        .def("to",
+             [](const StorageView& view, DataType dtype) {
+               ScopedDeviceSetter device_setter(view.device(), view.device_index());
+               StorageView converted = view.to(dtype);
+               synchronize_stream(view.device());
+               return converted;
+             },
+             py::arg("dtype"),
+             py::call_guard<py::gil_scoped_release>(),
+             R"pbdoc(
+                 Converts the storage to another type.
+
+                 Arguments:
+                   dtype: The data type to convert to.
+
+                 Returns:
+                   A new ``StorageView`` instance.
+             )pbdoc")
 
         ;
     }

--- a/python/cpp/storage_view.cc
+++ b/python/cpp/storage_view.cc
@@ -155,6 +155,18 @@ namespace ctranslate2 {
         .def_property_readonly("dtype", &StorageView::dtype,
                                "Data type used by the storage.")
 
+        .def_property_readonly("shape", &StorageView::shape,
+                               "Shape of the storage view.")
+
+        .def_property_readonly("device_index", &StorageView::device_index,
+                               "Device index.")
+
+        .def_property_readonly("device",
+                               [](const StorageView& view) {
+                                 return device_to_str(view.device());
+                               },
+                               "Device where the storage is allocated (\"cpu\" or \"cuda\").")
+
         .def_property_readonly("__array_interface__", [](const StorageView& view) {
           if (view.device() == Device::CUDA)
             throw py::attribute_error("Cannot get __array_interface__ when the StorageView "

--- a/python/ctranslate2/__init__.py
+++ b/python/ctranslate2/__init__.py
@@ -22,6 +22,7 @@ try:
         AsyncGenerationResult,
         AsyncScoringResult,
         AsyncTranslationResult,
+        DataType,
         Encoder,
         EncoderForwardOutput,
         ExecutionStats,

--- a/python/install_requirements.txt
+++ b/python/install_requirements.txt
@@ -1,3 +1,3 @@
-pybind11==2.10.1
+pybind11==2.11.1
 setuptools
 wheel

--- a/python/tests/test_storage_view.py
+++ b/python/tests/test_storage_view.py
@@ -27,7 +27,10 @@ def test_storageview_cpu(dtype, name):
     x = np.ones((2, 4), dtype=dtype)
     s = ctranslate2.StorageView.from_array(x)
 
+    assert s.device == "cpu"
+    assert s.device_index == 0
     assert s.dtype.name == name
+    assert s.shape == [2, 4]
 
     _assert_same_array(s.__array_interface__, x.__array_interface__)
 
@@ -50,6 +53,11 @@ def test_storageview_cuda():
 
     x = torch.ones((2, 4), device="cuda")
     s = ctranslate2.StorageView.from_array(x)
+
+    assert s.device == "cuda"
+    assert s.device_index == 0
+    assert s.dtype == ctranslate2.DataType.float32
+    assert s.shape == [2, 4]
 
     _assert_same_array(s.__cuda_array_interface__, x.__cuda_array_interface__)
 

--- a/python/tests/test_storage_view.py
+++ b/python/tests/test_storage_view.py
@@ -27,6 +27,8 @@ def test_storageview_cpu(dtype, name):
     x = np.ones((2, 4), dtype=dtype)
     s = ctranslate2.StorageView.from_array(x)
 
+    assert s.dtype.name == name
+
     _assert_same_array(s.__array_interface__, x.__array_interface__)
 
     with pytest.raises(AttributeError, match="CPU"):
@@ -62,6 +64,18 @@ def test_storageview_cuda():
 
     y = torch.as_tensor(s, device="cuda")
     _assert_same_array(s.__cuda_array_interface__, y.__cuda_array_interface__)
+
+
+def test_storageview_conversion():
+    x = np.ones((2, 4), dtype=np.float32)
+    s = ctranslate2.StorageView.from_array(x)
+    assert s.dtype == ctranslate2.DataType.float32
+
+    s = s.to(ctranslate2.DataType.bfloat16)
+    assert s.dtype == ctranslate2.DataType.bfloat16
+
+    with pytest.raises(RuntimeError, match="not supported in the array interface"):
+        s.__array_interface__
 
 
 def test_storageview_strides():


### PR DESCRIPTION
The "bfloat16" type is not supported in the array interface so there should be a way to convert the storage before passing it to Numpy or PyTorch.