### PR TITLE
Download CUDNN9 compatible wheels HERE

### DIFF
--- a/python/tools/prepare_build_environment_linux.sh
+++ b/python/tools/prepare_build_environment_linux.sh
@@ -20,7 +20,7 @@ if [ "$CIBW_ARCHS" == "aarch64" ]; then
 
 else
     # Install CUDA 12.2:
-    yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
+    yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
     # error mirrorlist.centos.org doesn't exists anymore.
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
@@ -29,7 +29,7 @@ else
         cuda-nvcc-12-2-12.2.140-1 \
         cuda-cudart-devel-12-2-12.2.140-1 \
         libcurand-devel-12-2-10.3.3.141-1 \
-        libcudnn9-devel-cuda-12-9.0.0.312-1 \
+        libcudnn9-devel-cuda-12-9.1.0.70-1 \
         libcublas-devel-12-2-12.2.5.6-1 \
         libnccl-devel-2.19.3-1+cuda12.2
     ln -s cuda-12.2 /usr/local/cuda

--- a/python/tools/prepare_build_environment_linux.sh
+++ b/python/tools/prepare_build_environment_linux.sh
@@ -29,7 +29,7 @@ else
         cuda-nvcc-12-2-12.2.140-1 \
         cuda-cudart-devel-12-2-12.2.140-1 \
         libcurand-devel-12-2-10.3.3.141-1 \
-        libcudnn8-devel-8.9.7.29-1.cuda12.2 \
+        libcudnn9-devel-cuda-12-9.0.0.312-1 \
         libcublas-devel-12-2-12.2.5.6-1 \
         libnccl-devel-2.19.3-1+cuda12.2
     ln -s cuda-12.2 /usr/local/cuda

--- a/python/tools/prepare_build_environment_windows.sh
+++ b/python/tools/prepare_build_environment_windows.sh
@@ -32,7 +32,7 @@ rm -r oneDNN-*
 
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CTRANSLATE2_ROOT -DCMAKE_PREFIX_PATH="C:/Program Files (x86)/Intel/oneAPI/compiler/latest/windows/compiler/lib/intel64_win;C:/Program Files (x86)/oneDNN" -DBUILD_CLI=OFF -DWITH_DNNL=ON -DWITH_CUDA=ON -DWITH_CUDNN=ON -DCUDA_TOOLKIT_ROOT_DIR="$CUDA_ROOT" -DCUDA_DYNAMIC_LOADING=ON -DCUDA_NVCC_FLAGS="-Xfatbin=-compress-all" -DCUDA_ARCH_LIST="Common" ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CTRANSLATE2_ROOT -DCMAKE_PREFIX_PATH="C:/Program Files (x86)/Intel/oneAPI/compiler/latest/windows/compiler/lib/intel64_win;C:/Program Files (x86)/oneDNN" -DBUILD_CLI=OFF -DWITH_DNNL=ON -DWITH_CUDA=ON -DWITH_CUDNN=ON -DCUDA_TOOLKIT_ROOT_DIR="$CUDA_ROOT" -DCUDNN_LIBRARY="${CUDNN_ROOT}\lib" -DCUDNN_INCLUDE_DIR="${CUDNN_ROOT}\include" -DCUDA_DYNAMIC_LOADING=ON -DCUDA_NVCC_FLAGS="-Xfatbin=-compress-all" -DCUDA_ARCH_LIST="Common" ..
 cmake --build . --config Release --target install --parallel 6 --verbose
 cd ..
 rm -r build

--- a/python/tools/prepare_build_environment_windows.sh
+++ b/python/tools/prepare_build_environment_windows.sh
@@ -8,8 +8,8 @@ curl -L -nv -o cuda.exe https://developer.download.nvidia.com/compute/cuda/12.2.
 ./cuda.exe -s nvcc_12.2 cudart_12.2 cublas_dev_12.2 curand_dev_12.2
 rm cuda.exe
 
