### PR TITLE
token type ids can be set by optional argument up to python wrapper

### DIFF
--- a/include/ctranslate2/encoder.h
+++ b/include/ctranslate2/encoder.h
@@ -11,19 +11,10 @@ namespace ctranslate2 {
     using ReplicaPool::ReplicaPool;
 
     std::future<EncoderForwardOutput>
-    forward_batch_async(std::vector<std::vector<std::string>> tokens);
-
-    std::future<EncoderForwardOutput>
     forward_batch_async(std::vector<std::vector<std::string>> tokens, std::vector<std::vector<size_t>> token_type_ids);
 
     std::future<EncoderForwardOutput>
-    forward_batch_async(std::vector<std::vector<size_t>> ids);
-
-    std::future<EncoderForwardOutput>
     forward_batch_async(std::vector<std::vector<size_t>> ids, std::vector<std::vector<size_t>> token_type_ids);
-
-    std::future<EncoderForwardOutput>
-    forward_batch_async(const StorageView& ids, const StorageView& lengths);
     
     std::future<EncoderForwardOutput>
     forward_batch_async(const StorageView& ids, const StorageView& lengths, std::vector<std::vector<size_t>> token_type_ids);

--- a/include/ctranslate2/encoder.h
+++ b/include/ctranslate2/encoder.h
@@ -11,13 +11,17 @@ namespace ctranslate2 {
     using ReplicaPool::ReplicaPool;
 
     std::future<EncoderForwardOutput>
-    forward_batch_async(std::vector<std::vector<std::string>> tokens, std::vector<std::vector<size_t>> token_type_ids);
+    forward_batch_async(std::vector<std::vector<std::string>> tokens,
+                        std::vector<std::vector<size_t>> token_type_ids = {});
 
     std::future<EncoderForwardOutput>
-    forward_batch_async(std::vector<std::vector<size_t>> ids, std::vector<std::vector<size_t>> token_type_ids);
-    
+    forward_batch_async(std::vector<std::vector<size_t>> ids,
+                        std::vector<std::vector<size_t>> token_type_ids = {});
+
     std::future<EncoderForwardOutput>
-    forward_batch_async(const StorageView& ids, const StorageView& lengths, std::vector<std::vector<size_t>> token_type_ids);
+    forward_batch_async(const StorageView& ids,
+                        const StorageView& lengths,
+                        std::vector<std::vector<size_t>> token_type_ids = {});
   };
 
 }

--- a/include/ctranslate2/encoder.h
+++ b/include/ctranslate2/encoder.h
@@ -14,10 +14,19 @@ namespace ctranslate2 {
     forward_batch_async(std::vector<std::vector<std::string>> tokens);
 
     std::future<EncoderForwardOutput>
+    forward_batch_async(std::vector<std::vector<std::string>> tokens, std::vector<std::vector<size_t>> token_type_ids);
+
+    std::future<EncoderForwardOutput>
     forward_batch_async(std::vector<std::vector<size_t>> ids);
 
     std::future<EncoderForwardOutput>
+    forward_batch_async(std::vector<std::vector<size_t>> ids, std::vector<std::vector<size_t>> token_type_ids);
+
+    std::future<EncoderForwardOutput>
     forward_batch_async(const StorageView& ids, const StorageView& lengths);
+    
+    std::future<EncoderForwardOutput>
+    forward_batch_async(const StorageView& ids, const StorageView& lengths, std::vector<std::vector<size_t>> token_type_ids);
   };
 
 }

--- a/include/ctranslate2/models/language_model.h
+++ b/include/ctranslate2/models/language_model.h
@@ -123,13 +123,19 @@ namespace ctranslate2 {
         return model.as_sequence_encoder();
       }
 
