### PR TITLE
fix issue with return_logits_vocab option

### DIFF
--- a/src/decoding.cc
+++ b/src/decoding.cc
@@ -631,7 +631,7 @@ namespace ctranslate2 {
             if (alive_attention)
               result.attention.emplace_back(build_attention(alive_attention, i, k, start, end));
             if (return_logits_vocab) {
-              result.logits_vocab.emplace_back(std::move(logits_vec[i * k]));
+              result.logits_vocab.emplace_back(std::vector<StorageView>{std::move(logits_vec[i * k])});
             }
 
             // Move another active beam to this position.


### PR DESCRIPTION
When setting the `return_logits_vocab` option, the logits of type `StorageView` are saved with `emplace_back` in the `DecodingResult.logits_vocab` of type `std::vector<std::vector<StorageView>>`. The type mismatch (`StorageView` instead of `std::vector<StorageView>`) results in an empty `StorageView` being emplaced intead of the computed logits.