### PR TITLE
Shallow Contextual Biasing for Whisper

### DIFF
--- a/docs/decoding.md
+++ b/docs/decoding.md
@@ -79,7 +79,7 @@ The prefix effectively changes the target context and the rest of the translatio
 
 > Dieses Projekt ist auf das effiziente **Servieren** von Standard-Übersetzungsmodellen ausgerichtet, ist aber auch ein Ort für Experimente rund um Modellkompression und Inferenzbeschleunigung.
 
-## Biased decoding
+## Biased prefix decoding for translation
 
 Instead of using {ref}`decoding:autocompletion` to force a translation to start with a `target_prefix` argument, we can "bias" a translation towards a prefix by setting `prefix_bias_beta` to a value in (0, 1).  The higher `prefix_bias_beta` is, the stronger the bias. A translation can diverge from a prefix when `prefix_bias_beta` is low and the translator is confident in decoding tokens that are different from the prefix's tokens.  See [section 4.2](https://arxiv.org/abs/1912.03393) for more details on the biasing algorithm.
 
@@ -112,6 +112,10 @@ print(detokenize(results[0].hypotheses[0]))
 Lowering the bias by setting `prefix_bias_beta=0.1` results in a divergence in the prefix from `das` to `die`:
 
 > Dieses Projekt ist auf **die** effiziente Bedienung von Standard-Übersetzungsmodellen ausgerichtet, ist aber auch ein Ort für Experimente rund um Modellkompression und Inferenzbeschleunigung.
