### PR TITLE
T5Gemma

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The project implements a custom runtime that applies many performance optimizati
 
 The following model types are currently supported:
 
-* Encoder-decoder models: Transformer base/big, M2M-100, NLLB, BART, mBART, Pegasus, T5, Whisper
+* Encoder-decoder models: Transformer base/big, M2M-100, NLLB, BART, mBART, Pegasus, T5, T5Gemma, Whisper
 * Decoder-only models: GPT-2, GPT-J, GPT-NeoX, OPT, BLOOM, MPT, Llama, Mistral, Gemma, CodeGen, GPTBigCode, Falcon, Qwen2
 * Encoder-only models: BERT, DistilBERT, XLM-RoBERTa
 

--- a/include/ctranslate2/layers/transformer.h
+++ b/include/ctranslate2/layers/transformer.h
@@ -68,6 +68,10 @@ namespace ctranslate2 {
 
     private:
       std::unique_ptr<AttentionLayer> _self_attention;
+      const std::unique_ptr<const LayerNorm> _input_layer_norm;
+      const std::unique_ptr<const LayerNorm> _post_attention_layer_norm;
+      const std::unique_ptr<const LayerNorm> _pre_feedforward_layer_norm;
+      const std::unique_ptr<const LayerNorm> _post_feedforward_layer_norm;
       const FeedForwardNetwork _ff;
     };
 
@@ -121,6 +125,8 @@ namespace ctranslate2 {
       const std::unique_ptr<const LayerNorm> _post_attention_layer_norm;
       const std::unique_ptr<const LayerNorm> _pre_feedforward_layer_norm;
       const std::unique_ptr<const LayerNorm> _post_feedforward_layer_norm;
+      const std::unique_ptr<const LayerNorm> _pre_cross_attention_layer_norm;
+      const std::unique_ptr<const LayerNorm> _post_cross_attention_layer_norm;
       const std::unique_ptr<const AttentionLayer> _encoder_attention;
       const FeedForwardNetwork _ff;
     };


### PR DESCRIPTION
Support [T5Gemma](https://arxiv.org/abs/2504.06225) architecture. Here's the basic idea from the [`transformers` T5Gemma documentation](https://huggingface.co/docs/transformers/main/model_doc/t5gemma):

> T5Gemma (aka encoder-decoder Gemma) was proposed in a [research paper](https://huggingface.co/papers/2504.06225) by Google. It is a family of encoder-decoder large language models, developed by adapting pretrained decoder-only models into encoder-decoder. T5Gemma includes pretrained and instruction-tuned variants. The architecture is based on transformer encoder-decoder design following T5, with improvements from Gemma 2: GQA, RoPE, GeGLU activation, RMSNorm, and interleaved local/global attention.

For reference, here is the [T5Gemma PR](https://github.com/huggingface/transformers/pull/38332) that merged model support for these architectures into `transformers`. 