### PR TITLE
Fix index calculation for logits_vocab

### DIFF
--- a/src/decoding.cc
+++ b/src/decoding.cc
@@ -631,7 +631,7 @@ namespace ctranslate2 {
             if (alive_attention)
               result.attention.emplace_back(build_attention(alive_attention, i, k, start, end));
             if (return_logits_vocab) {
-              result.logits_vocab.emplace_back(std::move(logits_vec[i * k]));
+              result.logits_vocab.emplace_back(std::move(logits_vec[i * _beam_size + k]));
             }
 
             // Move another active beam to this position.


### PR DESCRIPTION
Attempts to fix issue with empty logits vector when beam_size > 1. Closes #1616 