-      EncoderForwardOutput forward(const std::vector<std::vector<std::string>>& tokens, const std::vector<std::vector<size_t>>& token_type_ids);
-      EncoderForwardOutput forward(const std::vector<std::vector<size_t>>& ids, const std::vector<std::vector<size_t>>& token_type_ids);
-      EncoderForwardOutput forward(const StorageView& ids, const StorageView& lengths, const std::vector<std::vector<size_t>>& token_type_ids);
+      EncoderForwardOutput forward(const std::vector<std::vector<std::string>>& tokens,
+                                   const std::vector<std::vector<size_t>>& token_type_ids = {});
+      EncoderForwardOutput forward(const std::vector<std::vector<size_t>>& ids,
+                                   const std::vector<std::vector<size_t>>& token_type_ids = {});
+      EncoderForwardOutput forward(const StorageView& ids,
+                                   const StorageView& lengths,
+                                   const std::vector<std::vector<size_t>>& token_type_ids = {});
 
     protected:
       virtual EncoderForwardOutput
-      forward_impl(const StorageView& ids, const StorageView& lengths, const StorageView& token_type_ids) = 0;
+      forward_impl(const StorageView& ids,
+                   const StorageView& lengths,
+                   const StorageView& token_type_ids) = 0;
 
     private:
       const std::shared_ptr<const LanguageModel> _model;
