### PR TITLE
cuda: add simple cudaMalloc/cudaFree allocator as opt-in (workaround for #2038)

### DIFF
--- a/src/cuda/allocator.cc
+++ b/src/cuda/allocator.cc
@@ -13,6 +13,8 @@
 #define cub hipcub
 #define cudaGetDevice hipGetDevice
 #define cudaSetDevice hipSetDevice
+#define cudaFree hipFree
+#define cudaMalloc hipMalloc
 #define cudaFreeAsync hipFreeAsync
 #define cudaMallocAsync hipMallocAsync
 #define cudaDeviceGetAttribute hipDeviceGetAttribute
@@ -74,6 +76,45 @@ namespace ctranslate2 {
 
     private:
       std::unique_ptr<cub::CachingDeviceAllocator> _allocator;
+    };
+
+    // Direct cudaMalloc/cudaFree allocator — no caching, no event tracking.
+    //
+    // Exists primarily as an opt-in escape hatch for the deadlock on
+    // ROCm 7.2.1 / Windows reported in issue #2038: there, the hipcub
+    // CachingDeviceAllocator's per-block hipEventRecord / hipFree calls
+    // can hang inside the runtime during `del model` cleanup.  Falling
+    // back to a stateless allocator (no cached blocks, no ready events,
+    // no per-block streams) sidesteps every code path that the upstream
+    // bug touches.  Costs a fresh hipMalloc per allocation — fine for
+    // workloads that mostly run inference and rarely allocate.
+    //
+    // Enabled with `CT2_CUDA_ALLOCATOR=simple` (or `none`).
+    class SimpleAllocator : public Allocator {
+    public:
+      void* allocate(size_t size, int device_index) override {
+        int prev_device_index = -1;
+        if (device_index >= 0) {
+          CUDA_CHECK(cudaGetDevice(&prev_device_index));
+          CUDA_CHECK(cudaSetDevice(device_index));
+        }
+        void* ptr = nullptr;
+        CUDA_CHECK(cudaMalloc(&ptr, size));
+        if (prev_device_index >= 0)
+          CUDA_CHECK(cudaSetDevice(prev_device_index));
+        return ptr;
+      }
+
+      void free(void* ptr, int device_index) override {
+        int prev_device_index = -1;
+        if (device_index >= 0) {
+          CUDA_CHECK(cudaGetDevice(&prev_device_index));
+          CUDA_CHECK(cudaSetDevice(device_index));
+        }
+        CUDA_CHECK(cudaFree(ptr));
+        if (prev_device_index >= 0)
+          CUDA_CHECK(cudaSetDevice(prev_device_index));
+      }
     };
 
     class CudaAsyncAllocator : public Allocator {
@@ -139,6 +180,7 @@ namespace ctranslate2 {
     enum class CudaAllocator {
       CubCaching,
       MallocAsync,
+      Simple,
     };
 
     static CudaAllocator resolve_cuda_allocator() {
@@ -156,6 +198,10 @@ namespace ctranslate2 {
         if (!cuda_malloc_async_is_supported)
           throw std::runtime_error("The asynchronous CUDA allocator requires CUDA >= 11.2");
         allocator = CudaAllocator::MallocAsync;
+      } else if (allocator_name == "simple" || allocator_name == "none") {
+        // Stateless cudaMalloc/cudaFree — opt-in workaround for issue
+        // #2038 (HIP allocator free path deadlocks on ROCm 7.2.1 / Windows).
+        allocator = CudaAllocator::Simple;
       } else {
         throw std::invalid_argument("Invalid CUDA allocator " + allocator_name);
       }
@@ -177,6 +223,11 @@ namespace ctranslate2 {
     if (cuda_allocator == cuda::CudaAllocator::CubCaching) {
       // Use 1 allocator per thread for performance.
       static thread_local cuda::CubCachingAllocator allocator;
+      return allocator;
+    }
+
+    if (cuda_allocator == cuda::CudaAllocator::Simple) {
+      static cuda::SimpleAllocator allocator;
       return allocator;
     }
 


### PR DESCRIPTION
## Summary

Addresses #2038 (`del model` deadlocks on ROCm 7.2.1 + Windows + gfx1100 inside the hipcub CachingDeviceAllocator's free path).

Adds a third option for \`CT2_CUDA_ALLOCATOR\`:
- \`cub_caching\` (existing default on Windows / pre-CUDA-11.2)
- \`cuda_malloc_async\` (existing default on Linux+CUDA / Linux+HIP)
- **\`simple\`** / **\`none\`** (new) — stateless \`cudaMalloc\` / \`cudaFree\`, no caching, no per-block events

The default behaviour is unchanged. The \`simple\` allocator is an opt-in workaround for users hitting the deadlock until the ROCm runtime bug is fixed upstream.

## Why not just hardcode the workaround on Windows-HIP?

I checked whether \`hipMallocAsync\` would work as a drop-in (it's currently disabled on Windows via \`CT2_USE_ASYNC_ALLOC = !_WIN32\` per #1072). On ROCm 7.2.0 + RX 7900 XTX + Windows 11, the first \`generate()\` call still crashes with \`IndexError: invalid vector subscript\` — so \`hipMallocAsync\` isn't usable as a Windows default yet. Reverted the experiment, kept the existing guard.

The hipcub deadlock itself isn't reproducible on ROCm 7.2.0 in my local setup (the reporter sees it on 7.2.1), so I can't fix the bug at its root in this repo. The opt-in \`simple\` allocator just routes around every code path the upstream bug is sensitive to: no cached blocks, no \`hipEventRecord\`, no per-block streams.

## Trade-off

- Every allocation becomes a fresh \`cudaMalloc\` (no cache reuse).
- For typical inference workloads (load model → many forward passes → unload), allocation happens once at load time and then mostly stays the same, so the impact is small.
- For workloads with frequent allocation/deallocation churn, expect a measurable slowdown. Those workloads can stay on \`cub_caching\`.

## Test plan

- [x] Build with \`-DWITH_HIP=ON\` on gfx1100 (Windows 11, ROCm 7.2.0).
- [x] \`CT2_CUDA_ALLOCATOR=simple python repro.py\` → Whisper-medium load + inference + \`del model\` returns in ~10 ms (vs ~22 ms with \`cub_caching\`).
- [x] Default allocator path still works: \`CT2_CUDA_ALLOCATOR=cub_caching\` → identical token output, identical timing.
- [x] All 15 tests in my local \`python/tests/test_flash_attention.py\` pass under \`CT2_CUDA_ALLOCATOR=simple\` with the same correctness thresholds as on \`cub_caching\`.
- [ ] CI: build & wheel jobs.
- [ ] Confirmation from #2038 reporter that \`CT2_CUDA_ALLOCATOR=simple\` avoids the hang on ROCm 7.2.1.

cc @sssshhhhhh @jordimas

Closes #2038 once confirmed by the reporter.