### PR TITLE
directly set device index the first time to avoid initializing unused gpu

### DIFF
--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -423,7 +423,7 @@ namespace ctranslate2 {
 
       {
         // Check that the device and device index are valid.
-        ScopedDeviceSetter(device, device_index);
+        set_device_index(device, device_index);
       }
 
       std::unique_ptr<std::istream> model_file_ptr = model_reader.get_required_file(binary_file,


### PR DESCRIPTION
reported  #1628