### PR TITLE
fix forward batch

### DIFF
--- a/src/layers/attention.cc
+++ b/src/layers/attention.cc
@@ -572,7 +572,7 @@ namespace ctranslate2 {
                             _alibi,
                             position_bias);
 
-      if (prefilling && cached_keys->shape()[2] > _sliding_window) {
+      if (prefilling && cached_keys && cached_keys->shape()[2] > _sliding_window) {
         // set only last sliding_window tokens to cached_keys and cached_values after computing attention
         const ops::Slide slide_op(2, cached_keys->shape()[2] - _sliding_window, _sliding_window);
         StorageView tmp(dtype, device);

--- a/src/layers/transformer.cc
+++ b/src/layers/transformer.cc
@@ -581,6 +581,7 @@ namespace ctranslate2 {
             layer_attention = std::make_unique<StorageView>(dtype, device);
 
           dim_t offset = _sliding_window * i + step;
+          offset = offset < 0 ? 0 : offset;
           if (i > 0) {
             auto max_tokens = _sliding_window + layer_in_chunk.dim(1);
             StorageView tmp_lengths = StorageView(Shape{layer_in_chunk.dim(0)}, int32_t(max_tokens), device);


### PR DESCRIPTION
A bug generated after the dev on Mistral and the optimization in the rotary embedding. In case of forward batch, step initialized is -1 and there is any cache used. It cause the bad calculation for the offset in the rotary embedding and unexpected usage of cache.