### PR TITLE
Fix iomp5 linking with latest Intel OpenAPI on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ if(NOT OPENMP_RUNTIME STREQUAL "NONE")
       ${INTEL_ROOT}/oneAPI/compiler/latest/windows/compiler/lib/intel64_win
       ${INTEL_ROOT}/oneapi/compiler/latest/linux/compiler/lib/intel64_lin
       ${INTEL_ROOT}/oneapi/compiler/latest/mac/compiler/lib
+      ${INTEL_ROOT}/oneapi/compiler/latest/lib
       )
     if(IOMP5_LIBRARY)
       list(APPEND LIBRARIES ${IOMP5_LIBRARY})


### PR DESCRIPTION
Trying to build from source using latest Inter opeAPI Base Toolkit on Ubuntu 20.04 (installed via `sudo apt install intel-basekit`), I encountered a CMake error that `libiomp5` cannot be found. It turned out that the necessary path to library was not present in the corresponding PATHS section inside `CMakeLists.txt`.

Probably the package layout has changed recently, or the apt package for Ubuntu/Debian had different layout from the start. In any case, this small fix solves the problem.