+
+## Shallow biasing for contextual ASR
+
+Setting `sequence_bias` with tuples of `(sequence, biasing_multiplier)` for Whisper models to boost or diminute the hypotheses hitting words in the biasing list during beam search. See [Ssection 3.3](https://aclanthology.org/2024.lrec-main.328.pdf) for the general concept. See [HuggingFace implementation](https://huggingface.co/docs/transformers/en/internal/generation_utils#transformers.SequenceBiasLogitsProcessor) of an additive version.
 
 ## Alternatives at a position
 

--- a/include/ctranslate2/decoding.h
+++ b/include/ctranslate2/decoding.h
@@ -161,6 +161,7 @@ namespace ctranslate2 {
     std::vector<size_t> disable_ids;
     std::vector<size_t> disable_ids_begin;
     std::vector<std::vector<size_t>> disable_sequences;
+    std::vector<std::pair<std::vector<size_t>, float>> sequence_bias;
     std::vector<std::shared_ptr<LogitsProcessor>> logits_processors;
     std::function<bool(DecodingStepResult)> callback = nullptr;
   };

--- a/include/ctranslate2/models/whisper.h
+++ b/include/ctranslate2/models/whisper.h
@@ -56,6 +56,9 @@ namespace ctranslate2 {
       // List of token IDs to suppress.
       // -1 will suppress a default set of symbols as defined in the model config.json file.
       std::vector<int> suppress_tokens = {-1};
+
+      // List of sequences and a bias factor to contextualize decoding.
+      std::vector<std::pair<std::vector<size_t>, float>> sequence_bias = {};
     };
 
     struct WhisperGenerationResult {

--- a/include/ctranslate2/primitives.h
+++ b/include/ctranslate2/primitives.h
@@ -19,6 +19,8 @@ namespace ctranslate2 {
     static void strided_fill(T* x, T a, dim_t inc_x, dim_t size);
     template <typename T>
     static void indexed_fill(T* x, T a, const int32_t* indices, dim_t num_indices);
+    template <typename T>
+    static void indexed_pointwise_multiply(T* x,  const T* values, const int32_t* indices, dim_t num_indices);
 
     template <typename T>
     static void copy(const T* x, T* y, dim_t size);

--- a/python/cpp/whisper.cc
+++ b/python/cpp/whisper.cc
@@ -45,6 +45,7 @@ namespace ctranslate2 {
                size_t max_initial_timestamp_index,
                bool suppress_blank,
                const std::optional<std::vector<int>>& suppress_tokens,
+               const std::optional<std::vector<std::pair<std::vector<size_t>, float>>>& sequence_bias,
                size_t sampling_topk,
                float sampling_temperature) {
         std::vector<std::future<models::WhisperGenerationResult>> futures;
@@ -69,6 +70,10 @@ namespace ctranslate2 {
           options.suppress_tokens = suppress_tokens.value();
         else
           options.suppress_tokens.clear();
+        if (sequence_bias)
+          options.sequence_bias = sequence_bias.value();
+        else
+          options.sequence_bias.clear();
         std::shared_lock lock(_mutex);
         assert_model_is_ready();
 
@@ -254,6 +259,7 @@ namespace ctranslate2 {
              py::arg("max_initial_timestamp_index")=50,
              py::arg("suppress_blank")=true,
              py::arg("suppress_tokens")=std::vector<int>{-1},
+             py::arg("sequence_bias")=std::vector<std::pair<int, float>>{},
              py::arg("sampling_topk")=1,
              py::arg("sampling_temperature")=1,
              py::call_guard<py::gil_scoped_release>(),
@@ -286,6 +292,8 @@ namespace ctranslate2 {
                    suppress_blank: Suppress blank outputs at the beginning of the sampling.
                    suppress_tokens: List of token IDs to suppress. -1 will suppress a default set
                      of symbols as defined in the model ``config.json`` file.
+                   sequence_bias: List of pairs of sequences and a biasing factor to boost or surpass
+                     certain sequences.
                    sampling_topk: Randomly sample predictions from the top K candidates.
                    sampling_temperature: Sampling temperature to generate more random samples.
 

--- a/python/tests/test_transformers.py
+++ b/python/tests/test_transformers.py
@@ -832,6 +832,146 @@ class TestWhisper:
             transcription = processor.decode(token_ids)
             assert transcription == expected_transcription
 
+
+    @test_utils.only_on_linux
+    @test_utils.on_available_devices
+    @pytest.mark.parametrize(
+        "model_name,prompts,expected_transcriptions,expected_no_speech_probs",
+        [
+            (
+                "openai/whisper-tiny",
+                [
+                    [
+                        "<|startoftranscript|>",
+                        "<|en|>",
+                        "<|transcribe|>",
+                        "<|notimestamps|>",
+                    ],
+                    [
+                        "<|startoftranscript|>",
+                        "<|en|>",
+                        "<|transcribe|>",
+                        "<|notimestamps|>",
+                        "ĠAnd",
+                        "Ġthus",
+                        "Ġmy",
+                    ],
+                ],
+                [
+                    " Mr. Quiltre is the apostle of the middle classes and we are glad"
+                    " to welcome his gospel.",
+                    " And thus my fellow Americans ask not what your country can do for you,"
+                    " ask what you can do for your country.",
+                ],
+                [
+                    pytest.approx(0.0022832120303064585, abs=1e-4),
+                    pytest.approx(0.06885894387960434, abs=1e-3),
+                ],
+            ),
+            (
+                "openai/whisper-tiny",
+                [
+                    ["<|startoftranscript|>", "<|en|>", "<|transcribe|>"],
+                    ["<|startoftranscript|>", "<|en|>", "<|transcribe|>"],
+                ],
+                [
+                    " Mr. Quiltre is the apostle of the middle classes and we are glad"
+                    " to welcome his gospel.",
+                    " And so, my fellow Americans, ask not what your country can do for you,"
+                    " ask what you can do for your country.",
+                ],
+                [
+                    pytest.approx(0.0022832120303064585, abs=1e-4),
+                    pytest.approx(0.06885894387960434, abs=1e-3),
+                ],
+            )
+        ],
+    )
+    def test_transformers_contextually_biased_whisper(
+        self,
+        tmp_dir,
+        device,
+        model_name,
+        prompts,
+        expected_transcriptions,
+        expected_no_speech_probs,
+    ):
+        import transformers
+
+        converter = ctranslate2.converters.TransformersConverter(model_name)
+        output_dir = str(tmp_dir.join("ctranslate2_model"))
+        output_dir = converter.convert(output_dir)
+        print(os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "..", "..", "tests", "data"
+        ))
+        audio_paths = [
+            os.path.join(test_utils.get_data_dir(), "audio", "mr_quilter.npy"),
+            os.path.join(test_utils.get_data_dir(), "audio", "jfk.npy"),
+        ]
+        audio = list(map(np.load, audio_paths))
+
+        processor = transformers.WhisperProcessor.from_pretrained(model_name)
+
+        def _get_features(audio):
+            # Pad after computing the log-Mel spectrogram to match the openai/whisper behavior.
+            inputs = processor(audio, padding=False, sampling_rate=16000)
+            features = inputs.input_features[0]
+            features = np.pad(features, [(0, 0), (0, 3000 - features.shape[-1])])
+            return features
+
+        features = np.stack(list(map(_get_features, audio)))
+        features = ctranslate2.StorageView.from_array(features)
+
+        model = ctranslate2.models.Whisper(output_dir, device=device)
+
+        assert model.is_multilingual == (not model_name.endswith(".en"))
+
+        if model.is_multilingual:
+            for result in model.detect_language(features):
+                best_lang, best_prob = result[0]
+                assert best_lang == "<|en|>"
+                assert best_prob > 0.9
+        else:
+            with pytest.raises(RuntimeError, match="multilingual"):
+                model.detect_language(features)
+
+        #bias the first two generated words into ("Mr. Quiltre")
+        results = model.generate(
+            features,
+            prompts,
+            beam_size=2,
+            num_hypotheses=2,
+            return_no_speech_prob=True,
+            sequence_bias=[([2221, 13, 2326, 2352, 265], 1.3), ([2221, 13, 2326, 2352], 1.3), ([2221, 13, 2326], 1.3)],
+        )
+
+        timestamp_begin = (
+            processor.tokenizer.convert_tokens_to_ids("<|notimestamps|>") + 1
+        )
+
+        for prompt, result, expected_transcription, expected_no_speech_prob in zip(
+            prompts, results, expected_transcriptions, expected_no_speech_probs
+        ):
+            assert len(result.sequences_ids) == 2
+            assert result.no_speech_prob == expected_no_speech_prob
+
+            for tokens in result.sequences_ids:
+                if "<|notimestamps|>" in prompt:
+                    assert all(token < timestamp_begin for token in tokens)
+                else:
+                    assert tokens[0] >= timestamp_begin
+                    assert tokens[-1] >= timestamp_begin
+                    assert tokens[-1] > tokens[0]
+
+            token_ids = list(
+                filter(lambda token: token < timestamp_begin, result.sequences_ids[0])
+            )
+
+            transcription = processor.decode(token_ids)
+            print(transcription)
+            print(expected_transcription)
+            assert transcription == expected_transcription
+
     @test_utils.only_on_linux
     @test_utils.on_available_devices
     @pytest.mark.parametrize(
@@ -1008,86 +1148,6 @@ class TestWav2Vec2:
         ).input_values
 
         hidden_states = np.ascontiguousarray(input_values.unsqueeze(0))
-        hidden_states = ctranslate2.StorageView.from_array(hidden_states)
-        to_cpu = model.device == "cuda" and len(model.device_index) > 1
-        output = model.encode(hidden_states, to_cpu=to_cpu)
-        if model.device == "cuda":
-            logits = torch.as_tensor(output, device=model.device)[0]
-        else:
-            logits = torch.as_tensor(
-                np.array(output), dtype=torch.float32, device=model.device
-            )[0]
-
-        predicted_ids = torch.argmax(logits, dim=-1)
-        transcription = processor.decode(predicted_ids, output_word_offsets=True)
-        transcription = transcription[0].replace(processor.tokenizer.unk_token, "")
-
-        assert transcription == expected_transcription[0]
-
-
-class TestWav2Vec2Bert:
-    @classmethod
-    def teardown_class(cls):
-        clear_transformers_cache_in_ci()
-
-    @test_utils.only_on_linux
-    @test_utils.on_available_devices
-    @pytest.mark.parametrize(
-        "model_name,expected_transcription",
-        [
-            (
-                "hf-audio/wav2vec2-bert-CV16-en",
-                [
-                    "mr quilter is the apostle of the middle classes and"
-                    " we are glad to welcome his gospel"
-                ],
-            ),
-        ],
-    )
-    def test_transformers_wav2vec2bert(
-        self,
-        tmp_dir,
-        device,
-        model_name,
-        expected_transcription,
-    ):
-        import torch
-        import transformers
-
-        converter = ctranslate2.converters.TransformersConverter(
-            model_name, load_as_float16="int8"
-        )
-        output_dir = str(tmp_dir.join("ctranslate2_model"))
-        output_dir = converter.convert(output_dir)
-
-        w2v2_processor = transformers.Wav2Vec2BertProcessor.from_pretrained(model_name)
-        w2v2_processor.save_pretrained(output_dir + "/wav2vec2_processor")
-        processor = transformers.AutoProcessor.from_pretrained(
-            output_dir + "/wav2vec2_processor"
-        )
-
-        device = "cuda" if os.environ.get("CUDA_VISIBLE_DEVICES") else "cpu"
-        cpu_threads = int(os.environ.get("OMP_NUM_THREADS", 0))
-        model = ctranslate2.models.Wav2Vec2Bert(
-            output_dir,
-            device=device,
-            device_index=[0],
-            compute_type="int8",
-            intra_threads=cpu_threads,
-            inter_threads=1,
-        )
-
-        speech_array = np.load(
-            os.path.join(test_utils.get_data_dir(), "audio", "mr_quilter.npy")
-        )
-        input_values = processor(
-            [speech_array],
-            padding=True,
-            return_tensors="pt",
-            sampling_rate=16000,
-        ).input_features
-
-        hidden_states = np.ascontiguousarray(input_values)
         hidden_states = ctranslate2.StorageView.from_array(hidden_states)
         to_cpu = model.device == "cuda" and len(model.device_index) > 1
         output = model.encode(hidden_states, to_cpu=to_cpu)

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -13,7 +13,7 @@ def get_data_dir():
     )
 
     # Verify that downloaded files are present.
-    translit_model = os.path.join(data_dir, "models", "transliteration-aren-all")
+    translit_model = os.path.join(data_dir, "models", "v1", "aren-transliteration")
     if not os.path.isdir(translit_model):
         pytest.skip("Data files are not available")
 

--- a/src/cpu/primitives.cc
+++ b/src/cpu/primitives.cc
@@ -323,6 +323,15 @@ namespace ctranslate2 {
 
   template<>
   template<>
+  void primitives<Device::CPU>::sigmoid(const float* x, float* y, dim_t size) {
+    cpu::parallel_for(0, size, cpu::GRAIN_SIZE / 10,
+                      [x, y](dim_t begin, dim_t end) {
+                        CPU_ISA_DISPATCH((cpu::sigmoid<ISA>(x + begin, y + begin, end - begin)));
+                      });
+  }
+
+  template<>
+  template<>
   void primitives<Device::CPU>::swish(const float* x, float* y, dim_t size) {
     cpu::parallel_for(0, size, cpu::GRAIN_SIZE / 10,
                       [x, y](dim_t begin, dim_t end) {

--- a/src/cpu/primitives.cc
+++ b/src/cpu/primitives.cc
@@ -64,6 +64,14 @@ namespace ctranslate2 {
 
   template<>
   template <typename T>
+  void primitives<Device::CPU>::indexed_pointwise_multiply(T* x, const T* values, const int32_t* indices, dim_t num_indices) {
+    for (dim_t i = 0; i < num_indices; ++i) {
+      x[indices[i]] = x[indices[i]] * values[i];
+    }
+  }
+
+  template<>
+  template <typename T>
   void primitives<Device::CPU>::copy(const T* x, T* y, dim_t size) {
     std::copy(x, x + size, y);
   }
@@ -310,15 +318,6 @@ namespace ctranslate2 {
     cpu::parallel_for(0, size, /*grain_size=*/512,
                       [x, y](dim_t begin, dim_t end) {
                         CPU_ISA_DISPATCH((cpu::gelu_sigmoid<ISA>(x + begin, y + begin, end - begin)));
-                      });
-  }
-
-  template<>
-  template<>
-  void primitives<Device::CPU>::sigmoid(const float* x, float* y, dim_t size) {
-    cpu::parallel_for(0, size, cpu::GRAIN_SIZE / 10,
-                      [x, y](dim_t begin, dim_t end) {
-                        CPU_ISA_DISPATCH((cpu::sigmoid<ISA>(x + begin, y + begin, end - begin)));
                       });
   }
 
@@ -1152,6 +1151,8 @@ namespace ctranslate2 {
   primitives<Device::CPU>::strided_fill(T* x, T a, dim_t inc_x, dim_t size); \
   template void                                                         \
   primitives<Device::CPU>::indexed_fill(T*, T, const int32_t*, dim_t);  \
+  template void                                                         \
+  primitives<Device::CPU>::indexed_pointwise_multiply(T* x, const T*, const int32_t*, dim_t);  \
   template void                                                         \
   primitives<Device::CPU>::copy(const T* x, T* y, dim_t size);          \
   template T                                                            \

--- a/src/decoding.cc
+++ b/src/decoding.cc
@@ -498,6 +498,7 @@ namespace ctranslate2 {
       const dim_t cur_batch_size = is_expanded ? logits.dim(0) / _beam_size : logits.dim(0);
 
       DisableTokens disable_tokens(logits);
+      BiasTokens bias_tokens(logits);
 
       // Prevent the generation of end_ids until the minimum length is reached.
       apply_min_length(step,
@@ -512,12 +513,14 @@ namespace ctranslate2 {
         if (alive_seq)
           merge_batch_beam(alive_seq);
         for (const auto& logits_processor : logits_processors)
-          logits_processor->apply(step, logits, disable_tokens, alive_seq, batch_offset, prefix_ids);
+          logits_processor->apply(step, logits, disable_tokens, bias_tokens, alive_seq, batch_offset, prefix_ids);
         if (alive_seq)
           split_batch_beam(alive_seq, _beam_size);
       }
 
       disable_tokens.apply();
+      bias_tokens.apply();
+      
       std::vector<StorageView> logits_vec;
       if (return_logits_vocab)
         logits_vec = build_logits(logits, cur_batch_size);
@@ -840,6 +843,7 @@ namespace ctranslate2 {
               gather_attention ? &attention_step_device : nullptr);
 
       DisableTokens disable_tokens(logits);
+      BiasTokens bias_tokens(logits);
 
       // Prevent the generation of end_id until the minimum length is reached.
       apply_min_length(step,
@@ -851,9 +855,10 @@ namespace ctranslate2 {
                        prefix_ids);
 
       for (const auto& logits_processor : logits_processors)
-        logits_processor->apply(step, logits, disable_tokens, alive_seq, batch_offset, prefix_ids);
+        logits_processor->apply(step, logits, disable_tokens, bias_tokens, alive_seq, batch_offset, prefix_ids);
 
       disable_tokens.apply();
+      bias_tokens.apply();
 
       std::vector<StorageView> logits_vec;
       StorageView logits_orig(dtype, device);
@@ -1099,6 +1104,9 @@ namespace ctranslate2 {
 
     if (!options.disable_sequences.empty())
       processors.emplace_back(std::make_shared<SuppressSequences>(options.disable_sequences));
+
+    if (!options.sequence_bias.empty())
+      processors.emplace_back(std::make_shared<BiasSequences>(options.sequence_bias));
 
     for (const auto& processor : options.logits_processors) {
       if (!processor->apply_first())

--- a/src/models/whisper.cc
+++ b/src/models/whisper.cc
@@ -210,6 +210,7 @@ namespace ctranslate2 {
       void apply(dim_t step,
                  StorageView& logits,
                  DisableTokens&,
+                 BiasTokens&,
                  const StorageView&,
                  const std::vector<dim_t>& batch_offset,
                  const std::vector<std::vector<size_t>>*) override {
@@ -304,6 +305,7 @@ namespace ctranslate2 {
       decoding_options.return_scores = options.return_scores;
       decoding_options.return_logits_vocab = options.return_logits_vocab;
       decoding_options.include_eos_in_hypotheses = false;
+      decoding_options.sequence_bias = options.sequence_bias;
 
       for (const auto& id : options.suppress_tokens) {
         if (id >= 0)
@@ -749,6 +751,7 @@ namespace ctranslate2 {
       void apply(dim_t step,
                  StorageView& logits,
                  DisableTokens& disable_tokens,
+                 BiasTokens&,
                  const StorageView& sequences,
                  const std::vector<dim_t>& batch_offset,
                  const std::vector<std::vector<size_t>>* prefix) override {

--- a/tests/decoding_test.cc
+++ b/tests/decoding_test.cc
@@ -14,3 +14,17 @@ TEST(DecodingTest, DisableTokens) {
 
   expect_storage_eq(input, expected);
 }
+
+TEST(BiasDecodingTest, BiasTokens) {
+  StorageView input({2, 5}, std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+  StorageView expected({2, 5}, std::vector<float>{1, 3, 6, 4, 5, 6, 7, 48, 27, 10});
+  BiasTokens bias_tokens(input);
+
+  bias_tokens.add(2, 2.0);
+  bias_tokens.add(0, 1, 1.5);
+  bias_tokens.add(1, 3, 3.0);
+  bias_tokens.add(1, 2, 3.0);
+  bias_tokens.apply();
+
+  expect_storage_eq(input, expected);
+}

--- a/tests/primitives_test.cc
+++ b/tests/primitives_test.cc
@@ -22,6 +22,16 @@ TEST_P(PrimitiveTest, IndexedFill) {
   expect_storage_eq(x, expected);
 }
 
+TEST_P(PrimitiveTest, IndexedPointwiseMultiply) {
+  const Device device = GetParam();
+  StorageView x({6}, float(2), device);
+  StorageView values({3}, std::vector<float>{3.0, 3.0, 3.0}, device);
+  StorageView ids({3}, std::vector<int32_t>{0, 2, 5}, device);
+  StorageView expected({6}, std::vector<float>{6, 2, 6, 2, 2, 6}, device);
+  DEVICE_DISPATCH(device, primitives<D>::indexed_pointwise_multiply(x.data<float>(), values.data<float>(), ids.data<int32_t>(), 3));
+  expect_storage_eq(x, expected);
+}
+
 TEST_P(PrimitiveTest, LogSumExp) {
   const Device device = GetParam();
   StorageView x({8}, std::vector<float>{0.6, 0.2, -1.2, 0.1, 0.3, 0.5, -1.3, 0.2}, device);


### PR DESCRIPTION
Adds an optional contextual biasing parameter to the Whisper model to enable shallow contextual biasing toward given sequences by modifying logits. This is a flexible and fairly simple method useful for transcribing out-of-vocabulary entities in ASR or mitigating harmful mistranscriptions toward unwanted token sequences. Similar parameter is implemented in the HuggingFace package: https://huggingface.co/docs/transformers/en/internal/generation_utils#transformers.SequenceBiasLogitsProcessor