-CUDNN_ROOT="C:/Program Files/NVIDIA/CUDNN/v9.0"
-curl -L -nv -o cudnn.exe https://developer.download.nvidia.com/compute/cudnn/9.0.0/local_installers/cudnn_9.0.0_windows.exe
+CUDNN_ROOT="C:/Program Files/NVIDIA/CUDNN/v9.1"
+curl -L -nv -o cudnn.exe https://developer.download.nvidia.com/compute/cudnn/9.1.0/local_installers/cudnn_9.1.0_windows.exe
 ./cudnn.exe -s
 sleep 10
 cp -r "$CUDNN_ROOT"/* "$CUDA_ROOT"

--- a/python/tools/prepare_build_environment_windows.sh
+++ b/python/tools/prepare_build_environment_windows.sh
@@ -32,7 +32,7 @@ rm -r oneDNN-*
 
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CTRANSLATE2_ROOT -DCMAKE_PREFIX_PATH="C:/Program Files (x86)/Intel/oneAPI/compiler/latest/windows/compiler/lib/intel64_win;C:/Program Files (x86)/oneDNN" -DBUILD_CLI=OFF -DWITH_DNNL=ON -DWITH_CUDA=ON -DWITH_CUDNN=ON -DCUDA_TOOLKIT_ROOT_DIR="$CUDA_ROOT" -DCUDNN_LIBRARY="${CUDNN_ROOT}\lib\12.4\x64" -DCUDNN_INCLUDE_DIR="${CUDNN_ROOT}\include\12.4" -DCUDA_DYNAMIC_LOADING=ON -DCUDA_NVCC_FLAGS="-Xfatbin=-compress-all" -DCUDA_ARCH_LIST="Common" ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CTRANSLATE2_ROOT -DCMAKE_PREFIX_PATH="C:/Program Files (x86)/Intel/oneAPI/compiler/latest/windows/compiler/lib/intel64_win;C:/Program Files (x86)/oneDNN" -DBUILD_CLI=OFF -DWITH_DNNL=ON -DWITH_CUDA=ON -DWITH_CUDNN=ON -DCUDA_TOOLKIT_ROOT_DIR="$CUDA_ROOT" -DCUDNN_LIBRARY="${CUDNN_ROOT}/lib/12.4/x64" -DCUDNN_INCLUDE_DIR="${CUDNN_ROOT}/include/12.4" -DCUDA_DYNAMIC_LOADING=ON -DCUDA_NVCC_FLAGS="-Xfatbin=-compress-all" -DCUDA_ARCH_LIST="Common" ..
 cmake --build . --config Release --target install --parallel 6 --verbose
 cd ..
 rm -r build
@@ -40,4 +40,4 @@ rm -r build
 cp README.md python/
 cp $CTRANSLATE2_ROOT/bin/ctranslate2.dll python/ctranslate2/
 cp "C:/Program Files (x86)/Intel/oneAPI/compiler/latest/windows/redist/intel64_win/compiler/libiomp5md.dll" python/ctranslate2/
-cp "$CUDA_ROOT/bin/cudnn64_9.dll" python/ctranslate2/
+cp "$CUDA_ROOT/bin/12.4/cudnn64_9.dll" python/ctranslate2/

--- a/python/tools/prepare_build_environment_windows.sh
+++ b/python/tools/prepare_build_environment_windows.sh
@@ -8,8 +8,8 @@ curl -L -nv -o cuda.exe https://developer.download.nvidia.com/compute/cuda/12.2.
 ./cuda.exe -s nvcc_12.2 cudart_12.2 cublas_dev_12.2 curand_dev_12.2
 rm cuda.exe
 
-CUDNN_ROOT="C:/Program Files/NVIDIA/CUDNN/v8.8"
-curl -L -nv -o cudnn.exe https://developer.download.nvidia.com/compute/redist/cudnn/v8.8.0/local_installers/12.0/cudnn_8.8.0.121_windows.exe
+CUDNN_ROOT="C:/Program Files/NVIDIA/CUDNN/v9.0"
+curl -L -nv -o cudnn.exe https://developer.download.nvidia.com/compute/cudnn/9.0.0/local_installers/cudnn_9.0.0_windows.exe
 ./cudnn.exe -s
 sleep 10
 cp -r "$CUDNN_ROOT"/* "$CUDA_ROOT"
@@ -40,4 +40,4 @@ rm -r build
 cp README.md python/
 cp $CTRANSLATE2_ROOT/bin/ctranslate2.dll python/ctranslate2/
 cp "C:/Program Files (x86)/Intel/oneAPI/compiler/latest/windows/redist/intel64_win/compiler/libiomp5md.dll" python/ctranslate2/
-cp "$CUDA_ROOT/bin/cudnn64_8.dll" python/ctranslate2/
+cp "$CUDA_ROOT/bin/cudnn64_9.dll" python/ctranslate2/

--- a/python/tools/prepare_build_environment_windows.sh
+++ b/python/tools/prepare_build_environment_windows.sh
@@ -12,6 +12,20 @@ CUDNN_ROOT="C:/Program Files/NVIDIA/CUDNN/v9.1"
 curl -L -nv -o cudnn.exe https://developer.download.nvidia.com/compute/cudnn/9.1.0/local_installers/cudnn_9.1.0_windows.exe
 ./cudnn.exe -s
 sleep 10
+# Remove 11.8 folders
+rm -rf "$CUDNN_ROOT/bin/11.8"
+rm -rf "$CUDNN_ROOT/lib/11.8"
+rm -rf "$CUDNN_ROOT/include/11.8"
+
+# Move contents of 12.4 to parent directories
+mv "$CUDNN_ROOT/bin/12.4/"* "$CUDNN_ROOT/bin/"
+mv "$CUDNN_ROOT/lib/12.4/"* "$CUDNN_ROOT/lib/"
+mv "$CUDNN_ROOT/include/12.4/"* "$CUDNN_ROOT/include/"
+
+# Remove empty 12.4 folders
+rmdir "$CUDNN_ROOT/bin/12.4"
+rmdir "$CUDNN_ROOT/lib/12.4"
+rmdir "$CUDNN_ROOT/include/12.4"
 cp -r "$CUDNN_ROOT"/* "$CUDA_ROOT"
 rm cudnn.exe
 
@@ -32,7 +46,7 @@ rm -r oneDNN-*
 
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CTRANSLATE2_ROOT -DCMAKE_PREFIX_PATH="C:/Program Files (x86)/Intel/oneAPI/compiler/latest/windows/compiler/lib/intel64_win;C:/Program Files (x86)/oneDNN" -DBUILD_CLI=OFF -DWITH_DNNL=ON -DWITH_CUDA=ON -DWITH_CUDNN=ON -DCUDA_TOOLKIT_ROOT_DIR="$CUDA_ROOT" -DCUDNN_LIBRARY="${CUDNN_ROOT}/lib/12.4/x64" -DCUDNN_INCLUDE_DIR="${CUDNN_ROOT}/include/12.4" -DCUDA_DYNAMIC_LOADING=ON -DCUDA_NVCC_FLAGS="-Xfatbin=-compress-all" -DCUDA_ARCH_LIST="Common" ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CTRANSLATE2_ROOT -DCMAKE_PREFIX_PATH="C:/Program Files (x86)/Intel/oneAPI/compiler/latest/windows/compiler/lib/intel64_win;C:/Program Files (x86)/oneDNN" -DBUILD_CLI=OFF -DWITH_DNNL=ON -DWITH_CUDA=ON -DWITH_CUDNN=ON -DCUDA_TOOLKIT_ROOT_DIR="$CUDA_ROOT" -DCUDA_DYNAMIC_LOADING=ON -DCUDA_NVCC_FLAGS="-Xfatbin=-compress-all" -DCUDA_ARCH_LIST="Common" ..
 cmake --build . --config Release --target install --parallel 6 --verbose
 cd ..
 rm -r build
@@ -40,4 +54,4 @@ rm -r build
 cp README.md python/
 cp $CTRANSLATE2_ROOT/bin/ctranslate2.dll python/ctranslate2/
 cp "C:/Program Files (x86)/Intel/oneAPI/compiler/latest/windows/redist/intel64_win/compiler/libiomp5md.dll" python/ctranslate2/
-cp "$CUDA_ROOT/bin/12.4/cudnn64_9.dll" python/ctranslate2/
+cp "$CUDA_ROOT/bin/cudnn64_9.dll" python/ctranslate2/

--- a/python/tools/prepare_build_environment_windows.sh
+++ b/python/tools/prepare_build_environment_windows.sh
@@ -32,7 +32,7 @@ rm -r oneDNN-*
 
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CTRANSLATE2_ROOT -DCMAKE_PREFIX_PATH="C:/Program Files (x86)/Intel/oneAPI/compiler/latest/windows/compiler/lib/intel64_win;C:/Program Files (x86)/oneDNN" -DBUILD_CLI=OFF -DWITH_DNNL=ON -DWITH_CUDA=ON -DWITH_CUDNN=ON -DCUDA_TOOLKIT_ROOT_DIR="$CUDA_ROOT" -DCUDNN_LIBRARY="${CUDNN_ROOT}\lib" -DCUDNN_INCLUDE_DIR="${CUDNN_ROOT}\include" -DCUDA_DYNAMIC_LOADING=ON -DCUDA_NVCC_FLAGS="-Xfatbin=-compress-all" -DCUDA_ARCH_LIST="Common" ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CTRANSLATE2_ROOT -DCMAKE_PREFIX_PATH="C:/Program Files (x86)/Intel/oneAPI/compiler/latest/windows/compiler/lib/intel64_win;C:/Program Files (x86)/oneDNN" -DBUILD_CLI=OFF -DWITH_DNNL=ON -DWITH_CUDA=ON -DWITH_CUDNN=ON -DCUDA_TOOLKIT_ROOT_DIR="$CUDA_ROOT" -DCUDNN_LIBRARY="${CUDNN_ROOT}\lib\12.4\x64" -DCUDNN_INCLUDE_DIR="${CUDNN_ROOT}\include\12.4" -DCUDA_DYNAMIC_LOADING=ON -DCUDA_NVCC_FLAGS="-Xfatbin=-compress-all" -DCUDA_ARCH_LIST="Common" ..
 cmake --build . --config Release --target install --parallel 6 --verbose
 cd ..
 rm -r build


### PR DESCRIPTION
Hello, use this PR to download CT2 wheels that are compatible with `cudnn9` that is used by `torch>=2.4`

1. Go to Checks tab in this PR
2. Download the artifact "python-wheels"
3. Extract the archive
4. Install the wheel matching your system and Python version, for example:
`pip install --force-reinstall ctranslate2-4.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`