### PR TITLE
update install documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -65,7 +65,8 @@ Compiling the library requires a compiler supporting C++17 and CMake 3.15 or gre
 mkdir build && cd build
 cmake ..
 make -j4
-make install
+sudo make install
+sudo ldconfig
 ```
 
 By default, the library is compiled with the [Intel MKL](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) backend which should be installed separately. See the {ref}`installation:build options` to select or add another backend.


### PR DESCRIPTION
After build and install from source, I got following problems. `ldconfig` fix it.

I think this should fix 

```
File ~/.local/lib/python3.11/site-packages/ctranslate2/__init__.py:21
     18         ctypes.CDLL(library)
     20 try:
---> 21     from ctranslate2._ext import (
     22         AsyncGenerationResult,
     23         AsyncScoringResult,
     24         AsyncTranslationResult,
     25         DataType,
     26         Encoder,
     27         EncoderForwardOutput,
     28         ExecutionStats,
     29         GenerationResult,
     30         GenerationStepResult,
     31         Generator,
     32         ScoringResult,
     33         StorageView,
     34         TranslationResult,
     35         Translator,
     36         contains_model,
     37         get_cuda_device_count,
     38         get_supported_compute_types,
     39         set_random_seed,
     40     )
     41     from ctranslate2.extensions import register_extensions
     42     from ctranslate2.logging import get_log_level, set_log_level

ImportError: libctranslate2.so.3: cannot open shared object file: No such file or directory
```
And ldd got following
```
ldd ctranslate2/_ext.cpython-311-x86_64-linux-gnu.so
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
        linux-vdso.so.1 (0x00007fff777fb000)
        libctranslate2.so.3 => not found
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f1361169000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f1361149000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f1360f21000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f136147f000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f1360e3a000)

```