### PR TITLE
Remove vocabulary workaround in the Llama converter

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -1209,14 +1209,6 @@ class LlamaLoader(ModelLoader):
         self.set_linear(spec.decoder.projection, model.lm_head)
         return spec
 
-    def get_vocabulary(self, model, tokenizer):
-        tokens = super().get_vocabulary(model, tokenizer)
-
-        if len(tokens) > model.config.vocab_size:
-            tokens = tokens[: model.config.vocab_size]
-
-        return tokens
-
     def set_vocabulary(self, spec, tokens):
         spec.register_vocabulary(tokens)
 


### PR DESCRIPTION
The configuration of Llama 2 models was fixed upstream, cf. https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/commit/0d52e200fc7ba73089b86c1b5727267dccf65311.