### PR TITLE
FIX: package libctranslate2.so in wheel to avoid build fail

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -53,7 +53,7 @@ elif sys.platform == "win32":
     package_data["ctranslate2"] = ["*.dll"]
 elif sys.platform == "linux":
     cflags.append("-fPIC")
-    ldflags.append("-Wl,-rpath,-Wl,-rpath,/usr/local/lib64")
+    ldflags.append("-Wl,-rpath,/usr/local/lib64:/usr/local/lib")
 
 ctranslate2_module = Extension(
     "ctranslate2._ext",


### PR DESCRIPTION
On Linux, installing the ctranslate2 wheel may fail to find the libctranslate2 shared library, causing import errors.

This patch updates setup.py to include libctranslate2.so in the wheel via package_data for Linux.

For detailed error information, see the related issue: [[issue#1919](https://github.com/OpenNMT/CTranslate2/issues/1919)]