### PR TITLE
Better HF-to-CT2 conversion for Whisper model

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -916,11 +916,14 @@ class WhisperLoader(BartLoader):
             config.suppress_ids = gen_config.suppress_tokens
             config.suppress_ids_begin = gen_config.begin_suppress_tokens
             config.alignment_heads = gen_config.alignment_heads
-            config.lang_ids = sorted(gen_config.lang_to_id.values())
+            if hasattr(gen_config, "lang_to_id"):
+                config.lang_ids = sorted(gen_config.lang_to_id.values())
         else:
             config.suppress_ids = model.config.suppress_tokens
             config.suppress_ids_begin = model.config.begin_suppress_tokens
             config.alignment_heads = _WHISPER_ALIGNMENT_HEADS.get(model.name_or_path)
+
+        if getattr(config, "lang_ids", None) is None:
             config.lang_ids = self._get_lang_ids_from_tokenizer(tokenizer)
 
         if config.alignment_heads is None:

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -890,11 +890,36 @@ class WhisperLoader(BartLoader):
         return spec
 
     def set_config(self, config, model, tokenizer):
-        config.suppress_ids = model.config.suppress_tokens
-        config.suppress_ids_begin = model.config.begin_suppress_tokens
-        config.lang_ids = tokenizer.additional_special_tokens_ids[2:-6]
+        gen_config = getattr(model, "generation_config", None)
 
-        config.alignment_heads = _WHISPER_ALIGNMENT_HEADS.get(model.name_or_path)
+        if gen_config is not None:
+            config.suppress_ids = gen_config.suppress_tokens
+            config.suppress_ids_begin = gen_config.begin_suppress_tokens
+            config.alignment_heads = gen_config.alignment_heads
+        else:
+            config.suppress_ids = model.config.suppress_tokens
+            config.suppress_ids_begin = model.config.begin_suppress_tokens
+            config.alignment_heads = _WHISPER_ALIGNMENT_HEADS.get(model.name_or_path)
+
+        non_lang_special_tokens = [
+            "<|endoftext|>",
+            "<|startoftranscript|>",
+            "<|translate|>",
+            "<|transcribe|>",
+            "<|startoflm|>",
+            "<|startofprev|>",
+            "<|nocaptions|>",
+            "<|notimestamps|>",
+        ]
+        config.lang_ids = [
+            token_id
+            for token_id, token in zip(
+                tokenizer.additional_special_tokens_ids,
+                tokenizer.additional_special_tokens,
+            )
+            if token not in non_lang_special_tokens
+        ]
+
         if config.alignment_heads is None:
             # Use the last half layers for alignment by default.
             num_layers = model.config.decoder_layers


### PR DESCRIPTION
On attempt to convert Whisper-v3 model from HF to ct2 format I encountered two issues:

- Due to the difference in the `additional_tokens_ids` lists resulting from the tokenizer checkpoints in `large-v3` and previous versions, the first language token `<|en|>` was not included in the `lang_ids` list, which resulted in the inability of the model to transcribe English text - every such transcription became a translation to some other language;
- The converter ignored the information contained in `generation_config.json` of the HF checkpoint, which resulted in auto-generated alignment heads and non-present set of suppressed tokens.

Those issues are fixed in this PR. The logic of selecting language IDs got more complicated, but less prone to bugs stemming from any future updates of HF checkpoints.