### PR TITLE
Update whisper.cc : Add logits to WhisperGenerationResult

### DIFF
--- a/python/cpp/whisper.cc
+++ b/python/cpp/whisper.cc
@@ -133,6 +133,7 @@ namespace ctranslate2 {
           return "WhisperGenerationResult(sequences=" + std::string(py::repr(py::cast(result.sequences)))
             + ", sequences_ids=" + std::string(py::repr(py::cast(result.sequences_ids)))
             + ", scores=" + std::string(py::repr(py::cast(result.scores)))
+            + ", logits=" + std::string(py::repr(py::cast(result.logits)))
             + ", no_speech_prob=" + std::string(py::repr(py::cast(result.no_speech_prob)))
             + ")";
         })


### PR DESCRIPTION
WhisperGenerationResult was missing return value for logits despite register_whisper having a readonly definition for said logits.
Logits are documented on https://opennmt.net/CTranslate2/python/ctranslate2.models.Whisper.html as being returned when return_logits_vocab is set to True, however, there was no written return value to access them within WhisperGenerationResult if it was set to True.

This fixes issue [#1779](https://github.com/OpenNMT/CTranslate2/issues/1779).