### PR TITLE
Disable INT8 for sm120 - Blackwell GPUs

### DIFF
--- a/src/cuda/utils.cc
+++ b/src/cuda/utils.cc
@@ -182,6 +182,9 @@ namespace ctranslate2 {
 
     bool gpu_supports_int8(int device) {
       const cudaDeviceProp& device_prop = get_device_properties(device);
+      // Disable INT8 for sm120: https://github.com/OpenNMT/CTranslate2/issues/1865
+      if (device_prop.major == 12 && device_prop.minor == 0)
+        return false;
       return device_prop.major > 6 || (device_prop.major == 6 && device_prop.minor == 1);
     }
 


### PR DESCRIPTION
Closes: https://github.com/OpenNMT/CTranslate2/issues/1865

I debugged the issue a bit, observed the `CUBLAS_STATUS_NOT_SUPPORTED` error only when `n`[fw] is not multiple by 4 and some `m`[fw] values [I didn't noticed a pattern with `m`].  
[Note: `ldc`=`n`[fw] and `n` / `m` are swapped in CT2's call to GEMM] 
The cuBLAS docs doesn't say that `m` or `ldc` should be divisible by 4, it only recommends it for performance:
```
To use IMMA kernels, one of the following sets of requirements, with the first being the preferred one, must be met:
    1) Using a regular data ordering:
        All matrix pointers must be 4-byte aligned. For even better performance, this condition should hold with 16 instead of 4.
        Leading dimensions of matrices A, B, C must be multiples of 4.
        Dimensions m and k must be multiples of 4.
```

I guess, NVIDIA dropped some kernels for sm120, and now cublasGemmEx() fails when `n`[fw] % 4 ≠ 0 and some `m`[fw] (batch * sequence_length) combination.

In some calls to GEMM, `n`[fw]=vocab[whisper]. In multilingual models vocab is 51865 or 51866[v3] - not divisible by 4.

Sure way to reproduce the error - use `word_timestamps=True`.
Should be reproducible with `word_timestamps=False` and high `beam_size`, for example 24. [not tested]
I think `word_timestamps` is irrelevant to reproduce in batched mode. [not tested]

