### PR TITLE
Use LLVM ThreadSanitizer instead of Google  

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           tests/ctranslate2_test tests/data
           
-  build-and-test-cpp-x86_64-sanitizer:
+  build-and-test-cpp-x86_64-address_sanitizer:
     runs-on: ubuntu-22.04
     env:
       CT2_VERBOSE: 1


### PR DESCRIPTION
Google sanitizer is [archived](https://github.com/google/sanitizers).     LLVM project is the current official [maintainer](https://clang.llvm.org/docs/AddressSanitizer.html).