### PR TITLE
Changes a deprecated cublasGemmAlgo_t type

### DIFF
--- a/src/cuda/primitives.cu
+++ b/src/cuda/primitives.cu
@@ -503,7 +503,7 @@ namespace ctranslate2 {
                               beta_ptr,
                               c, CUDA_R_16F, ldc,
                               compute_type,
-                              CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+                              CUBLAS_GEMM_DEFAULT));
   }
 
   template<>
@@ -528,7 +528,7 @@ namespace ctranslate2 {
                               &beta,
                               c, CUDA_R_16BF, ldc,
                               CUDA_R_32F,
-                              CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+                              CUBLAS_GEMM_DEFAULT));
   }
 
   template<>
@@ -556,7 +556,7 @@ namespace ctranslate2 {
                               &beta_i,
                               c, CUDA_R_32I, ldc,
                               CUDA_R_32I,
-                              CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+                              CUBLAS_GEMM_DEFAULT));
   }
 
   template<>
@@ -617,7 +617,7 @@ namespace ctranslate2 {
                                             c, CUDA_R_16F, ldc, stridec,
                                             batch_size,
                                             compute_type,
-                                            CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+                                            CUBLAS_GEMM_DEFAULT));
   }
 
   template<>
@@ -642,7 +642,7 @@ namespace ctranslate2 {
                                             c, CUDA_R_16BF, ldc, stridec,
                                             batch_size,
                                             CUDA_R_32F,
-                                            CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+                                            CUBLAS_GEMM_DEFAULT));
   }
 
   template <typename T>


### PR DESCRIPTION
Changes the deprecated [since CUDA 11] cublasGemmAlgo_t type - `CUBLAS_GEMM_DEFAULT_TENSOR_OP`.

From cuBLAS doc:
``
CUBLAS_GEMM_DEFAULT_TENSOR_OP[DEPRECATED] | This mode is deprecated and will be removed in a future release.
``

To the recommended `CUBLAS_GEMM_DEFAULT`.

Change doesn't show any effect on performance.
