### PR TITLE
By default, keep the same FP precision when converting models

### DIFF
--- a/cli/translator.cc
+++ b/cli/translator.cc
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) {
 
   cmd_options.add_options("Model")
     ("model", "Path to the CTranslate2 model directory.", cxxopts::value<std::string>())
-    ("compute_type", "The type used for computation: default, auto, float32, float16, bfloat16, int16, int8, int8_float16, or int8_bfloat16",
+    ("compute_type", "The type used for computation: default, auto, float32, float16, bfloat16, int16, int8, int8_float32, int8_float16, or int8_bfloat16",
      cxxopts::value<std::string>()->default_value("default"))
     ("cuda_compute_type", "Computation type on CUDA devices (overrides compute_type)",
      cxxopts::value<std::string>())

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -16,11 +16,13 @@ See the benchmark results in the main [README](https://github.com/OpenNMT/CTrans
 Enabling the quantization when converting the model is helpful to reduce its size on disk. The converters expose the option `quantization` that accepts the following values:
 
 * `int8`
+* `int8_float32`
 * `int8_float16`
 * `int8_bfloat16`
 * `int16`
 * `float16`
 * `bfloat16`
+* `float32`
 
 For example,
 
@@ -36,11 +38,11 @@ For reference, the table below compares the model size on disk for a base Transf
 
 | Quantization | Model size |
 | --- | --- |
-| None | 364MB |
+| `float32` | 364MB |
 | `int16` | 187MB |
 | `float16` | 182MB |
 | `bfloat16` | 182MB |
-| `int8` | 100MB |
+| `int8_float32` | 100MB |
 | `int8_float16` | 95MB |
 | `int8_bfloat16` | 95MB |
 
@@ -51,6 +53,7 @@ Quantization can also be enabled or changed when loading the model. The translat
 * `default`: keep the same quantization that was used during model conversion (see {ref}`quantization:implicit type conversion on load` for exceptions)
 * `auto`: use the fastest computation type that is supported on this system and device
 * `int8`
+* `int8_float32`
 * `int8_float16`
 * `int8_bfloat16`
 * `int16`
@@ -74,21 +77,21 @@ By default, the runtime tries to use the type that is saved in the converted mod
 
 **On CPU:**
 
-| Architecture | int8 | int8_float16 | int8_bfloat16 | int16 | float16 | bfloat16 |
+| Architecture | int8_float32 | int8_float16 | int8_bfloat16 | int16 | float16 | bfloat16 |
 | --- | --- | --- | --- | --- | --- | --- |
-| x86-64 (Intel) | int8 | int8 | int8 | int16 | float32 | float32 |
-| x86-64 (other) | int8 | int8 | int8 | int8 | float32 | float32 |
-| AArch64/ARM64 (Apple) | int8 | int8 | int8 | int8 | float32 | float32 |
-| AArch64/ARM64 (other) | int8 | int8 | int8 | int8 | float32 | float32 |
+| x86-64 (Intel) | int8_float32 | int8_float32 | int8_float32 | int16 | float32 | float32 |
+| x86-64 (other) | int8_float32 | int8_float32 | int8_float32 | int8_float32 | float32 | float32 |
+| AArch64/ARM64 (Apple) | int8_float32 | int8_float32 | int8_float32 | int8_float32 | float32 | float32 |
+| AArch64/ARM64 (other) | int8_float32 | int8_float32 | int8_float32 | int8_float32 | float32 | float32 |
 
 **On GPU:**
 
-| Compute Capability | int8 | int8_float16 | int8_bfloat16 | int16 | float16 | bfloat16 |
+| Compute Capability | int8_float32 | int8_float16 | int8_bfloat16 | int16 | float16 | bfloat16 |
 | --- | --- | --- | --- | --- | --- | -- |
-| >= 8.0 | int8 | int8_float16 | int8_bfloat16 | float16 | float16 | bfloat16 |
-| >= 7.0, < 8.0 | int8 | int8_float16 | int8 | float16 | float16 | float32 |
+| >= 8.0 | int8_float32 | int8_float16 | int8_bfloat16 | float16 | float16 | bfloat16 |
+| >= 7.0, < 8.0 | int8_float32 | int8_float16 | int8_float32 | float16 | float16 | float32 |
 | 6.2 | float32 | float32 | float32 | float32 | float32 | float32 |
-| 6.1 | int8 | int8 | int8 | float32 | float32 | float32 |
+| 6.1 | int8_float32 | int8_float32 | int8_float32 | float32 | float32 | float32 |
 | <= 6.0 | float32 | float32 | float32 | float32 | float32 | float32 |
 
 ```{tip}
@@ -119,6 +122,12 @@ WQ[i,j] = round(scale[i] * W[i,j])
 This formula corresponds to a symmetric quantization (absolute maximum of the input range instead of separate min/max values).
 ```
 
+Non quantized layers are run in the floating point precision of the original model. For example, if the model is saved in `float16`, the actual quantization type will be `int8_float16`. This behavior can be changed by selecting more specific quantization types:
+
+* `int8_float32`
+* `int8_float16`
+* `int8_bfloat16`
+
 ### 16-bit integers (`int16`)
 
 **Supported on:**
@@ -133,7 +142,7 @@ scale = 2^10 / max(abs(W))
 
 As suggested by the author, the idea is to use 10 bits for the input so that the multiplication is 20 bits which gives 12 bits left for accumulation.
 
-Similar to the `int8` quantization, only the weights of the embedding and linear layers are quantized to 16-bit integers.
+Similar to the `int8` quantization, only the weights of the embedding and linear layers are quantized to 16-bit integers. The other layers are run in FP32.
 
 ### 16-bit floating points (`float16`)
 
@@ -150,19 +159,3 @@ In this mode, all model weights are stored in half precision and all layers are 
 * NVIDIA GPU with Compute Capability >= 8.0
 
 In this mode, all model weights are stored in BF16 and all layers are run with this type.
-
-### Mixed 8-bit integers and 16-bit floating points (`int8_float16`)
-
-**Supported on:**
-
-* NVIDIA GPU with Compute Capability >= 7.0
-
-This mode is the same as `int8`, but all non quantized layers are run in FP16 instead of FP32.
-
-### Mixed 8-bit integers and 16-bit brain floating points (`int8_bfloat16`)
-
-**Supported on:**
-
-* NVIDIA GPU with Compute Capability >= 8.0
-
-This mode is the same as `int8`, but all non quantized layers are run in BF16 instead of FP32.

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -30,7 +30,9 @@ For example,
 ct2-opennmt-py-converter --model_path model.pt --quantization int8 --output_dir ct2_model
 ```
 
-```{note}
+When the option `--quantization` is not set, the converted model will be saved with the same type as the original model (typically one of float32, float16, or bfloat16).
+
+```{important}
 Whatever quantization type is selected here, the runtime ensures the model can be loaded and executed efficiently. This implies the model weights are possibly converted to another type when the model is loaded, see {ref}`quantization:implicit type conversion on load`.
 ```
 

--- a/include/ctranslate2/replica_pool.h
+++ b/include/ctranslate2/replica_pool.h
@@ -145,12 +145,12 @@ namespace ctranslate2 {
       }
     }
 
-  protected:
     const Replica& get_first_replica() const {
       auto& worker = static_cast<ReplicaWorker<Replica>&>(_thread_pool->get_worker(0));
       return worker.replica();
     }
 
+  protected:
     template <typename Result, typename Func>
     std::vector<std::future<Result>>
     post_examples(const std::vector<Example>& examples,

--- a/include/ctranslate2/types.h
+++ b/include/ctranslate2/types.h
@@ -30,6 +30,7 @@ namespace ctranslate2 {
     AUTO,
     FLOAT32,
     INT8,
+    INT8_FLOAT32,
     INT8_FLOAT16,
     INT8_BFLOAT16,
     INT16,

--- a/python/cpp/encoder.cc
+++ b/python/cpp/encoder.cc
@@ -81,8 +81,8 @@ namespace ctranslate2 {
                    device: Device to use (possible values are: cpu, cuda, auto).
                    device_index: Device IDs where to place this encoder on.
                    compute_type: Model computation type or a dictionary mapping a device name
-                     to the computation type (possible values are: default, auto, int8, int8_float16,
-                     int8_bfloat16, int16, float16, bfloat16, float32).
+                     to the computation type (possible values are: default, auto, int8, int8_float32,
+                     int8_float16, int8_bfloat16, int16, float16, bfloat16, float32).
                    inter_threads: Maximum number of parallel generations.
                    intra_threads: Number of OpenMP threads per encoder (0 to use a default value).
                    max_queued_batches: Maximum numbers of batches in the queue (-1 for unlimited,

--- a/python/cpp/encoder.cc
+++ b/python/cpp/encoder.cc
@@ -97,6 +97,8 @@ namespace ctranslate2 {
                                "Device this encoder is running on.")
         .def_property_readonly("device_index", &EncoderWrapper::device_index,
                                "List of device IDs where this encoder is running on.")
+        .def_property_readonly("compute_type", &EncoderWrapper::compute_type,
+                               "Computation type used by the model.")
         .def_property_readonly("num_encoders", &EncoderWrapper::num_replicas,
                                "Number of encoders backing this instance.")
         .def_property_readonly("num_queued_batches", &EncoderWrapper::num_queued_batches,

--- a/python/cpp/generator.cc
+++ b/python/cpp/generator.cc
@@ -146,8 +146,8 @@ namespace ctranslate2 {
                    device: Device to use (possible values are: cpu, cuda, auto).
                    device_index: Device IDs where to place this generator on.
                    compute_type: Model computation type or a dictionary mapping a device name
-                     to the computation type (possible values are: default, auto, int8, int8_float16,
-                     int8_bfloat16, int16, float16, bfloat16, float32).
+                     to the computation type (possible values are: default, auto, int8, int8_float32,
+                     int8_float16, int8_bfloat16, int16, float16, bfloat16, float32).
                    inter_threads: Maximum number of parallel generations.
                    intra_threads: Number of OpenMP threads per generator (0 to use a default value).
                    max_queued_batches: Maximum numbers of batches in the queue (-1 for unlimited,

--- a/python/cpp/generator.cc
+++ b/python/cpp/generator.cc
@@ -162,6 +162,8 @@ namespace ctranslate2 {
                                "Device this generator is running on.")
         .def_property_readonly("device_index", &GeneratorWrapper::device_index,
                                "List of device IDs where this generator is running on.")
+        .def_property_readonly("compute_type", &GeneratorWrapper::compute_type,
+                               "Computation type used by the model.")
         .def_property_readonly("num_generators", &GeneratorWrapper::num_replicas,
                                "Number of generators backing this instance.")
         .def_property_readonly("num_queued_batches", &GeneratorWrapper::num_queued_batches,

--- a/python/cpp/replica_pool.h
+++ b/python/cpp/replica_pool.h
@@ -73,6 +73,10 @@ namespace ctranslate2 {
         return _model_loader.device_indices;
       }
 
+      std::string compute_type() const {
+        return compute_type_to_str(model()->effective_compute_type());
+      }
+
       size_t num_replicas() const {
         return _pool->num_replicas();
       }
@@ -89,6 +93,10 @@ namespace ctranslate2 {
       std::unique_ptr<T> _pool;
       models::ModelLoader _model_loader;
       ReplicaPoolConfig _pool_config;
+
+      const std::shared_ptr<const models::Model>& model() const {
+        return _pool->get_first_replica().model();
+      }
     };
 
   }

--- a/python/cpp/translator.cc
+++ b/python/cpp/translator.cc
@@ -393,8 +393,8 @@ namespace ctranslate2 {
                    device: Device to use (possible values are: cpu, cuda, auto).
                    device_index: Device IDs where to place this generator on.
                    compute_type: Model computation type or a dictionary mapping a device name
-                     to the computation type (possible values are: default, auto, int8, int8_float16,
-                     int8_bfloat16, int16, float16, bfloat16, float32).
+                     to the computation type (possible values are: default, auto, int8, int8_float32,
+                     int8_float16, int8_bfloat16, int16, float16, bfloat16, float32).
                    inter_threads: Maximum number of parallel translations.
                    intra_threads: Number of OpenMP threads per translator (0 to use a default value).
                    max_queued_batches: Maximum numbers of batches in the queue (-1 for unlimited,

--- a/python/cpp/translator.cc
+++ b/python/cpp/translator.cc
@@ -409,6 +409,8 @@ namespace ctranslate2 {
                                "Device this translator is running on.")
         .def_property_readonly("device_index", &TranslatorWrapper::device_index,
                                "List of device IDs where this translator is running on.")
+        .def_property_readonly("compute_type", &TranslatorWrapper::compute_type,
+                               "Computation type used by the model.")
         .def_property_readonly("num_translators", &TranslatorWrapper::num_replicas,
                                "Number of translators backing this instance.")
         .def_property_readonly("num_queued_batches", &TranslatorWrapper::num_queued_batches,

--- a/python/cpp/whisper.cc
+++ b/python/cpp/whisper.cc
@@ -167,8 +167,8 @@ namespace ctranslate2 {
                    device: Device to use (possible values are: cpu, cuda, auto).
                    device_index: Device IDs where to place this model on.
                    compute_type: Model computation type or a dictionary mapping a device name
-                     to the computation type (possible values are: default, auto, int8, int8_float16,
-                     int8_bfloat16, int16, float16, bfloat16, float32).
+                     to the computation type (possible values are: default, auto, int8, int8_float32,
+                     int8_float16, int8_bfloat16, int16, float16, bfloat16, float32).
                    inter_threads: Number of workers to allow executing multiple batches in parallel.
                    intra_threads: Number of OpenMP threads per worker (0 to use a default value).
                    max_queued_batches: Maximum numbers of batches in the worker queue (-1 for unlimited,

--- a/python/cpp/whisper.cc
+++ b/python/cpp/whisper.cc
@@ -183,6 +183,8 @@ namespace ctranslate2 {
                                "Device this model is running on.")
         .def_property_readonly("device_index", &WhisperWrapper::device_index,
                                "List of device IDs where this model is running on.")
+        .def_property_readonly("compute_type", &WhisperWrapper::compute_type,
+                               "Computation type used by the model.")
         .def_property_readonly("num_workers", &WhisperWrapper::num_replicas,
                                "Number of model workers backing this instance.")
         .def_property_readonly("num_queued_batches", &WhisperWrapper::num_queued_batches,

--- a/python/ctranslate2/converters/converter.py
+++ b/python/ctranslate2/converters/converter.py
@@ -29,11 +29,13 @@ class Converter(abc.ABC):
             default=None,
             choices=[
                 "int8",
+                "int8_float32",
                 "int8_float16",
                 "int8_bfloat16",
                 "int16",
                 "float16",
                 "bfloat16",
+                "float32",
             ],
             help="Weight quantization type.",
         )

--- a/python/ctranslate2/converters/converter.py
+++ b/python/ctranslate2/converters/converter.py
@@ -5,7 +5,7 @@ import shutil
 
 from typing import Optional
 
-from ctranslate2.specs.model_spec import ModelSpec
+from ctranslate2.specs.model_spec import ACCEPTED_MODEL_TYPES, ModelSpec
 
 
 class Converter(abc.ABC):
@@ -27,16 +27,7 @@ class Converter(abc.ABC):
         parser.add_argument(
             "--quantization",
             default=None,
-            choices=[
-                "int8",
-                "int8_float32",
-                "int8_float16",
-                "int8_bfloat16",
-                "int16",
-                "float16",
-                "bfloat16",
-                "float32",
-            ],
+            choices=ACCEPTED_MODEL_TYPES,
             help="Weight quantization type.",
         )
         parser.add_argument(
@@ -76,8 +67,8 @@ class Converter(abc.ABC):
           output_dir: Output directory where the CTranslate2 model is saved.
           vmap: Optional path to a vocabulary mapping file that will be included
             in the converted model directory.
-          quantization: Weight quantization scheme
-            (possible values are: int8, int8_float16, int16, float16).
+          quantization: Weight quantization scheme (possible values are: int8, int8_float32,
+            int8_float16, int8_bfloat16, int16, float16, bfloat16, float32).
           force: Override the output directory if it already exists.
 
         Returns:

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -102,9 +102,14 @@ class TransformersConverter(Converter):
             model_class = getattr(transformers, loader.architecture_name)
             tokenizer_class = transformers.AutoTokenizer
 
-            kwargs = {}
-            if self._load_as_float16:
-                kwargs["torch_dtype"] = torch.float16
+            kwargs = {
+                "torch_dtype": (
+                    torch.float16
+                    if self._load_as_float16
+                    else getattr(config, "torch_dtype", None)
+                )
+            }
+
             if self._revision:
                 kwargs["revision"] = self._revision
             if self._low_cpu_mem_usage:

--- a/python/ctranslate2/specs/model_spec.py
+++ b/python/ctranslate2/specs/model_spec.py
@@ -197,7 +197,12 @@ class LayerSpec(FrozenAttr, metaclass=FrozenMeta):
                     value = value.astype(np.int16)
                     scale = NumpyVariable(scale)
                     value = NumpyVariable(value)
-                elif quantization in ("int8", "int8_float16", "int8_bfloat16"):
+                elif quantization in (
+                    "int8",
+                    "int8_float32",
+                    "int8_float16",
+                    "int8_bfloat16",
+                ):
                     value = value.to("float32").numpy()
                     amax = np.amax(np.absolute(value), axis=1)
                     amax[amax == 0] = 127.0
@@ -207,17 +212,15 @@ class LayerSpec(FrozenAttr, metaclass=FrozenMeta):
                     value = value.astype(np.int8)
                     scale = NumpyVariable(scale)
                     value = NumpyVariable(value)
-                elif quantization in ("float16", "bfloat16"):
+                elif quantization in ("float16", "bfloat16", "float32"):
                     value = value.to(quantization)
-                else:
-                    value = value.to("float32")
 
             elif is_convertible:
                 if quantization in ("float16", "int8_float16"):
                     value = value.to("float16")
                 elif quantization in ("bfloat16", "int8_bfloat16"):
                     value = value.to("bfloat16")
-                else:
+                elif quantization in ("float32", "int16", "int8_float32"):
                     value = value.to("float32")
 
             setattr(spec, key, value)

--- a/python/ctranslate2/specs/model_spec.py
+++ b/python/ctranslate2/specs/model_spec.py
@@ -24,6 +24,17 @@ except ImportError:
 OPTIONAL = "__optional"
 CURRENT_BINARY_VERSION = 6
 
+ACCEPTED_MODEL_TYPES = (
+    "int8",
+    "int8_float32",
+    "int8_float16",
+    "int8_bfloat16",
+    "int16",
+    "float16",
+    "bfloat16",
+    "float32",
+)
+
 
 def _join_scope(scope, name):
     if not scope:
@@ -173,6 +184,11 @@ class LayerSpec(FrozenAttr, metaclass=FrozenMeta):
 
     def _quantize(self, quantization):
         """Possibly quantizes the variable of the layer."""
+        if quantization is not None and quantization not in ACCEPTED_MODEL_TYPES:
+            raise ValueError(
+                "%s is not a valid quantization type. Accepted types are: %s"
+                % (quantization, ", ".join(ACCEPTED_MODEL_TYPES))
+            )
 
         def _quantize(spec, name, value):
             if not isinstance(value, Variable) or value.is_scalar():
@@ -236,8 +252,8 @@ class LayerSpec(FrozenAttr, metaclass=FrozenMeta):
         * Quantize weights.
 
         Arguments:
-          quantization: Weight quantization scheme
-            (possible values are: int8, int8_float16, int16, float16).
+          quantization: Weight quantization scheme (possible values are: int8, int8_float32,
+            int8_float16, int8_bfloat16, int16, float16, bfloat16, float32).
         """
         self._alias_variables()
         self._quantize(quantization)

--- a/python/tests/test_spec.py
+++ b/python/tests/test_spec.py
@@ -116,6 +116,12 @@ def test_int8_quantization():
     [
         (
             None,
+            np.array([[-10, -3, 5, 2]], dtype=np.float16),
+            None,
+            np.array([4], dtype=np.float16),
+        ),
+        (
+            "float32",
             np.array([[-10, -3, 5, 2]], dtype=np.float32),
             None,
             np.array([4], dtype=np.float32),
@@ -130,13 +136,19 @@ def test_int8_quantization():
             "int8",
             np.array([[-127, -38, 64, 25]], dtype=np.int8),
             np.array([12.7], dtype=np.float32),
-            np.array([4], dtype=np.float32),
+            np.array([4], dtype=np.float16),
         ),
         (
             "int8_float16",
             np.array([[-127, -38, 64, 25]], dtype=np.int8),
             np.array([12.7], dtype=np.float32),
             np.array([4], dtype=np.float16),
+        ),
+        (
+            "int8_float32",
+            np.array([[-127, -38, 64, 25]], dtype=np.int8),
+            np.array([12.7], dtype=np.float32),
+            np.array([4], dtype=np.float32),
         ),
         (
             "int16",
@@ -166,10 +178,10 @@ def test_fp16_weights(
     assert test_utils.array_equal(spec.bias.numpy(), expected_bias)
 
     # Check the weights were not copied or converted.
-    if quantization == "float16":
+    if quantization in (None, "float16"):
         assert spec.weight.numpy() is weight
         assert spec.bias.numpy() is bias
-    elif quantization == "int8_float16":
+    elif quantization in ("int8", "int8_float16"):
         assert spec.bias.numpy() is bias
 
     if expected_weight_scale is None:
@@ -248,19 +260,26 @@ def test_smooth_activation_torch():
 @pytest.mark.parametrize(
     "quantization,expected_weight_dtype,expected_bias_dtype",
     [
-        (None, "float32", "float32"),
-        ("int8", "int8", "float32"),
+        (None, None, None),
+        ("int8", "int8", None),
+        ("int8_float32", "int8", "float32"),
         ("int8_float16", "int8", "float16"),
         ("int8_bfloat16", "int8", "bfloat16"),
         ("int16", "int16", "float32"),
         ("float16", "float16", "float16"),
         ("bfloat16", "bfloat16", "bfloat16"),
+        ("float32", "float32", "float32"),
     ],
 )
 def test_torch_variables(
     tmp_dir, variable_dtype, quantization, expected_weight_dtype, expected_bias_dtype
 ):
     import torch
+
+    if expected_weight_dtype is None:
+        expected_weight_dtype = variable_dtype
+    if expected_bias_dtype is None:
+        expected_bias_dtype = variable_dtype
 
     variable_dtype = getattr(torch, variable_dtype)
 

--- a/python/tests/test_spec.py
+++ b/python/tests/test_spec.py
@@ -92,6 +92,11 @@ def test_layer_spec_optimize():
     assert spec.sub.weight.dtype == "float16"
     assert spec.sub.a.dtype == "float16"
 
+    spec = Spec()
+    spec.validate()
+    with pytest.raises(ValueError, match="not a valid quantization type"):
+        spec.optimize(quantization="int32")
+
 
 def test_int8_quantization():
     class Spec(ctranslate2.specs.LayerSpec):

--- a/python/tests/test_transformers.py
+++ b/python/tests/test_transformers.py
@@ -228,6 +228,18 @@ def test_transformers_generation(
 
 
 @test_utils.only_on_linux
+def test_transformers_dtype(clear_transformers_cache, tmp_dir):
+    converter = ctranslate2.converters.TransformersConverter("facebook/opt-350m")
+    output_dir = str(tmp_dir.join("ctranslate2_model"))
+    output_dir = converter.convert(output_dir)
+
+    model_b = os.path.getsize(os.path.join(output_dir, "model.bin"))
+    model_mb = model_b / (1000**2)
+
+    assert model_mb < 700
+
+
+@test_utils.only_on_linux
 def test_transformers_marianmt_vocabulary(clear_transformers_cache, tmp_dir):
     converter = ctranslate2.converters.TransformersConverter(
         "Helsinki-NLP/opus-mt-en-de"

--- a/python/tests/test_translator.py
+++ b/python/tests/test_translator.py
@@ -68,6 +68,7 @@ def test_get_supported_compute_types():
     compute_types = ctranslate2.get_supported_compute_types("cpu")
     assert "float32" in compute_types
     assert "int8" in compute_types
+    assert "int8_float32" in compute_types
 
 
 def test_translator_properties():

--- a/python/tests/test_translator.py
+++ b/python/tests/test_translator.py
@@ -86,8 +86,14 @@ def test_compute_type():
         ctranslate2.Translator(model_path, compute_type="float64")
     with pytest.raises(TypeError, match="incompatible constructor arguments"):
         ctranslate2.Translator(model_path, compute_type=["int8", "int16"])
-    ctranslate2.Translator(model_path, compute_type="int8")
-    ctranslate2.Translator(model_path, compute_type={"cuda": "float16", "cpu": "int8"})
+
+    translator = ctranslate2.Translator(model_path, compute_type="int8")
+    assert translator.compute_type == "int8_float32"
+
+    translator = ctranslate2.Translator(
+        model_path, compute_type={"cuda": "float16", "cpu": "int8"}
+    )
+    assert translator.compute_type == "int8_float32"
 
 
 @pytest.mark.parametrize("max_batch_size", [0, 1])

--- a/src/cpu/backend.cc
+++ b/src/cpu/backend.cc
@@ -48,17 +48,22 @@ namespace ctranslate2 {
     }
 
     GemmBackend get_gemm_backend(ComputeType compute_type) {
+      const bool is_int8 = (compute_type == ComputeType::INT8
+                            || compute_type == ComputeType::INT8_FLOAT32
+                            || compute_type == ComputeType::INT8_FLOAT16
+                            || compute_type == ComputeType::INT8_BFLOAT16);
+
 #ifdef CT2_WITH_MKL
       if (mayiuse_mkl()
           && (compute_type == ComputeType::FLOAT32
               || compute_type == ComputeType::INT16
-              || compute_type == ComputeType::INT8)) {
+              || is_int8)) {
         return GemmBackend::MKL;
       }
 #endif
 
 #ifdef CT2_WITH_DNNL
-      if (compute_type == ComputeType::FLOAT32 || compute_type == ComputeType::INT8) {
+      if (compute_type == ComputeType::FLOAT32 || is_int8) {
         return GemmBackend::DNNL;
       }
 #endif
@@ -76,7 +81,7 @@ namespace ctranslate2 {
 #endif
 
 #ifdef CT2_WITH_RUY
-      if (compute_type == ComputeType::INT8) {
+      if (is_int8) {
         return GemmBackend::RUY;
       }
 #endif


### PR DESCRIPTION
Currently, converting models without setting the option `--quantization` will implicitly cast the weights to FP32. This behavior may be surprising if the original model is saved in FP16 for example.

Now the converted model will use the same FP precision as the original model by default.

The option `--quantization` is updated to accept the value "float32" to always upcast the weights to FP32.

This new behavior also impacts the "int8" quantization type which will keep non quantized weights in their original precision, unless a more specific quantization type is used:

* int8_float32
* int8_float16
* int8_bfloat16