### PR TITLE
Added converter for MixFormerSequentialForCausalLM

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -109,14 +109,7 @@ class TransformersConverter(Converter):
                     % (config_name, ", ".join(sorted(_MODEL_LOADERS.keys())))
                 )
 
-            model_class = getattr(transformers, loader.architecture_name, None)
-            # load model class from hf if available in auto_map
-            if not model_class and hasattr(config, "auto_map"):
-                cls_name = next(
-                    filter(lambda k: k.startswith("AutoModel"), config.auto_map.keys()),
-                    None,
-                )
-                model_class = getattr(transformers, cls_name)
+            model_class = getattr(transformers, loader.architecture_name)
             tokenizer_class = transformers.AutoTokenizer
 
             kwargs = {
@@ -1304,7 +1297,7 @@ class LlamaLoader(ModelLoader):
 class MixFormerSequentialLoader(ModelLoader):
     @property
     def architecture_name(self):
-        return "MixFormerSequentialForCausalLM"
+        return "AutoModelForCausalLM"
 
     def get_model_spec(self, model):
         spec = transformer_spec.TransformerDecoderModelSpec.from_config(

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -111,8 +111,11 @@ class TransformersConverter(Converter):
 
             model_class = getattr(transformers, loader.architecture_name, None)
             # load model class from hf if available in auto_map
-            if not model_class and hasattr(config, 'auto_map'):
-                cls_name = next(filter(lambda k: k.startswith('AutoModel'), config.auto_map.keys()), None)
+            if not model_class and hasattr(config, "auto_map"):
+                cls_name = next(
+                    filter(lambda k: k.startswith("AutoModel"), config.auto_map.keys()),
+                    None,
+                )
                 model_class = getattr(transformers, cls_name)
             tokenizer_class = transformers.AutoTokenizer
 
@@ -1340,7 +1343,7 @@ class MixFormerSequentialLoader(ModelLoader):
         self.set_embeddings(spec.embeddings, module[0].wte)
         self.set_layer_norm(spec.layer_norm, module[-1].ln)
 
-        for layer_spec, layer in zip(spec.layer, module[1: -1]):
+        for layer_spec, layer in zip(spec.layer, module[1:-1]):
             self.set_layer_norm(layer_spec.shared_layer_norm, layer.ln)
             self.set_linear(layer_spec.self_attention.linear[0], layer.mixer.Wqkv)
             self.set_linear(layer_spec.self_attention.linear[1], layer.mixer.out_proj)

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -1306,6 +1306,7 @@ class MixFormerSequentialLoader(ModelLoader):
             pre_norm=True,
             activation=_SUPPORTED_ACTIVATIONS[model.config.activation_function],
             rotary_dim=model.config.rotary_dim,
+            rotary_interleave=False,
             parallel_residual=True,
             shared_layer_norm=True,
         )


### PR DESCRIPTION
This PR adds support for MixFormerSequentialForCausalLM architecture by introducing MixFormerSequentialLoader. This will enable conversion of phi-1 and phi-1.5 model weights using `ct2-transformers-converter`.

I converted phi-1.5 model weights using the following command,

```sh
ct2-transformers-converter --model microsoft/phi-1_5 --output_dir ct2fast-phi-1_5 --trust_remote_code --force --quantization int8
```

And this is the code I used for testing to make sure the conversion happened correctly.

```py
import ctranslate2
from transformers import AutoTokenizer, AutoModelForCausalLM
from timeit import default_timer as timer

model_ct2 = ctranslate2.Generator(
    "./ct2fast-phi-1_5",
    device="cpu",
    compute_type="int8",
)

name_hf = 'microsoft/phi-1_5'
model_hf = AutoModelForCausalLM.from_pretrained(name_hf, trust_remote_code=True)
tokenizer =  AutoTokenizer.from_pretrained(name_hf, device="cpu", trust_remote_code=True)

def inference_ct2(text: str):
    tokens_in = tokenizer.convert_ids_to_tokens(tokenizer.encode(text))
    s = timer()
    tokens_out = model_ct2.generate_batch([tokens_in], max_length=32, min_length=32)
    total_ct2 = timer() - s
    text_out = tokenizer.decode(tokens_out[0].sequences_ids[0])
    return total_ct2, text_out

def inference_hf(text: str):
    inputs = tokenizer.encode(text, return_tensors="pt")
    s = timer()
    outputs = model_hf.generate(inputs, max_length=32, min_length=32, pad_token_id=50256)
    total_hf = timer() - s
    text_out2 = tokenizer.batch_decode(outputs)[0]
    return total_hf, text_out2

text = "# this code print('hello', name) in python3 \n\ndef hello_name(name"

_, _ = inference_ct2("warm up")
_, _ = inference_hf("warm up")

total_ct2, text_out_ct2 = inference_ct2(text)
total_hf, text_out_hf = inference_hf(text)

print("hf\n",text_out_hf, "\nct2\n",text_out_ct2)
print(f"time for ct2={total_ct2} time for hf={total_hf}")
assert text_out_ct2[:len(text_out_hf)] == text_out_hf # same, ct2 generates +1 token compared to HF
print("done")
```

Which results in the following output,

```
hf
 # this code print('hello', name) in python3 

def hello_name(name):
    print('hello', name)

 
ct2
 # this code print('hello', name) in python3 

def hello_name(name):
    print('hello', name)

def
time for ct2=1.3792399680000926 time for hf=1.493508115000168
done
```

Closes #1473
Closes TabbyML/tabby#435
/claim TabbyML/tabby#435