### PR TITLE
Fix process-killing integer division by zero when Whisper align() gets a window with no frames

### DIFF
--- a/src/models/whisper.cc
+++ b/src/models/whisper.cc
@@ -510,7 +510,13 @@ namespace ctranslate2 {
 
       std::vector<std::vector<std::pair<dim_t, dim_t>>> alignments;
 
-      if (variable_num_frames) {
+      if (std::all_of(num_frames.begin(), num_frames.end(), [](size_t size) { return size == 0; })) {
+        // A window shorter than the encoder stride (num_frames < 2) has no
+        // frames left to align against: running the attention post-processing
+        // on zero-size tensors is at best undefined. Return empty alignments.
+        alignments.resize(batch_size);
+
+      } else if (variable_num_frames) {
         const StorageView frame_sizes({batch_size},
                                       std::vector<int32_t>(num_frames.begin(), num_frames.end()),
                                       device);
@@ -524,6 +530,11 @@ namespace ctranslate2 {
         alignments.reserve(batch_size);
 
         for (dim_t b = 0; b < batch_size; ++b) {
+          if (num_frames[b] == 0) {
+            alignments.emplace_back();
+            continue;
+          }
+
           // Retrieve attention probs for batch and remove padding.
           StorageView batch_id({1}, int32_t(b), device);
           StorageView attention_probs(dtype, device);

--- a/src/ops/median_filter_cpu.cc
+++ b/src/ops/median_filter_cpu.cc
@@ -13,16 +13,23 @@ namespace ctranslate2 {
     void MedianFilter::compute(const StorageView& input,
                        const dim_t axis_size,
                        StorageView& output) const {
+      const dim_t depth = axis_size;
+      const dim_t rank = _width / 2;
+
+      // Guard before dividing by depth: a zero-size axis (e.g. Whisper align()
+      // with num_frames < 2, halved to 0 by the encoder stride) would make
+      // input.size() / depth an integer division by zero — a native crash,
+      // not a catchable exception. Pass the input through like the GPU path.
+      if (depth <= rank) {
+        if (&output != &input)
+          output.copy_from(input);
+        return;
+      }
+
       const auto* src = input.data<T>();
       auto* dst = output.data<T>();
 
-
-      const dim_t depth = axis_size;
       const dim_t batch_size = input.size() / depth;
-      const dim_t rank = _width / 2;
-
-      if (depth <= rank)
-        return;
 
       cpu::parallel_for(0, batch_size, 1, [&](dim_t begin, dim_t end) {
         StorageView window_storage({_width}, DataType::FLOAT32);

--- a/src/ops/median_filter_gpu.cu
+++ b/src/ops/median_filter_gpu.cu
@@ -51,11 +51,14 @@ namespace ctranslate2 {
                               const dim_t axis_size,
                               StorageView& output) const {
       const int depth = static_cast<int>(axis_size);
-      const int rows = static_cast<int>(input.size() / depth);
       const int width = static_cast<int>(_width);
       const int rank = width / 2;
 
-      // Host-side guards and fallbacks.
+      // Host-side guards and fallbacks. The depth guard must run before
+      // input.size() / depth below: a zero-size axis (e.g. Whisper align()
+      // with num_frames < 2, halved to 0 by the encoder stride) would make it
+      // an integer division by zero — a native crash, not a catchable
+      // exception (0xC0000094 on Windows, SIGFPE on Linux).
       if (width <= 1) {
         if (&output != &input)
           output.copy_from(input);
@@ -70,6 +73,8 @@ namespace ctranslate2 {
           output.copy_from(input);
         return;
       }
+
+      const int rows = static_cast<int>(input.size() / depth);
 
       // Grid configuration
       const int total = rows * depth;

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -146,6 +146,27 @@ TEST_P(OpDeviceFPTest, MedianFilter) {
   expect_storage_eq(y.to_float32(), expected, error);
 }
 
+TEST_P(OpDeviceFPTest, MedianFilterShortAxis) {
+  // An axis shorter than the filter rank (including a zero-size axis, as
+  // produced by Whisper align() when num_frames < 2) must pass the input
+  // through instead of crashing on an integer division by zero.
+  const Device device = GetParam().device;
+  const DataType dtype = GetParam().dtype;
+  const float error = GetParam().error;
+  {
+    StorageView x({2, 0}, std::vector<float>{}, device);
+    StorageView y(dtype, device);
+    ops::MedianFilter(5)(x.to(dtype), y);
+    EXPECT_EQ(y.size(), 0);
+  }
+  {
+    StorageView x({2, 2}, std::vector<float>{0.1f, 0.2f, 0.3f, 0.4f}, device);
+    StorageView y(dtype, device);
+    ops::MedianFilter(5)(x.to(dtype), y);
+    expect_storage_eq(y.to_float32(), x, error);
+  }
+}
+
 TEST_P(OpDeviceTest, Add) {
   Device device = GetParam();
   StorageView a({4}, std::vector<float>{1, 2, 3, 4}, device);


### PR DESCRIPTION
## Problem

`Whisper::align()` halves each `num_frames` entry for the encoder''s stride-2 convolution. A window with `num_frames < 2` therefore ends up with **0 frames**, and the zero-size time axis flows into `MedianFilter`, whose CPU and GPU implementations both compute

```cpp
const dim_t batch_size = input.size() / depth;   // depth == 0 → integer division by zero
```

*before* their `depth <= rank` short-axis guard. Integer division by zero is UB; in the CUDA build''s host code it deterministically kills the host process — `0xC0000094` (`STATUS_INTEGER_DIVIDE_BY_ZERO`) on Windows — with no catchable exception. (The CPU build happens to survive on MSVC because the optimizer reorders the division past the early return, which is why reports of this are sparse and platform-dependent.)

This is reachable from the public API with real-world input: faster-whisper''s VAD path produces ~10ms final speech chunks on audio where Whisper hallucinates past the end of the clip, and calls `align()` with `num_frames=1`. That is the root cause of SYSTRAN/faster-whisper#1342 ("Divide by zero crash on Windows for specific audio files when word level timestamps are enabled").

## Reproduction (no audio file needed)

```python
import ctranslate2, numpy as np, huggingface_hub

model_dir = huggingface_hub.snapshot_download("Systran/faster-whisper-tiny")
model = ctranslate2.models.Whisper(model_dir, device="cuda")

features = np.zeros((1, model.n_mels, 3000), dtype=np.float32)
encoded = model.encode(ctranslate2.StorageView.from_array(features))

model.align(encoded, [50258, 50259, 50359], [[1396, 264, 1002]], [3000])  # fine
model.align(encoded, [50258, 50259, 50359], [[1396, 264, 1002]], [1])     # kills the process
```

## Fix (two commits)

1. **`MedianFilter` (CPU + GPU): move the `depth <= rank` guard above the division.** The guard already existed in both files — it just ran after the division it should protect. The CPU early-return now also copies input → output like the GPU path does (previously it returned an uninitialized buffer for short axes).
2. **`Whisper::align()`: return empty alignments for windows with no frames left after the stride halving.** Even with the MedianFilter fix, running the attention post-processing on zero-size tensors fails downstream (thrust `parallel_for` error on CUDA) or produces meaningless `(token, -1)` pairs on CPU. No frames → no alignment is the honest result, and it is consistent across devices.

Added `OpDeviceFPTest.MedianFilterShortAxis` covering the zero-size axis and the pass-through behavior.

## Verification

- New test passes on CPU and CUDA (float32/float16/bfloat16); full `ctranslate2_test` suite: 360 tests, 353 pass, 4 skipped. 3 pre-existing failures in `CPU/OpDeviceFPTest.Gemm*/float32` are float32 GEMM numerics under the Ruy fallback backend of my local build (no MKL installed) and are untouched by this change.
- The reproduction above: control window aligns normally (1503 pairs), `num_frames=[1]` returns an empty alignment instead of killing the process — verified on Windows/CUDA 12.0 (RTX 3090, sm_86) and CPU.
- End-to-end through faster-whisper: the originally-crashing real-world clip now transcribes completely (the degenerate window is Whisper''s trailing-credits hallucination past the audio end, returned with no word timestamps).

## AI assistance disclosure

Per the contribution guidelines: I used an AI assistant (Claude) to help trace the crash to this code and draft the patch. I directed the investigation, and every claim above was verified empirically on my machine: the degenerate input was captured live with `faulthandler` + an instrumented `align()` call, the fix was validated with a local CUDA build, the test suite, the minimal repro, and the original real-world clip. I am responsible for the change and happy to adjust it.