### PR TITLE
Remove unnecessary check from wav2vec2

### DIFF
--- a/include/ctranslate2/layers/wav2vec2.h
+++ b/include/ctranslate2/layers/wav2vec2.h
@@ -80,17 +80,6 @@ namespace ctranslate2 {
         return 1024;
       }
 
-      bool is_encoded(const StorageView& features) const {
-        // Input features shape: [batch_size, input_size, input_time]
-        // Encoder output shape: [batch_size, input_time // 2, output_size]
-        //
-        // input_time is variable so we check that dimension 1 is different than its original value.
-
-        return (features.rank() == 3
-                && features.dim(2) == output_size()
-                && features.dim(1) != input_size());
-      }
-
       const StorageView* _upgraded_model;
 
     private:

--- a/include/ctranslate2/models/wav2vec2.h
+++ b/include/ctranslate2/models/wav2vec2.h
@@ -56,8 +56,6 @@ namespace ctranslate2 {
     private:
       const std::shared_ptr<const Wav2Vec2Model> _model;
       const std::unique_ptr<layers::Wav2Vec2Encoder> _encoder;
-
-      StorageView maybe_encode(StorageView features);
     };
 
     class Wav2Vec2 : public ReplicaPool<Wav2Vec2Replica> {

--- a/src/models/wav2vec2.cc
+++ b/src/models/wav2vec2.cc
@@ -78,12 +78,7 @@ namespace ctranslate2 {
       features.move_to(device, dtype);
 
       StorageView encoder_output(dtype, device);
-      if (_encoder->_upgraded_model) {
-        encoder_output = maybe_encode(std::move(features));
-      }
-      else {
-        (*_encoder)(features, encoder_output);
-      }
+      (*_encoder)(features, encoder_output);
 
       if (to_cpu) {
         if (device != Device::CPU)
@@ -95,20 +90,6 @@ namespace ctranslate2 {
       // Ensure all operations are finished before returning the output.
       synchronize_stream(device);
 
-      return encoder_output;
-    }
-
-    StorageView Wav2Vec2Replica::maybe_encode(StorageView features) {
-      const Device device = _model->device();
-      const DataType dtype = _encoder->output_type();
-
-      features.move_to(device, dtype);
-
-      if (_encoder->is_encoded(features))
-        return features;
-
-      StorageView encoder_output(dtype, device);
-      (*_encoder)(features, encoder_output);
       return encoder_output;
     }
 


### PR DESCRIPTION
Remove the unnecessary check which causes inference not to be ran in some edge cases discussed  in #1969.