### PR TITLE
Implement python bindings for profiler

### DIFF
--- a/python/cpp/module.cc
+++ b/python/cpp/module.cc
@@ -76,6 +76,7 @@ PYBIND11_MODULE(_ext, m)
   m.def("set_random_seed", &ctranslate2::set_random_seed, py::arg("seed"),
         "Sets the seed of random generators.");
 
+  ctranslate2::python::register_profiling(m);
   ctranslate2::python::register_logging(m);
   ctranslate2::python::register_storage_view(m);
   ctranslate2::python::register_translation_stats(m);

--- a/python/cpp/module.h
+++ b/python/cpp/module.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
+#include <pybind11/chrono.h>
 
 namespace py = pybind11;
 
 namespace ctranslate2 {
   namespace python {
 
+    void register_profiling(py::module& m);
     void register_encoder(py::module& m);
     void register_generation_result(py::module& m);
     void register_generator(py::module& m);

--- a/python/cpp/profiling.cc
+++ b/python/cpp/profiling.cc
@@ -1,0 +1,19 @@
+#include "module.h"
+#include <sstream>
+#include <ctranslate2/profiler.h>
+
+namespace ctranslate2 {
+  namespace python {
+
+    void register_profiling(py::module& m) {
+
+      m.def("init_profiling", &ctranslate2::init_profiling);
+      m.def("dump_profiling", []() {
+        std::ostringstream oss;
+        ctranslate2::dump_profiling(oss);
+        return oss.str();
+	});
+	}
+
+  }
+}

--- a/python/ctranslate2/__init__.py
+++ b/python/ctranslate2/__init__.py
@@ -42,6 +42,7 @@ try:
     )
     from ctranslate2.extensions import register_extensions
     from ctranslate2.logging import get_log_level, set_log_level
+    from ctranslate2.profiling import init_profiler, dump_profiler
 
     register_extensions()
     del register_extensions

--- a/python/ctranslate2/__init__.py
+++ b/python/ctranslate2/__init__.py
@@ -42,7 +42,7 @@ try:
     )
     from ctranslate2.extensions import register_extensions
     from ctranslate2.logging import get_log_level, set_log_level
-    from ctranslate2.profiling import init_profiler, dump_profiler
+    from ctranslate2.profiling import dump_profiler, init_profiler
 
     register_extensions()
     del register_extensions

--- a/python/ctranslate2/profiling.py
+++ b/python/ctranslate2/profiling.py
@@ -1,7 +1,9 @@
-from ctranslate2 import _ext, Device
 import sys
 
-def init_profiler(device = Device.cpu, num_threads = 1):
+from ctranslate2 import Device, _ext
+
+
+def init_profiler(device=Device.cpu, num_threads=1):
     _ext.init_profiling(device, num_threads)
 
 

--- a/python/ctranslate2/profiling.py
+++ b/python/ctranslate2/profiling.py
@@ -1,0 +1,10 @@
+from ctranslate2 import _ext, Device
+import sys
+
+def init_profiler(device = Device.cpu, num_threads = 1):
+    _ext.init_profiling(device, num_threads)
+
+
+def dump_profiler():
+    profiling_data = _ext.dump_profiling()
+    sys.stdout.write(profiling_data)


### PR DESCRIPTION

## Overview
Related to: https://github.com/OpenNMT/CTranslate2/issues/1736 ,will also resolve: https://github.com/OpenNMT/CTranslate2/issues/1734

Expose profiler functionality - `ctranslate2::init_profiling()` & `ctranslate2::dump_profiling()` to python level. 


### Example usage: 

```python
import ctranslate2

# Initialize the profiler on CPU
ctranslate2.init_profiler(device = ctranslate2.Device.cpu, 1)

Load model, generate/translate...

# Dump profiling to stdout
ctranslate2.dump_profiler()
```
