### PR TITLE
Optimize attention softmax buffer reuse

### DIFF
--- a/src/layers/attention.cc
+++ b/src/layers/attention.cc
@@ -265,10 +265,13 @@ namespace ctranslate2 {
         alibi->apply(output, queries_scale);
 
       StorageView attn(values.dtype(), values.device());
-      ops::SoftMax()(output, values_lengths, attn);
-
-      if (attention && !return_normalized_attention)
+      if (attention && !return_normalized_attention) {
+        ops::SoftMax()(output, values_lengths, attn);
         save_attention(*attention, std::move(output), beam_size);
+      } else {
+        attn = std::move(output);
+        ops::SoftMax()(attn, values_lengths, attn);
+      }
 
       const ops::MatMul values_matmul;
       values_matmul(attn, values, output);


### PR DESCRIPTION
Reuses the output buffer in-place for softmax when raw attention is not needed, avoiding an extra allocation; only allocates a separate attn buffer when callers want unnormalize  attention.