@@ -144,7 +150,9 @@ namespace ctranslate2 {
 
     protected:
       EncoderForwardOutput
-      forward_impl(const StorageView& ids, const StorageView& lengths, const StorageView& token_type_ids) override;
+      forward_impl(const StorageView& ids,
+                   const StorageView& lengths,
+                   const StorageView& token_type_ids) override;
 
     private:
       const std::shared_ptr<const LanguageModel> _model;

--- a/include/ctranslate2/models/language_model.h
+++ b/include/ctranslate2/models/language_model.h
@@ -123,11 +123,8 @@ namespace ctranslate2 {
         return model.as_sequence_encoder();
       }
 
-      EncoderForwardOutput forward(const std::vector<std::vector<std::string>>& tokens);
       EncoderForwardOutput forward(const std::vector<std::vector<std::string>>& tokens, const std::vector<std::vector<size_t>>& token_type_ids);
-      EncoderForwardOutput forward(const std::vector<std::vector<size_t>>& ids);
       EncoderForwardOutput forward(const std::vector<std::vector<size_t>>& ids, const std::vector<std::vector<size_t>>& token_type_ids);
-      EncoderForwardOutput forward(const StorageView& ids, const StorageView& lengths);
       EncoderForwardOutput forward(const StorageView& ids, const StorageView& lengths, const std::vector<std::vector<size_t>>& token_type_ids);
 
     protected:

--- a/include/ctranslate2/models/language_model.h
+++ b/include/ctranslate2/models/language_model.h
@@ -124,12 +124,15 @@ namespace ctranslate2 {
       }
 
       EncoderForwardOutput forward(const std::vector<std::vector<std::string>>& tokens);
+      EncoderForwardOutput forward(const std::vector<std::vector<std::string>>& tokens, const std::vector<std::vector<size_t>>& token_type_ids);
       EncoderForwardOutput forward(const std::vector<std::vector<size_t>>& ids);
+      EncoderForwardOutput forward(const std::vector<std::vector<size_t>>& ids, const std::vector<std::vector<size_t>>& token_type_ids);
       EncoderForwardOutput forward(const StorageView& ids, const StorageView& lengths);
+      EncoderForwardOutput forward(const StorageView& ids, const StorageView& lengths, const std::vector<std::vector<size_t>>& token_type_ids);
 
     protected:
       virtual EncoderForwardOutput
-      forward_impl(const StorageView& ids, const StorageView& lengths) = 0;
+      forward_impl(const StorageView& ids, const StorageView& lengths, const StorageView& token_type_ids) = 0;
 
     private:
       const std::shared_ptr<const LanguageModel> _model;
@@ -144,7 +147,7 @@ namespace ctranslate2 {
 
     protected:
       EncoderForwardOutput
-      forward_impl(const StorageView& ids, const StorageView& lengths) override;
+      forward_impl(const StorageView& ids, const StorageView& lengths, const StorageView& token_type_ids) override;
 
     private:
       const std::shared_ptr<const LanguageModel> _model;

--- a/python/cpp/encoder.cc
+++ b/python/cpp/encoder.cc
@@ -20,18 +20,15 @@ namespace ctranslate2 {
 
         switch (inputs.index()) {
         case 0:
-          future = (token_type_ids) ? _pool->forward_batch_async(std::get<BatchTokens>(inputs), token_type_ids.value()) 
-                                    : _pool->forward_batch_async(std::get<BatchTokens>(inputs));
+          future = _pool->forward_batch_async(std::get<BatchTokens>(inputs), token_type_ids.value_or(std::vector<std::vector<size_t>>()));
           break;
         case 1:
-          future = (token_type_ids) ? _pool->forward_batch_async(std::get<BatchIds>(inputs), token_type_ids.value())
-                                    : _pool->forward_batch_async(std::get<BatchIds>(inputs));
+          future = _pool->forward_batch_async(std::get<BatchIds>(inputs), token_type_ids.value_or(std::vector<std::vector<size_t>>()));
           break;
         case 2:
           if (!lengths)
             throw std::invalid_argument("lengths vector is required when passing a dense input");
-          future =  (token_type_ids) ? _pool->forward_batch_async(std::get<StorageView>(inputs), lengths.value(), token_type_ids.value())
-                                     : _pool->forward_batch_async(std::get<StorageView>(inputs), lengths.value());
+          future =  _pool->forward_batch_async(std::get<StorageView>(inputs), lengths.value(), token_type_ids.value_or(std::vector<std::vector<size_t>>()));
           break;
         }
 
@@ -86,8 +83,8 @@ namespace ctranslate2 {
                    device: Device to use (possible values are: cpu, cuda, auto).
                    device_index: Device IDs where to place this encoder on.
                    compute_type: Model computation type or a dictionary mapping a device name
-                     to the computation type (possible values are: default, auto, int8, int8_float16,
-                     int8_bfloat16, int16, float16, bfloat16, float32).
+                     to the computation type (possible values are: default, auto, int8, int8_float32,
+                      int8_float16, int8_bfloat16, int16, float16, bfloat16, float32).
                    inter_threads: Maximum number of parallel generations.
                    intra_threads: Number of OpenMP threads per encoder (0 to use a default value).
                    max_queued_batches: Maximum numbers of batches in the queue (-1 for unlimited,
@@ -102,6 +99,8 @@ namespace ctranslate2 {
                                "Device this encoder is running on.")
         .def_property_readonly("device_index", &EncoderWrapper::device_index,
                                "List of device IDs where this encoder is running on.")
+        .def_property_readonly("compute_type", &EncoderWrapper::compute_type,
+                                "Computation type used by the model.")
         .def_property_readonly("num_encoders", &EncoderWrapper::num_replicas,
                                "Number of encoders backing this instance.")
         .def_property_readonly("num_queued_batches", &EncoderWrapper::num_queued_batches,
@@ -124,7 +123,7 @@ namespace ctranslate2 {
                    lengths: The length of each sequence as a int32 array with shape
                      ``[batch_size]``. Required when :obj:`inputs` is a dense array.
                    token_type_ids: A batch of token type IDs of same shape as :obj:`inputs`.
-                      ``[batch_size, max_length]``. 
+                     ``[batch_size, max_length]``. 
 
                  Returns:
                    The encoder model output.

--- a/python/cpp/encoder.cc
+++ b/python/cpp/encoder.cc
@@ -13,20 +13,25 @@ namespace ctranslate2 {
 
       EncoderForwardOutput
       forward_batch(const std::variant<BatchTokens, BatchIds, StorageView>& inputs,
-                    const std::optional<StorageView>& lengths) {
+                    const std::optional<StorageView>& lengths,
+                    const std::optional<BatchIds>& token_type_ids
+                    ) {
         std::future<EncoderForwardOutput> future;
 
         switch (inputs.index()) {
         case 0:
-          future = _pool->forward_batch_async(std::get<BatchTokens>(inputs));
+          future = (token_type_ids) ? _pool->forward_batch_async(std::get<BatchTokens>(inputs), token_type_ids.value()) 
+                                    : _pool->forward_batch_async(std::get<BatchTokens>(inputs));
           break;
         case 1:
-          future = _pool->forward_batch_async(std::get<BatchIds>(inputs));
+          future = (token_type_ids) ? _pool->forward_batch_async(std::get<BatchIds>(inputs), token_type_ids.value())
+                                    : _pool->forward_batch_async(std::get<BatchIds>(inputs));
           break;
         case 2:
           if (!lengths)
             throw std::invalid_argument("lengths vector is required when passing a dense input");
-          future = _pool->forward_batch_async(std::get<StorageView>(inputs), lengths.value());
+          future =  (token_type_ids) ? _pool->forward_batch_async(std::get<StorageView>(inputs), lengths.value(), token_type_ids.value())
+                                     : _pool->forward_batch_async(std::get<StorageView>(inputs), lengths.value());
           break;
         }
 
@@ -81,8 +86,8 @@ namespace ctranslate2 {
                    device: Device to use (possible values are: cpu, cuda, auto).
                    device_index: Device IDs where to place this encoder on.
                    compute_type: Model computation type or a dictionary mapping a device name
-                     to the computation type (possible values are: default, auto, int8, int8_float32,
-                     int8_float16, int8_bfloat16, int16, float16, bfloat16, float32).
+                     to the computation type (possible values are: default, auto, int8, int8_float16,
+                     int8_bfloat16, int16, float16, bfloat16, float32).
                    inter_threads: Maximum number of parallel generations.
                    intra_threads: Number of OpenMP threads per encoder (0 to use a default value).
                    max_queued_batches: Maximum numbers of batches in the queue (-1 for unlimited,
@@ -97,8 +102,6 @@ namespace ctranslate2 {
                                "Device this encoder is running on.")
         .def_property_readonly("device_index", &EncoderWrapper::device_index,
                                "List of device IDs where this encoder is running on.")
-        .def_property_readonly("compute_type", &EncoderWrapper::compute_type,
-                               "Computation type used by the model.")
         .def_property_readonly("num_encoders", &EncoderWrapper::num_replicas,
                                "Number of encoders backing this instance.")
         .def_property_readonly("num_queued_batches", &EncoderWrapper::num_queued_batches,
@@ -109,6 +112,7 @@ namespace ctranslate2 {
         .def("forward_batch", &EncoderWrapper::forward_batch,
              py::arg("inputs"),
              py::arg("lengths")=py::none(),
+             py::arg("token_type_ids")=py::none(),
              py::call_guard<py::gil_scoped_release>(),
              R"pbdoc(
                  Forwards a batch of sequences in the encoder.
@@ -119,6 +123,8 @@ namespace ctranslate2 {
                      ``[batch_size, max_length]`` (e.g. created from a Numpy array or PyTorch tensor).
                    lengths: The length of each sequence as a int32 array with shape
                      ``[batch_size]``. Required when :obj:`inputs` is a dense array.
+                   token_type_ids: A batch of token type IDs of same shape as :obj:`inputs`.
+                      ``[batch_size, max_length]``. 
 
                  Returns:
                    The encoder model output.

--- a/python/cpp/encoder.cc
+++ b/python/cpp/encoder.cc
@@ -14,21 +14,27 @@ namespace ctranslate2 {
       EncoderForwardOutput
       forward_batch(const std::variant<BatchTokens, BatchIds, StorageView>& inputs,
                     const std::optional<StorageView>& lengths,
-                    const std::optional<BatchIds>& token_type_ids
-                    ) {
+                    const std::optional<BatchIds>& token_type_ids) {
         std::future<EncoderForwardOutput> future;
 
         switch (inputs.index()) {
         case 0:
-          future = _pool->forward_batch_async(std::get<BatchTokens>(inputs), token_type_ids.value_or(std::vector<std::vector<size_t>>()));
+          future = _pool->forward_batch_async(
+            std::get<BatchTokens>(inputs),
+            token_type_ids.value_or(std::vector<std::vector<size_t>>()));
           break;
         case 1:
-          future = _pool->forward_batch_async(std::get<BatchIds>(inputs), token_type_ids.value_or(std::vector<std::vector<size_t>>()));
+          future = _pool->forward_batch_async(
+            std::get<BatchIds>(inputs),
+            token_type_ids.value_or(std::vector<std::vector<size_t>>()));
           break;
         case 2:
           if (!lengths)
             throw std::invalid_argument("lengths vector is required when passing a dense input");
-          future =  _pool->forward_batch_async(std::get<StorageView>(inputs), lengths.value(), token_type_ids.value_or(std::vector<std::vector<size_t>>()));
+          future = _pool->forward_batch_async(
+            std::get<StorageView>(inputs),
+            lengths.value(),
+            token_type_ids.value_or(std::vector<std::vector<size_t>>()));
           break;
         }
 

--- a/python/cpp/encoder.cc
+++ b/python/cpp/encoder.cc
@@ -84,7 +84,7 @@ namespace ctranslate2 {
                    device_index: Device IDs where to place this encoder on.
                    compute_type: Model computation type or a dictionary mapping a device name
                      to the computation type (possible values are: default, auto, int8, int8_float32,
-                      int8_float16, int8_bfloat16, int16, float16, bfloat16, float32).
+                     int8_float16, int8_bfloat16, int16, float16, bfloat16, float32).
                    inter_threads: Maximum number of parallel generations.
                    intra_threads: Number of OpenMP threads per encoder (0 to use a default value).
                    max_queued_batches: Maximum numbers of batches in the queue (-1 for unlimited,
@@ -100,7 +100,7 @@ namespace ctranslate2 {
         .def_property_readonly("device_index", &EncoderWrapper::device_index,
                                "List of device IDs where this encoder is running on.")
         .def_property_readonly("compute_type", &EncoderWrapper::compute_type,
-                                "Computation type used by the model.")
+                               "Computation type used by the model.")
         .def_property_readonly("num_encoders", &EncoderWrapper::num_replicas,
                                "Number of encoders backing this instance.")
         .def_property_readonly("num_queued_batches", &EncoderWrapper::num_queued_batches,

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -10,6 +10,15 @@ namespace ctranslate2 {
         return encoder.forward(tokens);
       });
   }
+  
+  std::future<EncoderForwardOutput>
+  Encoder::forward_batch_async(std::vector<std::vector<std::string>> tokens, std::vector<std::vector<size_t>> token_type_ids) {
+    return post<EncoderForwardOutput>(
+      [tokens = std::move(tokens), token_type_ids = std::move(token_type_ids)]
+      (models::SequenceEncoderReplica& encoder) {
+        return encoder.forward(tokens, token_type_ids);
+      });
+  }
 
   std::future<EncoderForwardOutput>
   Encoder::forward_batch_async(std::vector<std::vector<size_t>> ids) {
@@ -19,6 +28,15 @@ namespace ctranslate2 {
         return encoder.forward(ids);
       });
   }
+  
+  std::future<EncoderForwardOutput>
+  Encoder::forward_batch_async(std::vector<std::vector<size_t>> ids, std::vector<std::vector<size_t>> token_type_ids) {
+    return post<EncoderForwardOutput>(
+      [ids = std::move(ids), token_type_ids = std::move(token_type_ids)]
+      (models::SequenceEncoderReplica& encoder) {
+        return encoder.forward(ids, token_type_ids);
+      });
+  }
 
   std::future<EncoderForwardOutput>
   Encoder::forward_batch_async(const StorageView& ids, const StorageView& lengths) {
@@ -26,6 +44,15 @@ namespace ctranslate2 {
       [ids = ids.sync_copy(), lengths = lengths.sync_copy()]
       (models::SequenceEncoderReplica& encoder) {
         return encoder.forward(ids, lengths);
+      });
+  }
+
+  std::future<EncoderForwardOutput>
+  Encoder::forward_batch_async(const StorageView& ids, const StorageView& lengths, std::vector<std::vector<size_t>> token_type_ids) {
+    return post<EncoderForwardOutput>(
+      [ids = ids.sync_copy(), lengths = lengths.sync_copy(), token_type_ids = std::move(token_type_ids)]
+      (models::SequenceEncoderReplica& encoder) {
+        return encoder.forward(ids, lengths, token_type_ids);
       });
   }
 

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -1,36 +1,18 @@
 #include "ctranslate2/encoder.h"
 
 namespace ctranslate2 {
-
-  std::future<EncoderForwardOutput>
-  Encoder::forward_batch_async(std::vector<std::vector<std::string>> tokens) {
-    return post<EncoderForwardOutput>(
-      [tokens = std::move(tokens)]
-      (models::SequenceEncoderReplica& encoder) {
-        return encoder.forward(tokens);
-      });
-  }
   
   std::future<EncoderForwardOutput>
-  Encoder::forward_batch_async(std::vector<std::vector<std::string>> tokens, std::vector<std::vector<size_t>> token_type_ids) {
+  Encoder::forward_batch_async(std::vector<std::vector<std::string>> tokens, std::vector<std::vector<size_t>> token_type_ids = {}) {
     return post<EncoderForwardOutput>(
       [tokens = std::move(tokens), token_type_ids = std::move(token_type_ids)]
       (models::SequenceEncoderReplica& encoder) {
         return encoder.forward(tokens, token_type_ids);
       });
   }
-
-  std::future<EncoderForwardOutput>
-  Encoder::forward_batch_async(std::vector<std::vector<size_t>> ids) {
-    return post<EncoderForwardOutput>(
-      [ids = std::move(ids)]
-      (models::SequenceEncoderReplica& encoder) {
-        return encoder.forward(ids);
-      });
-  }
   
   std::future<EncoderForwardOutput>
-  Encoder::forward_batch_async(std::vector<std::vector<size_t>> ids, std::vector<std::vector<size_t>> token_type_ids) {
+  Encoder::forward_batch_async(std::vector<std::vector<size_t>> ids, std::vector<std::vector<size_t>> token_type_ids = {}) {
     return post<EncoderForwardOutput>(
       [ids = std::move(ids), token_type_ids = std::move(token_type_ids)]
       (models::SequenceEncoderReplica& encoder) {
@@ -39,16 +21,7 @@ namespace ctranslate2 {
   }
 
   std::future<EncoderForwardOutput>
-  Encoder::forward_batch_async(const StorageView& ids, const StorageView& lengths) {
-    return post<EncoderForwardOutput>(
-      [ids = ids.sync_copy(), lengths = lengths.sync_copy()]
-      (models::SequenceEncoderReplica& encoder) {
-        return encoder.forward(ids, lengths);
-      });
-  }
-
-  std::future<EncoderForwardOutput>
-  Encoder::forward_batch_async(const StorageView& ids, const StorageView& lengths, std::vector<std::vector<size_t>> token_type_ids) {
+  Encoder::forward_batch_async(const StorageView& ids, const StorageView& lengths, std::vector<std::vector<size_t>> token_type_ids = {}) {
     return post<EncoderForwardOutput>(
       [ids = ids.sync_copy(), lengths = lengths.sync_copy(), token_type_ids = std::move(token_type_ids)]
       (models::SequenceEncoderReplica& encoder) {

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -1,18 +1,20 @@
 #include "ctranslate2/encoder.h"
 
 namespace ctranslate2 {
-  
+
   std::future<EncoderForwardOutput>
-  Encoder::forward_batch_async(std::vector<std::vector<std::string>> tokens, std::vector<std::vector<size_t>> token_type_ids = {}) {
+  Encoder::forward_batch_async(std::vector<std::vector<std::string>> tokens,
+                               std::vector<std::vector<size_t>> token_type_ids) {
     return post<EncoderForwardOutput>(
       [tokens = std::move(tokens), token_type_ids = std::move(token_type_ids)]
       (models::SequenceEncoderReplica& encoder) {
         return encoder.forward(tokens, token_type_ids);
       });
   }
-  
+
   std::future<EncoderForwardOutput>
-  Encoder::forward_batch_async(std::vector<std::vector<size_t>> ids, std::vector<std::vector<size_t>> token_type_ids = {}) {
+  Encoder::forward_batch_async(std::vector<std::vector<size_t>> ids,
+                               std::vector<std::vector<size_t>> token_type_ids) {
     return post<EncoderForwardOutput>(
       [ids = std::move(ids), token_type_ids = std::move(token_type_ids)]
       (models::SequenceEncoderReplica& encoder) {
@@ -21,9 +23,13 @@ namespace ctranslate2 {
   }
 
   std::future<EncoderForwardOutput>
-  Encoder::forward_batch_async(const StorageView& ids, const StorageView& lengths, std::vector<std::vector<size_t>> token_type_ids = {}) {
+  Encoder::forward_batch_async(const StorageView& ids,
+                               const StorageView& lengths,
+                               std::vector<std::vector<size_t>> token_type_ids) {
     return post<EncoderForwardOutput>(
-      [ids = ids.sync_copy(), lengths = lengths.sync_copy(), token_type_ids = std::move(token_type_ids)]
+      [ids = ids.sync_copy(),
+       lengths = lengths.sync_copy(),
+       token_type_ids = std::move(token_type_ids)]
       (models::SequenceEncoderReplica& encoder) {
         return encoder.forward(ids, lengths, token_type_ids);
       });

--- a/src/models/language_model.cc
+++ b/src/models/language_model.cc
@@ -294,22 +294,27 @@ namespace ctranslate2 {
       decoder(ids, lengths, state, logits);
       return logits;
     }
-    
+
+
     EncoderForwardOutput
-    SequenceEncoderReplica::forward(const std::vector<std::vector<std::string>>& tokens, const std::vector<std::vector<size_t>>& token_type_ids = {}) {
+    SequenceEncoderReplica::forward(const std::vector<std::vector<std::string>>& tokens,
+                                    const std::vector<std::vector<size_t>>& token_type_ids) {
       const auto& vocabulary = _model->get_vocabulary();
       return forward(vocabulary.to_ids(tokens), token_type_ids);
     }
-    
+
     EncoderForwardOutput
-    SequenceEncoderReplica::forward(const std::vector<std::vector<size_t>>& ids, const std::vector<std::vector<size_t>>& token_type_ids = {}) {
+    SequenceEncoderReplica::forward(const std::vector<std::vector<size_t>>& ids,
+                                    const std::vector<std::vector<size_t>>& token_type_ids) {
       StorageView lengths;
       StorageView input_ids = layers::make_sequence_inputs(ids, Device::CPU, 1, &lengths);
       return forward(input_ids, lengths, token_type_ids);
     }
-    
+
     EncoderForwardOutput
-    SequenceEncoderReplica::forward(const StorageView& ids, const StorageView& lengths, const std::vector<std::vector<size_t>>& token_type_ids = {}) {
+    SequenceEncoderReplica::forward(const StorageView& ids,
+                                    const StorageView& lengths,
+                                    const std::vector<std::vector<size_t>>& token_type_ids) {
       PROFILE("SequenceEncoderReplica::forward");
       const auto& model = *this->model();
       const auto device = model.device();
@@ -342,7 +347,9 @@ namespace ctranslate2 {
     }
 
     EncoderForwardOutput
-    EncoderReplica::forward_impl(const StorageView& ids, const StorageView& lengths, const StorageView& token_type_ids) {
+    EncoderReplica::forward_impl(const StorageView& ids,
+                                 const StorageView& lengths,
+                                 const StorageView& token_type_ids) {
       if (ids.rank() != 2)
         throw std::invalid_argument("Expected input ids to have 2 dimensions, but got "
                                     + std::to_string(ids.rank())

--- a/src/models/language_model.cc
+++ b/src/models/language_model.cc
@@ -298,30 +298,49 @@ namespace ctranslate2 {
 
     EncoderForwardOutput
     SequenceEncoderReplica::forward(const std::vector<std::vector<std::string>>& tokens) {
+      std::vector<std::vector<size_t>> token_type_ids;
+      return forward(tokens, token_type_ids);
+    }
+    
+    EncoderForwardOutput
+    SequenceEncoderReplica::forward(const std::vector<std::vector<std::string>>& tokens, const std::vector<std::vector<size_t>>& token_type_ids) {
       const auto& vocabulary = _model->get_vocabulary();
-      return forward(vocabulary.to_ids(tokens));
+      return forward(vocabulary.to_ids(tokens), token_type_ids);
     }
 
     EncoderForwardOutput
     SequenceEncoderReplica::forward(const std::vector<std::vector<size_t>>& ids) {
+      std::vector<std::vector<size_t>> token_type_ids;
+      return forward(ids, token_type_ids);
+    }
+    
+    EncoderForwardOutput
+    SequenceEncoderReplica::forward(const std::vector<std::vector<size_t>>& ids, const std::vector<std::vector<size_t>>& token_type_ids) {
       StorageView lengths;
       StorageView input_ids = layers::make_sequence_inputs(ids, Device::CPU, 1, &lengths);
-      return forward(input_ids, lengths);
+      return forward(input_ids, lengths, token_type_ids);
     }
 
     EncoderForwardOutput
     SequenceEncoderReplica::forward(const StorageView& ids, const StorageView& lengths) {
+      std::vector<std::vector<size_t>> token_type_ids;
+      return forward(ids, lengths, token_type_ids);
+    }
+    
+    EncoderForwardOutput
+    SequenceEncoderReplica::forward(const StorageView& ids, const StorageView& lengths, const std::vector<std::vector<size_t>>& token_type_ids) {
       PROFILE("SequenceEncoderReplica::forward");
       const auto& model = *this->model();
       const auto device = model.device();
       const auto scoped_device_setter = model.get_scoped_device_setter();
 
+      StorageView input_token_type_ids = layers::make_sequence_inputs(token_type_ids, Device::CPU, 1, nullptr);
       EncoderForwardOutput output;
 
       if (ids.device() != device)
-        output = forward_impl(ids.to(device), lengths.to(device));
+        output = forward_impl(ids.to(device), lengths.to(device), input_token_type_ids.to(device));
       else
-        output = forward_impl(ids, lengths);
+        output = forward_impl(ids, lengths, input_token_type_ids);
 
       // Ensure all operations are finished before returning the output.
       synchronize_stream(device);
@@ -342,7 +361,7 @@ namespace ctranslate2 {
     }
 
     EncoderForwardOutput
-    EncoderReplica::forward_impl(const StorageView& ids, const StorageView& lengths) {
+    EncoderReplica::forward_impl(const StorageView& ids, const StorageView& lengths, const StorageView& token_type_ids) {
       if (ids.rank() != 2)
         throw std::invalid_argument("Expected input ids to have 2 dimensions, but got "
                                     + std::to_string(ids.rank())
@@ -360,9 +379,13 @@ namespace ctranslate2 {
       std::vector<StorageView> inputs{ids};
 
       if (_encoder->num_input_features() > 1) {
-        StorageView token_type_ids(ids.shape(), ids.dtype(), device);
-        token_type_ids.zero();
-        inputs.emplace_back(std::move(token_type_ids));
+        if (token_type_ids.empty()) {
+          StorageView placeholder_type_ids(ids.shape(), ids.dtype(), device);
+          placeholder_type_ids.zero();
+          inputs.emplace_back(std::move(placeholder_type_ids));
+        } else {
+          inputs.emplace_back(std::move(token_type_ids));
+        }
       }
 
       StorageView last_hidden_state(dtype, device);


### PR DESCRIPTION
# Description

This PR adds an optional token_type_ids argument to Encoder.translate_batch, to facilitate BERT models with multiple input features (sentence-sentence entailment, context and question answering etc.). The token_type_ids vector is optional at the pybind level, and overloaded into the future_batch_async functions, with all previous endpoints preserved for backwards compatibility.

Closes #1383.

```
...
output = ct2_model.forward_batch(input_ids, token_type_ids=token_type_ids)
pooler_output = output.pooler_output
pooler_output = np.array(pooler_output)
pooler_output = torch.as_tensor(pooler_output)
ct_logits = classifier(pooler_output)
```

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Docs update
- [ ] Refactor

# Testing
The code passes all C++ and python tests. For validation, the modified encoder was tested with both a bert-base-uncased and fine tuned bert-tiny for inference on the train split of the MRPC dataset (sentence pairs), and all output logits verified equal (<10e-12) to the output of a hugging face loaded model at full precision, when passing token_type_ids to both. When quantized, the logits are no longer equal, but the token_type_ids demonstrably improve the classifier accuracy. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
