### PR TITLE
Remove epsilon in the Softmax CPU kernel for consistency

### DIFF
--- a/src/cpu/kernels.cc
+++ b/src/cpu/kernels.cc
@@ -393,8 +393,7 @@ namespace ctranslate2 {
                              float* output,
                              dim_t batch_size,
                              dim_t depth,
-                             bool log,
-                             float epsilon) {
+                             bool log) {
       using VecType = Vec<float, TARGET_ISA>;
 
       parallel_for(0, batch_size, 1, [&](dim_t begin, dim_t end) {
@@ -441,7 +440,7 @@ namespace ctranslate2 {
           } else {
             vectorized_unary_transform<TARGET_ISA>(x, y, size, vec_exp_func);
             const auto exp_sum = reduce_sum<TARGET_ISA>(y, size);
-            mul<TARGET_ISA>(static_cast<float>(1) / (exp_sum + epsilon), y, y, size);
+            mul<TARGET_ISA>(static_cast<float>(1) / exp_sum, y, y, size);
           }
         }
       });

--- a/src/cpu/kernels.h
+++ b/src/cpu/kernels.h
@@ -68,8 +68,7 @@ namespace ctranslate2 {
                  float* output,
                  dim_t batch_size,
                  dim_t depth,
-                 bool log,
-                 float epsilon);
+                 bool log);
 
     template <CpuIsa ISA>
     void layer_norm(const float* input,

--- a/src/ops/softmax_cpu.cc
+++ b/src/ops/softmax_cpu.cc
@@ -9,7 +9,6 @@ namespace ctranslate2 {
     void SoftMax::compute(const StorageView& input,
                           const StorageView* lengths,
                           StorageView& output) const {
-      constexpr float epsilon = 0.000001f;
       const dim_t depth = input.dim(-1);
       const dim_t batch_size = input.size() / depth;
 
@@ -18,8 +17,7 @@ namespace ctranslate2 {
                                           output.data<T>(),
                                           batch_size,
                                           depth,
-                                          _log,
-                                          epsilon)));
+                                          _log)));
     }
 
 #define DECLARE_IMPL(T)                                                 \


### PR DESCRIPTION
The epsilon is not used in the other Softmax kernels.