### PR TITLE
fixed decoder_start_token_id for T5

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -1024,7 +1024,9 @@ class T5Loader(ModelLoader):
         config.bos_token = tokenizer.pad_token
         config.eos_token = tokenizer.eos_token
         config.unk_token = tokenizer.unk_token
-        config.decoder_start_token = tokenizer.pad_token
+        config.decoder_start_token = tokenizer.convert_ids_to_tokens(
+            model.config.decoder_start_token_id
+        )
 
     def set_stack(self, spec, module, is_decoder=False):
         self.set_layer_norm(spec.layer_norm, module.final_layer_norm)

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -1024,9 +1024,12 @@ class T5Loader(ModelLoader):
         config.bos_token = tokenizer.pad_token
         config.eos_token = tokenizer.eos_token
         config.unk_token = tokenizer.unk_token
-        config.decoder_start_token = tokenizer.convert_ids_to_tokens(
-            model.config.decoder_start_token_id
-        )
+        if hasattr(model.config, 'decoder_start_token_id'):
+            config.decoder_start_token = tokenizer.convert_ids_to_tokens(
+                model.config.decoder_start_token_id
+            )
+        else:
+            config.decoder_start_token = tokenizer.pad_token
 
     def set_stack(self, spec, module, is_decoder=False):
         self.set_layer_norm(spec.layer_norm, module.final_layer_norm)

--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -1024,7 +1024,7 @@ class T5Loader(ModelLoader):
         config.bos_token = tokenizer.pad_token
         config.eos_token = tokenizer.eos_token
         config.unk_token = tokenizer.unk_token
-        if hasattr(model.config, 'decoder_start_token_id'):
+        if hasattr(model.config, "decoder_start_token_id"):
             config.decoder_start_token = tokenizer.convert_ids_to_tokens(
                 model.config.decoder_start_token_id
             )


### PR DESCRIPTION
in most t5 models `pad_token` is equal to `decoder_start_token`, so this wasn't a problem. but MADLAD-400 uses different `decoder_start_token` and `pad_tokens` and doesn't work. this fixes the problem