### PR TITLE
Compatibility with Transformers v5

### DIFF
--- a/python/tests/test_transformers.py
+++ b/python/tests/test_transformers.py
@@ -21,7 +21,9 @@ def clear_transformers_cache_in_ci():
     import transformers
 
     if os.environ.get("CI") == "true":
-        shutil.rmtree(transformers.utils.default_cache_path, ignore_errors=True)
+        from huggingface_hub import constants
+
+        shutil.rmtree(constants.HF_HUB_CACHE, ignore_errors=True)
 
 
 _TRANSFORMERS_TRANSLATION_TESTS = [


### PR DESCRIPTION
Transformers v5 was released this week and breaks some of Transfomer's model conversions

Changes
- Replaces deprecated attributes with options which work in v4 and v5
- Adds logic to read the new rotary parameters