### PR TITLE
Fix to enter BestSampler route when temperature is 0.

### DIFF
--- a/src/decoding.cc
+++ b/src/decoding.cc
@@ -1007,7 +1007,7 @@ namespace ctranslate2 {
 
   static std::unique_ptr<const Sampler>
   make_sampler(const DecodingOptions& options) {
-    if (options.sampling_topk == 1)
+    if (options.sampling_topk == 1 || options.sampling_temperature == 0.0)
       return std::make_unique<BestSampler>();
     else
       return std::make_unique<RandomSampler>(options.sampling_topk,


### PR DESCRIPTION
This pull request addresses the issue raised in #1511 where specifying 0 for temperature resutls in division by zero. To resolv this issue, the code has been modified to enter to the "BestSampler" route when the temperature is 0, which seems to be a natural course of action. Similar handling can be observed in llama.cpp as well.
https://github.com/ggerganov/llama.cpp/blob/b2636/common/sampling.cpp#L189-L191

Please review and merge this pull request. Thank you!