### PR TITLE
Add setuptools dependency to setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -108,6 +108,7 @@ setup(
     ext_modules=[ctranslate2_module],
     python_requires=">=3.8",
     install_requires=[
+        "setuptools",
         "numpy",
         "pyyaml>=5.3,<7",
     ],


### PR DESCRIPTION
I experienced the following error when attempting to use CTranslate2 on Windows using Python 3.12:

```
Traceback (most recent call last):
   ...
  File "C:\hostedtoolcache\windows\Python\3.12.0\x64\Lib\site-packages\ctranslate2\__init__.py", line 8, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

This error is due to setuptools not being available. Previously, setuptools was bundled automatically in nearly all Python environments, but [3.12](https://docs.python.org/3/whatsnew/3.12.html) begins to change this (see [gh-95299](https://github.com/python/cpython/issues/95299)).

This change adds setuptools as a dependency in setup.py. This ensures that it will be present in all environments.