### PR TITLE
check alignment_heads in gen config before using

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -915,7 +915,8 @@ class WhisperLoader(BartLoader):
         if gen_config is not None:
             config.suppress_ids = gen_config.suppress_tokens
             config.suppress_ids_begin = gen_config.begin_suppress_tokens
-            config.alignment_heads = gen_config.alignment_heads
+            if hasattr(gen_config, "alignment_heads"):
+                config.alignment_heads = gen_config.alignment_heads
             if hasattr(gen_config, "lang_to_id"):
                 config.lang_ids = sorted(gen_config.lang_to_id.values())
         else:


### PR DESCRIPTION
When convert model distil-whisper, there is not the ``alignment _heads`` in the ``generation_config.json``. The conversion stops unexpectedly while getting missing attribute.