### PR TITLE
Bart models missing "embed_scale"

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -356,7 +356,7 @@ class BartLoader(ModelLoader):
         self.set_linear(spec.linear[-1], attention.out_proj)
 
     def set_common_layers(self, spec, module):
-        spec.scale_embeddings = module.embed_scale
+        spec.scale_embeddings = getattr(module, 'embed_scale', False)
         self.set_position_encodings(spec.position_encodings, module.embed_positions)
         self.set_embeddings(
             (


### PR DESCRIPTION
There appears to be an issue trying to convert BART models. Even using the example in the documentation: `ct2-transformers-converter --model facebook/bart-large-cnn --output_dir bart-large-cnn`

Gives an error: `'module' does not have attribute 'embed_scale'`

This should fix the issue.