### PR TITLE
Add native Apple Metal/MPS backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,11 +180,12 @@ jobs:
         run: |
           tests/ctranslate2_test tests/data
 
-  # Unlike the standard macOS runner, macos-15-xlarge exposes an Apple
-  # Silicon GPU. Keep this as a separate required job so MPS is exercised at
-  # runtime and cannot silently degrade into build-only coverage.
+  # The contributor fork uses its self-hosted Apple Silicon runner. Upstream
+  # keeps the GPU-enabled GitHub runner so this remains mergeable without
+  # depending on infrastructure owned by the contributor.
   build-and-test-mps:
-    runs-on: macos-15-xlarge
+    if: github.repository != 'TBO22/CTranslate2' || github.event_name == 'push'
+    runs-on: ${{ github.repository == 'TBO22/CTranslate2' && 'self-hosted' || 'macos-15-xlarge' }}
     env:
       CT2_VERBOSE: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,78 @@ jobs:
         run: |
           tests/ctranslate2_test tests/data
 
+  # Unlike the standard macOS runner, macos-15-xlarge exposes an Apple
+  # Silicon GPU. Keep this as a separate required job so MPS is exercised at
+  # runtime and cannot silently degrade into build-only coverage.
+  build-and-test-mps:
+    runs-on: macos-15-xlarge
+    env:
+      CT2_VERBOSE: 1
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify Apple Silicon runner
+        run: |
+          test "$(uname -m)" = "arm64"
+          system_profiler SPHardwareDataType SPDisplaysDataType
+
+      - name: Configure MPS build
+        run: |
+          cmake -S . -B build-mps \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/install-mps" \
+            -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DBUILD_TESTS=ON \
+            -DWITH_MPS=ON \
+            -DWITH_ACCELERATE=ON \
+            -DWITH_MKL=OFF \
+            -DWITH_RUY=ON \
+            -DOPENMP_RUNTIME=NONE
+
+      - name: Build and install MPS library
+        run: |
+          cmake --build build-mps --parallel "$(sysctl -n hw.logicalcpu)"
+          cmake --install build-mps
+
+      - name: Download test data
+        working-directory: tests/data/models
+        run: |
+          curl --fail --location --output transliteration-aren-all.tar.gz \
+            https://opennmt-models.s3.amazonaws.com/transliteration-aren-all.tar.gz
+          tar xf transliteration-aren-all.tar.gz
+
+      - name: Run MPS runtime test suite
+        run: |
+          build-mps/tests/ctranslate2_test tests/data \
+            --gtest_filter='MPSBackendTest.*:MPSPrimitiveTest.*:TranslatorTest.MPS*:MPS/*'
+
+      - name: Run CPU and shared test suite from MPS build
+        run: |
+          build-mps/tests/ctranslate2_test tests/data \
+            --gtest_filter='-MPSBackendTest.*:MPSPrimitiveTest.*:TranslatorTest.MPS*:MPS/*'
+
+      - name: Build MPS Python bindings
+        env:
+          CTRANSLATE2_ROOT: ${{ github.workspace }}/install-mps
+          CMAKE_BUILD_PARALLEL_LEVEL: 5
+        run: |
+          python -m pip install -r python/install_requirements.txt pytest
+          python -m pip install ./python
+
+      - name: Test Python CPU selection and explicit MPS inference
+        env:
+          CT2_TEST_MPS: 1
+        run: |
+          python -m pytest --import-mode=importlib -v python/tests/test_mps.py
+
   build-python-wheels:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$PWD/install-mps" \
             -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DBUILD_TESTS=ON \
             -DWITH_MPS=ON \
             -DWITH_ACCELERATE=ON \

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 *.pyc
 /.vs
 /build
+/build-*/
+/install-*/
+**/.DS_Store
+python/ctranslate2/_ext*.so
 
 CMake*.json
 .idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(WITH_RUY "Compile with Ruy backend" OFF)
 option(WITH_CUDA "Compile with CUDA backend" OFF)
 option(WITH_CUDNN "Compile with cuDNN backend" OFF)
 option(WITH_HIP "Compile with AMD HIP GPU backend" OFF)
+option(WITH_MPS "Compile with Apple Metal Performance Shaders backend" OFF)
 option(CUDA_DYNAMIC_LOADING "Dynamically load CUDA libraries at runtime" OFF)
 option(ENABLE_CPU_DISPATCH "Compile CPU kernels for multiple ISA and dispatch at runtime" ON)
 option(ENABLE_PROFILING "Compile with profiling support" OFF)
@@ -64,7 +65,13 @@ endif(NOT CMAKE_BUILD_TYPE)
 set(CMAKE_CXX_STANDARD 17)
 
 if(APPLE)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
+  if(WITH_MPS)
+    # Apple Silicon Macs ship with macOS 11 or newer. This also covers the
+    # Metal APIs used by the persistent command stream and MPSMatrix paths.
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)
+  else()
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
+  endif()
 endif()
 
 
@@ -776,6 +783,44 @@ elseif(WITH_CUDNN)
   message(FATAL_ERROR "WITH_CUDNN=ON requires WITH_CUDA=ON")
 else()
   add_library(${PROJECT_NAME} ${SOURCES})
+endif()
+
+if(WITH_MPS)
+  if(NOT APPLE)
+    message(FATAL_ERROR "WITH_MPS=ON is only supported on Apple platforms")
+  endif()
+  if(WITH_CUDA OR WITH_HIP)
+    message(FATAL_ERROR "WITH_MPS cannot be enabled together with CUDA or HIP")
+  endif()
+
+  message(STATUS "Enabling MPS (Metal) backend for Apple Silicon")
+  enable_language(OBJCXX)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC CT2_WITH_MPS)
+
+  set(MPS_SOURCES
+    src/mps/allocator.mm
+    src/mps/kernels.mm
+    src/mps/ops_impl.mm
+    src/mps/ops_stubs.mm
+    src/mps/primitives.mm
+    src/mps/utils.mm
+    src/ops/conv1d_mps.mm
+    src/ops/layer_norm_mps.mm
+    src/ops/mean_mps.mm
+    src/ops/rms_norm_mps.mm
+    src/ops/rotary_mps.mm
+    src/ops/softmax_mps.cc
+  )
+  target_sources(${PROJECT_NAME} PRIVATE ${MPS_SOURCES})
+
+  find_library(METAL_LIBRARY Metal REQUIRED)
+  find_library(MPS_LIBRARY MetalPerformanceShaders REQUIRED)
+  find_library(FOUNDATION_LIBRARY Foundation REQUIRED)
+  target_link_libraries(${PROJECT_NAME} PRIVATE
+    ${METAL_LIBRARY}
+    ${MPS_LIBRARY}
+    ${FOUNDATION_LIBRARY}
+  )
 endif()
 
 include(GenerateExportHeader)

--- a/cli/translator.cc
+++ b/cli/translator.cc
@@ -30,7 +30,7 @@ int main(int argc, char* argv[]) {
      cxxopts::value<size_t>()->default_value("1"))
     ("intra_threads", "Number of computation threads (set to 0 to use the default value).",
      cxxopts::value<size_t>()->default_value("0"))
-    ("device", "Device to use (can be cpu, cuda, auto).",
+    ("device", "Device to use (can be cpu, cuda, mps, auto).",
      cxxopts::value<std::string>()->default_value("cpu"))
     ("device_index", "Comma-separated list of device IDs to use.",
      cxxopts::value<std::vector<int>>()->default_value("0"))
@@ -43,6 +43,8 @@ int main(int argc, char* argv[]) {
     ("compute_type", "The type used for computation: default, auto, float32, float16, bfloat16, int16, int8, int8_float32, int8_float16, or int8_bfloat16",
      cxxopts::value<std::string>()->default_value("default"))
     ("cuda_compute_type", "Computation type on CUDA devices (overrides compute_type)",
+     cxxopts::value<std::string>())
+    ("mps_compute_type", "Computation type on MPS devices (overrides compute_type)",
      cxxopts::value<std::string>())
     ("cpu_compute_type", "Computation type on CPU devices (overrides compute_type)",
      cxxopts::value<std::string>())
@@ -138,6 +140,10 @@ int main(int argc, char* argv[]) {
   case ctranslate2::Device::CUDA:
     if (args.count("cuda_compute_type"))
       compute_type = ctranslate2::str_to_compute_type(args["cuda_compute_type"].as<std::string>());
+    break;
+  case ctranslate2::Device::MPS:
+    if (args.count("mps_compute_type"))
+      compute_type = ctranslate2::str_to_compute_type(args["mps_compute_type"].as<std::string>());
     break;
   };
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -61,10 +61,19 @@ command buffer is committed without waiting. The default is `16`.
 Set the maximum number of copy/blit operations encoded before the current MPS
 command buffer is committed without waiting. The default is `64`.
 
+## `CT2_MPS_MAX_INFLIGHT_COMMAND_BUFFERS`
+
+Set the maximum number of unfinished MPS command buffers. The default is `8`,
+which keeps useful CPU/GPU overlap while bounding Metal temporary resources on
+unified-memory systems. Increasing this value can help large-memory devices,
+but should be validated with cold, end-to-end inference rather than GEMM-only
+benchmarks.
+
 ## `CT2_MPS_MAX_OPS`
 
 Legacy command-buffer operation limit. When one of the more specific MPS
-limits above is not set, this value overrides its default.
+compute or blit limits above is not set, this value overrides its default. It
+does not change `CT2_MPS_MAX_INFLIGHT_COMMAND_BUFFERS`.
 
 ## `CT2_MPS_PROFILE`
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -51,6 +51,47 @@ export CT2_CUDA_CACHING_ALLOCATOR_CONFIG=8,3,7,6291455
 
 See the description of each parameter in the [allocator implementation](https://github.com/NVIDIA/cub/blob/main/cub/util_allocator.cuh).
 
+## `CT2_MPS_MAX_COMPUTE_OPS`
+
+Set the maximum number of compute operations encoded before the current MPS
+command buffer is committed without waiting. The default is `16`.
+
+## `CT2_MPS_MAX_BLIT_OPS`
+
+Set the maximum number of copy/blit operations encoded before the current MPS
+command buffer is committed without waiting. The default is `64`.
+
+## `CT2_MPS_MAX_OPS`
+
+Legacy command-buffer operation limit. When one of the more specific MPS
+limits above is not set, this value overrides its default.
+
+## `CT2_MPS_PROFILE`
+
+Print aggregated MPS execution counters at process exit, including command
+buffers, dispatches, synchronization points, GEMM paths, TopK calls, copies,
+allocations, and buffer lookups. Profiling is disabled by default.
+
+## `CT2_MPS_LOG_GEMM`
+
+Log each MPS GEMM shape, transpose and stride configuration, and selected
+execution path. This option is intended for debugging and benchmarking.
+
+## `CT2_MPS_LOG_SYNC`
+
+Log each MPS synchronization together with its reason and host-visible byte
+count.
+
+## `CT2_MPS_USE_GEMV`
+
+Enable the specialized MPS batch-size-1 GEMV path (default). Set to `0` to
+force the general GEMM path for correctness comparisons or benchmarking.
+
+## `CT2_MPS_USE_TOPK`
+
+Enable the MPS GPU TopK path (default). Set to `0` to use the fallback path for
+debugging or performance comparisons.
+
 ## `CT2_FORCE_CPU_ISA`
 
 Force CTranslate2 to select a specific instruction set architecture (ISA). Possible values are:

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -101,6 +101,17 @@ force the general GEMM path for correctness comparisons or benchmarking.
 Enable the MPS GPU TopK path (default). Set to `0` to use the fallback path for
 debugging or performance comparisons.
 
+## `CT2_MPS_CACHE_INT8_FP16`
+
+Expand INT8 Dense weights to FP16 once on first use so that warm MPS inference
+can use the optimized FP16 matrix kernels without dynamically quantizing every
+activation. This optimization is enabled by default for `int8` and
+`int8_float16` models. Set it to `0` to keep weights compressed in device
+memory and use the lower-memory weight-only INT8 path instead.
+
+The cache does not change the on-disk model size, but its resident memory usage
+is similar to an FP16 model after all Dense layers have run.
+
 ## `CT2_FORCE_CPU_ISA`
 
 Force CTranslate2 to select a specific instruction set architecture (ISA). Possible values are:

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -103,14 +103,14 @@ debugging or performance comparisons.
 
 ## `CT2_MPS_CACHE_INT8_FP16`
 
-Expand INT8 Dense weights to FP16 once on first use so that warm MPS inference
-can use the optimized FP16 matrix kernels without dynamically quantizing every
-activation. This optimization is enabled by default for `int8` and
-`int8_float16` models. Set it to `0` to keep weights compressed in device
-memory and use the lower-memory weight-only INT8 path instead.
+Resolve `int8` and `int8_float16` requests on MPS to the faster and more stable
+FP16 execution path (default). Stored INT8 weights are expanded once while the
+model is loaded; the compressed device allocation is not retained.
 
-The cache does not change the on-disk model size, but its resident memory usage
-is similar to an FP16 model after all Dense layers have run.
+Set this variable to `0` to explicitly keep weights compressed and use the
+experimental native MPS INT8 path. This reduces model memory, but can be slower
+than FP16 and may produce different decoding decisions because activations are
+quantized at runtime.
 
 ## `CT2_FORCE_CPU_ISA`
 

--- a/docs/hardware_support.md
+++ b/docs/hardware_support.md
@@ -17,6 +17,14 @@ See the [environment variables](environment_variables.md) `CT2_USE_MKL` and `CT2
 
 ## GPU
 
+### NVIDIA CUDA
+
 * NVIDIA GPUs with a Compute Capability greater or equal to 3.5
 
 The driver requirement depends on the CUDA version. See the [CUDA Compatibility guide](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for more information.
+
+### Apple Metal Performance Shaders
+
+The optional MPS backend supports Apple Silicon Macs. Build from source with
+`-DWITH_MPS=ON`, then select `device="mps"` in the C++ or Python API. The MPS
+backend cannot be enabled together with CUDA or HIP in the same build.

--- a/docs/hardware_support.md
+++ b/docs/hardware_support.md
@@ -25,6 +25,16 @@ The driver requirement depends on the CUDA version. See the [CUDA Compatibility 
 
 ### Apple Metal Performance Shaders
 
-The optional MPS backend supports Apple Silicon Macs. Build from source with
-`-DWITH_MPS=ON`, then select `device="mps"` in the C++ or Python API. The MPS
-backend cannot be enabled together with CUDA or HIP in the same build.
+The experimental MPS backend supports Apple Silicon Macs running macOS 11 or
+newer. It is not included in the prebuilt Python wheels: build from source
+with `-DWITH_MPS=ON`, then select `device="mps"` in the C++ or Python API.
+
+The backend supports FP32, FP16, BF16, and signed INT8 computation with FP32,
+FP16, or BF16 non-quantized layers. FP16 is the recommended compute type and
+is selected by `compute_type="auto"`. See [Quantization](quantization.md) for
+the exact type conversions and [Installation](installation.md) for a build
+example.
+
+The MPS backend cannot be enabled together with CUDA or HIP in the same build.
+FlashAttention, AWQ INT4, INT16 GEMM, distributed collectives, and
+packed/shifted-u8 INT8 GEMM are not currently implemented on MPS.

--- a/docs/hardware_support.md
+++ b/docs/hardware_support.md
@@ -29,11 +29,13 @@ The experimental MPS backend supports Apple Silicon Macs running macOS 11 or
 newer. It is not included in the prebuilt Python wheels: build from source
 with `-DWITH_MPS=ON`, then select `device="mps"` in the C++ or Python API.
 
-The backend supports FP32, FP16, BF16, and signed INT8 computation with FP32,
-FP16, or BF16 non-quantized layers. FP16 is the recommended compute type and
-is selected by `compute_type="auto"`. See [Quantization](quantization.md) for
-the exact type conversions and [Installation](installation.md) for a build
-example.
+The backend supports FP32, FP16, BF16, and experimental signed INT8
+computation. FP16 is the recommended compute type and is selected by
+`compute_type="auto"`. Requests for `int8` and `int8_float16` also resolve to
+FP16 by default because native INT8 is slower on current Apple GPUs and can
+change decoding decisions. See [Quantization](quantization.md) for the native
+INT8 opt-in and exact type conversions, and [Installation](installation.md)
+for a build example.
 
 The MPS backend cannot be enabled together with CUDA or HIP in the same build.
 FlashAttention, AWQ INT4, INT16 GEMM, distributed collectives, and

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,6 +88,7 @@ pip install dist/*.whl
 If you installed the C++ library in a custom directory, you should configure additional environment variables:
 
 * When running `setup.py`, set `CTRANSLATE2_ROOT` to the CTranslate2 install directory.
+  On macOS, this also embeds that library directory in the Python extension runtime search path so it loads the matching `libctranslate2` instead of falling back to `/usr/local/lib`.
 * When running your Python application, add the CTranslate2 library path to `LD_LIBRARY_PATH`.
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -113,6 +113,7 @@ The following options can be set with `-DOPTION=VALUE` during the CMake configur
 | WITH_DNNL | **OFF**, ON | Compiles with the oneDNN backend (a.k.a. DNNL) |
 | WITH_MKL | OFF, **ON** | Compiles with the Intel MKL backend |
 | WITH_ACCELERATE | **OFF**, ON | Compiles with the Apple Accelerate backend |
+| WITH_MPS | **OFF**, ON | Compiles the experimental Apple Metal/MPS backend |
 | WITH_OPENBLAS | **OFF**, ON | Compiles with the OpenBLAS backend |
 | WITH_RUY | **OFF**, ON | Compiles with the Ruy backend |
 | WITH_HIP | **OFF**, ON | Compiles with the AMD HIP GPU backend |
@@ -124,6 +125,7 @@ Some build options require additional dependencies. See their respective documen
 * `-DWITH_MKL=ON` requires [Intel MKL](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) >= 2019.5
 * `-DWITH_DNNL=ON` requires [oneDNN](https://github.com/oneapi-src/oneDNN) >= 3.0
 * `-DWITH_ACCELERATE=ON` requires [Accelerate](https://developer.apple.com/documentation/accelerate)
+* `-DWITH_MPS=ON` requires an Apple Silicon Mac with the Metal and Metal Performance Shaders frameworks
 * `-DWITH_OPENBLAS=ON` requires [OpenBLAS](https://github.com/xianyi/OpenBLAS)
 * `-DWITH_HIP=ON` requires [ROCm libraries](https://rocm.docs.amd.com/en/latest/reference/api-libraries.html)
 
@@ -132,3 +134,20 @@ Multiple backends can be enabled for a single build, for example:
 * `-DWITH_MKL=ON -DWITH_CUDA=ON`: enable CPU and GPU support
 * `-DWITH_MKL=ON -DWITH_DNNL=ON`: during runtime, the library will select Intel MKL when running on Intel and oneDNN when running on AMD
 * `-DWITH_OPENBLAS=ON -DWITH_RUY=ON`: use Ruy for quantized models and OpenBLAS for non quantized models
+
+To build a native Release library with CPU and MPS execution on Apple Silicon:
+
+```bash
+cmake -S . -B build-mps \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DWITH_MPS=ON \
+  -DWITH_ACCELERATE=ON \
+  -DWITH_MKL=OFF \
+  -DOPENMP_RUNTIME=NONE
+cmake --build build-mps -j
+cmake --install build-mps --prefix install-mps
+```
+
+`WITH_MPS` cannot be combined with `WITH_CUDA` or `WITH_HIP` in the same
+build. See [Hardware support](hardware_support.md) for current backend
+limitations.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -140,9 +140,11 @@ To build a native Release library with CPU and MPS execution on Apple Silicon:
 ```bash
 cmake -S . -B build-mps \
   -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
   -DWITH_MPS=ON \
   -DWITH_ACCELERATE=ON \
   -DWITH_MKL=OFF \
+  -DWITH_RUY=ON \
   -DOPENMP_RUNTIME=NONE
 cmake --build build-mps -j
 cmake --install build-mps --prefix install-mps

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -87,7 +87,7 @@ By default, the runtime tries to use the type that is saved in the converted mod
 | AArch64/ARM64 (Apple) | int8_float32 | int8_float32 | int8_float32 | int8_float32 | float32 | float32 |
 | AArch64/ARM64 (other) | int8_float32 | int8_float32 | int8_float32 | int8_float32 | float32 | float32 |
 
-**On GPU:**
+**On NVIDIA GPU:**
 
 | Compute Capability | int8_float32 | int8_float16 | int8_bfloat16 | int16 | float16 | bfloat16 |
 | --- | --- | --- | --- | --- | --- | -- |
@@ -96,6 +96,17 @@ By default, the runtime tries to use the type that is saved in the converted mod
 | 6.2 | float32 | float32 | float32 | float32 | float32 | float32 |
 | 6.1 | int8_float32 | int8_float32 | int8_float32 | float32 | float32 | float32 |
 | <= 6.0 | float32 | float32 | float32 | float32 | float32 | float32 |
+
+**On Apple MPS:**
+
+| Device | int8_float32 | int8_float16 | int8_bfloat16 | int16 | float16 | bfloat16 |
+| --- | --- | --- | --- | --- | --- | --- |
+| Apple Silicon GPU | int8_float32 | int8_float16 | int8_bfloat16 | float16 | float16 | bfloat16 |
+
+MPS `compute_type="auto"` selects `float16`. The explicit INT8 hybrid modes
+remain available when reduced model weight size or INT8 compatibility is more
+important than latency. On Apple GPUs, INT8 is not guaranteed to outperform
+FP16, especially for batch-size-1 autoregressive decoding.
 
 ```{tip}
 You can get more information about the detected capabilities of your system by enabling the info logs (set the environment variable `CT2_VERBOSE=1` or call ``ctranslate2.set_log_level(logging.INFO)``).
@@ -110,6 +121,7 @@ The supported compute types can also be queried at runtime with the Python funct
 **Supported on:**
 
 * NVIDIA GPU with Compute Capability >= 7.0 or Compute Capability 6.1
+* Apple Silicon GPU with the MPS backend
 * x86-64 CPU with the Intel MKL or oneDNN backends
 * AArch64/ARM64 CPU with the Ruy backend
 
@@ -130,6 +142,10 @@ Non quantized layers are run in the floating point precision of the original mod
 * `int8_float32`
 * `int8_float16`
 * `int8_bfloat16`
+
+On MPS, activations are quantized per row to signed INT8, matrix products
+accumulate in INT32, and the output is dequantized with optional bias and
+activation fusion. Packed and shifted-u8 INT8 matrices are not yet supported.
 
 ### 16-bit integers (`int16`)
 
@@ -152,6 +168,7 @@ Similar to the `int8` quantization, only the weights of the embedding and linear
 **Supported on:**
 
 * NVIDIA GPU with Compute Capability >= 7.0
+* Apple Silicon GPU with the MPS backend
 
 In this mode, all model weights are stored in half precision and all layers are run in half precision.
 
@@ -160,8 +177,12 @@ In this mode, all model weights are stored in half precision and all layers are 
 **Supported on:**
 
 * NVIDIA GPU with Compute Capability >= 8.0
+* Apple Silicon GPU with the MPS backend
 
-In this mode, all model weights are stored in BF16 and all layers are run with this type.
+In this mode, all model weights are stored in BF16 and all layers are run with
+this type. The MPS implementation stores BF16-encoded values and converts them
+to FP32 for GEMM and reduction accumulation before rounding results back to
+BF16.
 
 ### 4-bit AWQ
 
@@ -169,7 +190,8 @@ In this mode, all model weights are stored in BF16 and all layers are run with t
 
 * NVIDIA GPU with Compute Capability >= 7.5
 
-CTranslate2 internally handles the compute type for AWQ quantization.
+CTranslate2 internally handles the compute type for AWQ quantization. AWQ is
+not currently supported by the MPS backend.
 In this mode, all model weights are stored in half precision and all layers are run in half precision. Other parameters like scale and zero are stored in ``int32``.
 
 **Steps to use AWQ Quantization:**

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -101,12 +101,13 @@ By default, the runtime tries to use the type that is saved in the converted mod
 
 | Device | int8_float32 | int8_float16 | int8_bfloat16 | int16 | float16 | bfloat16 |
 | --- | --- | --- | --- | --- | --- | --- |
-| Apple Silicon GPU | int8_float32 | int8_float16 | int8_bfloat16 | float16 | float16 | bfloat16 |
+| Apple Silicon GPU | int8_float32 | float16 | int8_bfloat16 | float16 | float16 | bfloat16 |
 
-MPS `compute_type="auto"` selects `float16`. The explicit INT8 hybrid modes
-remain available when reduced model weight size or INT8 compatibility is more
-important than latency. On Apple GPUs, INT8 is not guaranteed to outperform
-FP16, especially for batch-size-1 autoregressive decoding.
+MPS `compute_type="auto"`, `int8`, and `int8_float16` select `float16` by
+default. Native INT8 is currently slower than FP16 on Apple GPUs and runtime
+activation quantization can change autoregressive decoding decisions. Set
+`CT2_MPS_CACHE_INT8_FP16=0` to explicitly enable the lower-memory experimental
+INT8 path; in that mode `int8` resolves to `int8_float16`.
 
 ```{tip}
 You can get more information about the detected capabilities of your system by enabling the info logs (set the environment variable `CT2_VERBOSE=1` or call ``ctranslate2.set_log_level(logging.INFO)``).
@@ -143,9 +144,10 @@ Non quantized layers are run in the floating point precision of the original mod
 * `int8_float16`
 * `int8_bfloat16`
 
-On MPS, activations are quantized per row to signed INT8, matrix products
-accumulate in INT32, and the output is dequantized with optional bias and
-activation fusion. Packed and shifted-u8 INT8 matrices are not yet supported.
+In the experimental native MPS mode, activations are quantized per row to
+signed INT8, matrix products accumulate in INT32, and the output is
+dequantized with optional bias and activation fusion. Packed and shifted-u8
+INT8 matrices are not yet supported.
 
 ### 16-bit integers (`int16`)
 

--- a/include/ctranslate2/devices.h
+++ b/include/ctranslate2/devices.h
@@ -12,7 +12,8 @@ namespace ctranslate2 {
 
   enum class Device {
     CPU,
-    CUDA
+    CUDA,
+    MPS
   };
 
   Device str_to_device(const std::string& device);

--- a/include/ctranslate2/layers/attention.h
+++ b/include/ctranslate2/layers/attention.h
@@ -76,7 +76,9 @@ namespace ctranslate2 {
                                 StorageView* cached_values,
                                 const Padder* queries_padder,
                                 const Padder* values_padder,
-                                dim_t& beam_size) const;
+                                dim_t& beam_size,
+                                bool use_interleaved_beam_layout = false,
+                                bool* interleaved_beam_layout = nullptr) const;
 
     private:
       static void split_heads(StorageView& x,

--- a/include/ctranslate2/layers/common.h
+++ b/include/ctranslate2/layers/common.h
@@ -50,6 +50,8 @@ namespace ctranslate2 {
       virtual dim_t output_size() const = 0;
     };
 
+    class LayerNorm;
+
     class Embeddings : public Layer
     {
     public:
@@ -132,6 +134,10 @@ namespace ctranslate2 {
       DataType output_type() const override;
       dim_t output_size() const override;
       void operator()(const StorageView& input, StorageView& output, const StorageView* residual = nullptr) const;
+      void forward_with_post_layer_norm(const StorageView& input,
+                                        const StorageView& residual,
+                                        const LayerNorm& layer_norm,
+                                        StorageView& output) const;
       void select_weights(const StorageView* index, const StorageView* extra_bias = nullptr);
     private:
       bool _packed_weight;
@@ -144,6 +150,9 @@ namespace ctranslate2 {
       StorageView _partial_bias;
       StorageView _partial_qscale;
       StorageView _partial_u8_shift_compensation;
+      // MPS expands INT8 weights once to FP16 so warm execution can use the
+      // optimized SIMD-group FP16 kernels without per-token conversion.
+      mutable StorageView _mps_float16_weight;
       const DataType _output_type;
       const models::QUANTIZATION_TYPE _quant_method;
       const bool _quantized_gemm;
@@ -161,6 +170,10 @@ namespace ctranslate2 {
       DataType output_type() const override;
       dim_t output_size() const override;
       void operator()(const StorageView& input, StorageView& output) const;
+      bool apply_fused_bias_residual(const StorageView& input,
+                                     const StorageView& bias,
+                                     const StorageView& residual,
+                                     StorageView& output) const;
     private:
       const StorageView* _beta;
       const StorageView& _gamma;

--- a/include/ctranslate2/layers/common.h
+++ b/include/ctranslate2/layers/common.h
@@ -150,9 +150,6 @@ namespace ctranslate2 {
       StorageView _partial_bias;
       StorageView _partial_qscale;
       StorageView _partial_u8_shift_compensation;
-      // MPS expands INT8 weights once to FP16 so warm execution can use the
-      // optimized SIMD-group FP16 kernels without per-token conversion.
-      mutable StorageView _mps_float16_weight;
       const DataType _output_type;
       const models::QUANTIZATION_TYPE _quant_method;
       const bool _quantized_gemm;

--- a/python/cpp/module.cc
+++ b/python/cpp/module.cc
@@ -56,6 +56,11 @@ PYBIND11_MODULE(_ext, m)
   m.def("get_cuda_device_count", &ctranslate2::get_gpu_count,
         "Returns the number of visible GPU devices.");
 
+  m.def("get_mps_device_count", []() {
+          return ctranslate2::get_device_count(ctranslate2::Device::MPS);
+        },
+        "Returns the number of MPS devices (1 on Apple Silicon).");
+
   m.def("get_supported_compute_types", &get_supported_compute_types,
         py::arg("device"),
         py::arg("device_index")=0,
@@ -63,7 +68,7 @@ PYBIND11_MODULE(_ext, m)
              Returns the set of supported compute types on a device.
 
              Arguments:
-               device: Device name (cpu or cuda).
+               device: Device name (cpu, cuda, or mps).
                device_index: Device index.
 
              Example:

--- a/python/cpp/storage_view.cc
+++ b/python/cpp/storage_view.cc
@@ -109,6 +109,7 @@ namespace ctranslate2 {
       py::enum_<Device>(m, "Device")
         .value("cpu", Device::CPU)
         .value("cuda", Device::CUDA)
+        .value("mps", Device::MPS)
         ;
 
       py::class_<StorageView>(
@@ -170,7 +171,7 @@ namespace ctranslate2 {
                                [](const StorageView& view) {
                                  return device_to_str(view.device());
                                },
-                               "Device where the storage is allocated (\"cpu\" or \"cuda\").")
+                               "Device where the storage is allocated (\"cpu\", \"cuda\", or \"mps\").")
 
         .def_property_readonly("__array_interface__", [](const StorageView& view) {
           if (view.device() == Device::CUDA)

--- a/python/ctranslate2/__init__.py
+++ b/python/ctranslate2/__init__.py
@@ -43,6 +43,10 @@ try:
         get_supported_compute_types,
         set_random_seed,
     )
+    try:
+        from ctranslate2._ext import get_mps_device_count
+    except ImportError:
+        pass
     from ctranslate2.extensions import register_extensions
     from ctranslate2.logging import get_log_level, set_log_level
 

--- a/python/ctranslate2/__init__.py
+++ b/python/ctranslate2/__init__.py
@@ -43,6 +43,7 @@ try:
         get_supported_compute_types,
         set_random_seed,
     )
+
     try:
         from ctranslate2._ext import get_mps_device_count
     except ImportError:

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,6 +10,14 @@ from setuptools import Extension, find_packages, setup
 base_dir = os.path.dirname(os.path.abspath(__file__))
 include_dirs = [pybind11.get_include()]
 library_dirs = []
+library_rpaths = []
+
+
+def _add_library_dir(path):
+    if path not in library_dirs:
+        library_dirs.append(path)
+    if path not in library_rpaths:
+        library_rpaths.append(path)
 
 
 def _get_long_description():
@@ -35,7 +43,7 @@ def _maybe_add_library_root(lib_name):
         for lib_dir in ("lib", "lib64"):
             path = "%s/%s" % (root, lib_dir)
             if os.path.exists(path):
-                library_dirs.append(path)
+                _add_library_dir(path)
                 break
 
 
@@ -47,12 +55,16 @@ package_data = {}
 if sys.platform == "darwin":
     # std::visit requires macOS 10.14
     cflags.append("-mmacosx-version-min=10.14")
+    for path in library_rpaths:
+        ldflags.append("-Wl,-rpath,%s" % path)
     ldflags.append("-Wl,-rpath,/usr/local/lib")
 elif sys.platform == "win32":
     cflags = ["/std:c++17", "/d2FH4-"]
     package_data["ctranslate2"] = ["*.dll"]
 elif sys.platform == "linux":
     cflags.append("-fPIC")
+    for path in library_rpaths:
+        ldflags.append("-Wl,-rpath,%s" % path)
     ldflags.append("-Wl,-rpath,/usr/local/lib64:/usr/local/lib")
 
 ctranslate2_module = Extension(

--- a/python/tests/test_mps.py
+++ b/python/tests/test_mps.py
@@ -1,0 +1,50 @@
+import os
+
+import pytest
+
+import ctranslate2
+
+
+def _require_mps():
+    if os.environ.get("CT2_TEST_MPS") != "1":
+        pytest.skip("Set CT2_TEST_MPS=1 to run tests on a real Metal device")
+
+    assert hasattr(ctranslate2, "get_mps_device_count")
+    assert ctranslate2.get_mps_device_count() > 0
+
+
+def _get_model_path():
+    return os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "tests",
+        "data",
+        "models",
+        "v2",
+        "aren-transliteration",
+    )
+
+
+def test_mps_is_explicit_opt_in():
+    _require_mps()
+
+    translator = ctranslate2.Translator(_get_model_path(), device="auto")
+    assert translator.device == "cpu"
+
+
+def test_mps_float16_translation_matches_cpu():
+    _require_mps()
+
+    source = [["آ", "ت", "ز", "م", "و", "ن"]]
+    options = dict(beam_size=1, max_decoding_length=12)
+    cpu = ctranslate2.Translator(
+        _get_model_path(), device="cpu", compute_type="float32"
+    )
+    mps = ctranslate2.Translator(
+        _get_model_path(), device="mps", compute_type="float16"
+    )
+
+    expected = cpu.translate_batch(source, **options)[0].hypotheses[0]
+    output = mps.translate_batch(source, **options)[0].hypotheses[0]
+    assert output == expected

--- a/python/tests/test_mps.py
+++ b/python/tests/test_mps.py
@@ -26,6 +26,19 @@ def _get_model_path():
     )
 
 
+def _get_int8_model_path():
+    return os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "tests",
+        "data",
+        "models",
+        "v2",
+        "aren-transliteration-i8",
+    )
+
+
 def test_mps_is_explicit_opt_in():
     _require_mps()
 
@@ -48,3 +61,38 @@ def test_mps_float16_translation_matches_cpu():
     expected = cpu.translate_batch(source, **options)[0].hypotheses[0]
     output = mps.translate_batch(source, **options)[0].hypotheses[0]
     assert output == expected
+
+
+@pytest.mark.parametrize("requested_compute_type", ["int8", "int8_float16"])
+def test_mps_int8_requests_use_float16_path(requested_compute_type, monkeypatch):
+    _require_mps()
+    monkeypatch.delenv("CT2_MPS_CACHE_INT8_FP16", raising=False)
+
+    source = [["آ", "ت", "ز", "م", "و", "ن"]]
+    options = dict(beam_size=1, max_decoding_length=12)
+    float16 = ctranslate2.Translator(
+        _get_model_path(), device="mps", compute_type="float16"
+    )
+    requested = ctranslate2.Translator(
+        _get_model_path(), device="mps", compute_type=requested_compute_type
+    )
+
+    assert requested.compute_type == "float16"
+    expected = float16.translate_batch(source, **options)[0].hypotheses[0]
+    output = requested.translate_batch(source, **options)[0].hypotheses[0]
+    assert output == expected
+
+
+def test_mps_stored_int8_model_is_converted_once(monkeypatch):
+    _require_mps()
+    monkeypatch.delenv("CT2_MPS_CACHE_INT8_FP16", raising=False)
+
+    translator = ctranslate2.Translator(
+        _get_int8_model_path(), device="mps", compute_type="int8"
+    )
+
+    assert translator.compute_type == "float16"
+    result = translator.translate_batch(
+        [["آ", "ت", "ز", "م", "و", "ن"]], beam_size=1, max_decoding_length=12
+    )[0]
+    assert result.hypotheses[0] == ["a", "t", "z", "m", "o", "n"]

--- a/python/tools/prepare_build_environment_windows_rocm.sh
+++ b/python/tools/prepare_build_environment_windows_rocm.sh
@@ -25,7 +25,7 @@ export PYTORCH_ROCM_ARCH="gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx120
 if [ ! -d "C:/Program Files (x86)/Intel/oneAPI" ]; then
     curl --netrc-optional -L -nv -o webimage.exe https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1f18901e-877d-469d-a41a-a10f11b39336/intel-oneapi-base-toolkit-2025.3.0.372_offline.exe
     ./webimage.exe -s -x -f webimage_extracted --log extract.log
-    rm webimage.exe
+    rm -f webimage.exe || true
     ./webimage_extracted/bootstrapper.exe -s --action install --components="intel.oneapi.win.mkl.devel" --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 --log-dir=.
 fi
 

--- a/src/decoding.cc
+++ b/src/decoding.cc
@@ -2,11 +2,16 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <memory>
 #include <numeric>
 
 #include "ctranslate2/ops/ops.h"
 #include "dispatch.h"
+
+#ifdef CT2_WITH_MPS
+#  include "mps/kernels.h"
+#endif
 
 namespace ctranslate2 {
 
@@ -533,8 +538,49 @@ namespace ctranslate2 {
           logits_vec = build_logits(logits, cur_batch_size);
       }
 
+      bool used_fused_beam_search = false;
+#ifdef CT2_WITH_MPS
+      static const bool use_fused_beam_search = []() {
+        const char* value = std::getenv("CT2_MPS_USE_FUSED_BEAM_SEARCH");
+        return value && value[0] != '\0' && value[0] != '0';
+      }();
+      if (use_fused_beam_search
+          && device == Device::MPS
+          && dtype == DataType::FLOAT16
+          && is_expanded
+          && !bias_towards_prefix
+          && dynamic_cast<const BestSampler*>(&sampler)
+          && num_candidates <= 16
+          && topk_scores) {
+        StorageView beam_scores_device = topk_scores.to(device);
+        StorageView sampled_ids_device({cur_batch_size, num_candidates},
+                                       DataType::INT32,
+                                       device);
+        StorageView sampled_scores_device({cur_batch_size, num_candidates},
+                                          dtype,
+                                          device);
+        used_fused_beam_search = mps::fused_beam_search_topk(
+          dtype,
+          logits.data<float16_t>(),
+          beam_scores_device.data<float16_t>(),
+          sampled_scores_device.data<float16_t>(),
+          sampled_ids_device.data<int32_t>(),
+          cur_batch_size,
+          _beam_size,
+          vocabulary_size,
+          num_candidates);
+        if (used_fused_beam_search) {
+          topk_ids.copy_from(sampled_ids_device);
+          topk_scores.copy_from(sampled_scores_device);
+        }
+      }
+#endif
+
       StorageView log_probs(dtype, device);
-      if (bias_towards_prefix) {
+      if (used_fused_beam_search) {
+        // The fused kernel already applied log-softmax, previous beam scores,
+        // flattening, and deterministic TopK selection.
+      } else if (bias_towards_prefix) {
         biased_decoder->decode(cur_batch_size,
                                step,
                                batch_offset,
@@ -547,7 +593,7 @@ namespace ctranslate2 {
       }
 
       // Multiply by the current beam log probs.
-      if (topk_scores) {
+      if (!used_fused_beam_search && topk_scores) {
         DEVICE_AND_TYPE_DISPATCH(log_probs.device(), log_probs.dtype(),
                                  primitives<D>::add_depth_broadcast(topk_scores.to(device).data<T>(),
                                                                     log_probs.data<T>(),
@@ -556,10 +602,12 @@ namespace ctranslate2 {
       }
 
       // Flatten the probs into a list of candidates.
-      log_probs.reshape({cur_batch_size, -1});
+      if (!used_fused_beam_search)
+        log_probs.reshape({cur_batch_size, -1});
 
       // TopK candidates.
-      sampler(log_probs, topk_ids, topk_scores, num_candidates);
+      if (!used_fused_beam_search)
+        sampler(log_probs, topk_ids, topk_scores, num_candidates);
 
       // Unflatten the ids.
       StorageView gather_indices = unflatten_ids(topk_ids, _beam_size, vocabulary_size, is_expanded);

--- a/src/device_dispatch.h
+++ b/src/device_dispatch.h
@@ -18,16 +18,32 @@
   }
 
 #define SINGLE_ARG(...) __VA_ARGS__
-#ifndef CT2_WITH_CUDA
+#if defined(CT2_WITH_CUDA) && defined(CT2_WITH_MPS)
+#  define DEVICE_DISPATCH(DEVICE, STMTS)                \
+  switch (DEVICE) {                                     \
+    DEVICE_CASE(Device::CUDA, SINGLE_ARG(STMTS))        \
+    DEVICE_CASE(Device::MPS, SINGLE_ARG(STMTS))         \
+    DEVICE_CASE(Device::CPU, SINGLE_ARG(STMTS))         \
+  }
+#elif defined(CT2_WITH_MPS)
 #  define DEVICE_DISPATCH(DEVICE, STMTS)                \
   switch (DEVICE) {                                     \
     UNSUPPORTED_DEVICE_CASE(Device::CUDA)               \
+    DEVICE_CASE(Device::MPS, SINGLE_ARG(STMTS))         \
+    DEVICE_CASE(Device::CPU, SINGLE_ARG(STMTS))         \
+  }
+#elif defined(CT2_WITH_CUDA)
+#  define DEVICE_DISPATCH(DEVICE, STMTS)                \
+  switch (DEVICE) {                                     \
+    DEVICE_CASE(Device::CUDA, SINGLE_ARG(STMTS))        \
+    UNSUPPORTED_DEVICE_CASE(Device::MPS)                \
     DEVICE_CASE(Device::CPU, SINGLE_ARG(STMTS))         \
   }
 #else
 #  define DEVICE_DISPATCH(DEVICE, STMTS)                \
   switch (DEVICE) {                                     \
-    DEVICE_CASE(Device::CUDA, SINGLE_ARG(STMTS))        \
+    UNSUPPORTED_DEVICE_CASE(Device::CUDA)               \
+    UNSUPPORTED_DEVICE_CASE(Device::MPS)                \
     DEVICE_CASE(Device::CPU, SINGLE_ARG(STMTS))         \
   }
 #endif

--- a/src/device_dispatch.h
+++ b/src/device_dispatch.h
@@ -25,6 +25,12 @@
     DEVICE_CASE(Device::MPS, SINGLE_ARG(STMTS))         \
     DEVICE_CASE(Device::CPU, SINGLE_ARG(STMTS))         \
   }
+#  define GPU_DEVICE_DISPATCH(DEVICE, STMTS)            \
+  switch (DEVICE) {                                     \
+    DEVICE_CASE(Device::CUDA, SINGLE_ARG(STMTS))        \
+    DEVICE_CASE(Device::MPS, SINGLE_ARG(STMTS))         \
+    UNSUPPORTED_DEVICE_CASE(Device::CPU)                \
+  }
 #elif defined(CT2_WITH_MPS)
 #  define DEVICE_DISPATCH(DEVICE, STMTS)                \
   switch (DEVICE) {                                     \
@@ -32,12 +38,24 @@
     DEVICE_CASE(Device::MPS, SINGLE_ARG(STMTS))         \
     DEVICE_CASE(Device::CPU, SINGLE_ARG(STMTS))         \
   }
+#  define GPU_DEVICE_DISPATCH(DEVICE, STMTS)            \
+  switch (DEVICE) {                                     \
+    UNSUPPORTED_DEVICE_CASE(Device::CUDA)               \
+    DEVICE_CASE(Device::MPS, SINGLE_ARG(STMTS))         \
+    UNSUPPORTED_DEVICE_CASE(Device::CPU)                \
+  }
 #elif defined(CT2_WITH_CUDA)
 #  define DEVICE_DISPATCH(DEVICE, STMTS)                \
   switch (DEVICE) {                                     \
     DEVICE_CASE(Device::CUDA, SINGLE_ARG(STMTS))        \
     UNSUPPORTED_DEVICE_CASE(Device::MPS)                \
     DEVICE_CASE(Device::CPU, SINGLE_ARG(STMTS))         \
+  }
+#  define GPU_DEVICE_DISPATCH(DEVICE, STMTS)            \
+  switch (DEVICE) {                                     \
+    DEVICE_CASE(Device::CUDA, SINGLE_ARG(STMTS))        \
+    UNSUPPORTED_DEVICE_CASE(Device::MPS)                \
+    UNSUPPORTED_DEVICE_CASE(Device::CPU)                \
   }
 #else
 #  define DEVICE_DISPATCH(DEVICE, STMTS)                \

--- a/src/devices.cc
+++ b/src/devices.cc
@@ -4,6 +4,9 @@
 #  include "cuda/utils.h"
 #  include "cuda/random.h"
 #endif
+#ifdef CT2_WITH_MPS
+#  include "mps/utils.h"
+#endif
 #ifdef CT2_WITH_TENSOR_PARALLEL
 #  include <unistd.h>
 #endif
@@ -21,12 +24,23 @@ namespace ctranslate2 {
 #endif
     if (device == "cpu" || device == "CPU")
       return Device::CPU;
-    if (device == "auto" || device == "AUTO")
-#ifdef CT2_WITH_CUDA
-      return cuda::has_gpu() ? Device::CUDA : Device::CPU;
+    if (device == "mps" || device == "MPS")
+#ifdef CT2_WITH_MPS
+      return Device::MPS;
 #else
-      return Device::CPU;
+      throw std::invalid_argument("This CTranslate2 package was not compiled with MPS support");
 #endif
+    if (device == "auto" || device == "AUTO") {
+#ifdef CT2_WITH_CUDA
+      if (cuda::has_gpu())
+        return Device::CUDA;
+#endif
+#ifdef CT2_WITH_MPS
+      if (mps::has_mps())
+        return Device::MPS;
+#endif
+      return Device::CPU;
+    }
     throw std::invalid_argument("unsupported device " + device);
   }
 
@@ -36,6 +50,8 @@ namespace ctranslate2 {
       return "cuda";
     case Device::CPU:
       return "cpu";
+    case Device::MPS:
+      return "mps";
     }
     return "";
   }
@@ -54,6 +70,12 @@ namespace ctranslate2 {
 #endif
     case Device::CPU:
       return 1;
+    case Device::MPS:
+#ifdef CT2_WITH_MPS
+      return mps::get_device_count();
+#else
+      return 0;
+#endif
     }
     return 0;
   }
@@ -88,6 +110,18 @@ namespace ctranslate2 {
   }
 #endif
 
+#ifdef CT2_WITH_MPS
+  template<>
+  int get_device_index<Device::MPS>() {
+    return mps::get_device_index();
+  }
+
+  template<>
+  void set_device_index<Device::MPS>(int index) {
+    mps::set_device_index(index);
+  }
+#endif
+
   int get_device_index(Device device) {
     int index = 0;
     DEVICE_DISPATCH(device, index = get_device_index<D>());
@@ -104,7 +138,14 @@ namespace ctranslate2 {
       const ScopedDeviceSetter scoped_device_setter(device, index);
       cudaDeviceSynchronize();
     }
-#else
+#endif
+#ifdef CT2_WITH_MPS
+    if (device == Device::MPS) {
+      const ScopedDeviceSetter scoped_device_setter(device, index);
+      mps::synchronize();
+    }
+#endif
+#if !defined(CT2_WITH_CUDA) && !defined(CT2_WITH_MPS)
     (void)device;
     (void)index;
 #endif
@@ -115,17 +156,22 @@ namespace ctranslate2 {
     if (device == Device::CUDA) {
       cudaStreamSynchronize(cuda::get_cuda_stream());
     }
-#else
+#endif
+#ifdef CT2_WITH_MPS
+    if (device == Device::MPS)
+      mps::synchronize();
+#endif
+#if !defined(CT2_WITH_CUDA) && !defined(CT2_WITH_MPS)
     (void)device;
 #endif
   }
 
   void destroy_context(Device device) {
 #ifdef CT2_WITH_CUDA
-      if (device == Device::CUDA) {
-          cuda::free_curand_states();
-      }
-#else
+    if (device == Device::CUDA)
+      cuda::free_curand_states();
+#endif
+#ifndef CT2_WITH_CUDA
       (void)device;
 #endif
   }

--- a/src/devices.cc
+++ b/src/devices.cc
@@ -35,10 +35,9 @@ namespace ctranslate2 {
       if (cuda::has_gpu())
         return Device::CUDA;
 #endif
-#ifdef CT2_WITH_MPS
-      if (mps::has_mps())
-        return Device::MPS;
-#endif
+      // MPS is experimental and remains an explicit opt-in backend.  In
+      // particular, compiling with CT2_WITH_MPS must not change the behavior
+      // of existing applications that use device="auto".
       return Device::CPU;
     }
     throw std::invalid_argument("unsupported device " + device);

--- a/src/dispatch.h
+++ b/src/dispatch.h
@@ -12,7 +12,7 @@
     throw std::invalid_argument(NAME " only supports float types");     \
 
 
-#ifndef CT2_WITH_CUDA
+#if !defined(CT2_WITH_CUDA) && !defined(CT2_WITH_MPS)
 
 #  define DEVICE_AND_FLOAT_DISPATCH(NAME, DEVICE, TYPE, STMTS)          \
   switch (TYPE) {                                                       \
@@ -26,16 +26,14 @@
   switch (TYPE) {                                                       \
     TYPE_CASE(float, DEVICE_DISPATCH(DEVICE, (STMTS)))                  \
     TYPE_CASE(float16_t, {                                              \
-      if (DEVICE != Device::CUDA)                                       \
+      if (DEVICE != Device::CUDA && DEVICE != Device::MPS)              \
         throw std::invalid_argument("FP16 " NAME " is only supported on GPU"); \
-      constexpr Device D = Device::CUDA;                                \
-      (STMTS);                                                          \
+      DEVICE_DISPATCH(DEVICE, (STMTS));                                 \
     })                                                                  \
     TYPE_CASE(bfloat16_t, {                                             \
-      if (DEVICE != Device::CUDA)                                       \
+      if (DEVICE != Device::CUDA && DEVICE != Device::MPS)              \
         throw std::invalid_argument("BF16 " NAME " is only supported on GPU"); \
-      constexpr Device D = Device::CUDA;                                \
-      (STMTS);                                                          \
+      DEVICE_DISPATCH(DEVICE, (STMTS));                                 \
     })                                                                  \
     NON_FLOAT_CASE(NAME)                                                \
   }

--- a/src/dispatch.h
+++ b/src/dispatch.h
@@ -28,12 +28,12 @@
     TYPE_CASE(float16_t, {                                              \
       if (DEVICE != Device::CUDA && DEVICE != Device::MPS)              \
         throw std::invalid_argument("FP16 " NAME " is only supported on GPU"); \
-      DEVICE_DISPATCH(DEVICE, (STMTS));                                 \
+      GPU_DEVICE_DISPATCH(DEVICE, (STMTS));                             \
     })                                                                  \
     TYPE_CASE(bfloat16_t, {                                             \
       if (DEVICE != Device::CUDA && DEVICE != Device::MPS)              \
         throw std::invalid_argument("BF16 " NAME " is only supported on GPU"); \
-      DEVICE_DISPATCH(DEVICE, (STMTS));                                 \
+      GPU_DEVICE_DISPATCH(DEVICE, (STMTS));                             \
     })                                                                  \
     NON_FLOAT_CASE(NAME)                                                \
   }

--- a/src/layers/attention.cc
+++ b/src/layers/attention.cc
@@ -5,10 +5,15 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <numeric>
 
 #include "dispatch.h"
 #include "cpu/parallel.h"
+
+#ifdef CT2_WITH_MPS
+#  include "mps/kernels.h"
+#endif
 
 namespace ctranslate2 {
   namespace layers {
@@ -166,6 +171,16 @@ namespace ctranslate2 {
 
     static const ops::Transpose transpose_op({0, 2, 1, 3});
 
+#ifdef CT2_WITH_MPS
+    static bool mps_fused_attention_enabled() {
+      static const bool enabled = []() {
+        const char* value = std::getenv("CT2_MPS_USE_FUSED_ATTENTION");
+        return value && value[0] != '\0' && value[0] != '0';
+      }();
+      return enabled;
+    }
+#endif
+
     static inline void save_attention(StorageView& attention, StorageView weights, dim_t beam_size) {
       if (beam_size == 1)
         attention = std::move(weights);
@@ -194,8 +209,98 @@ namespace ctranslate2 {
                                       bool with_cache = false,
                                       dim_t beam_size = 1,
                                       Alibi* alibi = nullptr,
-                                      StorageView* position_bias = nullptr) {
+                                      StorageView* position_bias = nullptr,
+                                      bool interleaved_queries = false) {
       PROFILE("dot_product_attention");
+
+#ifdef CT2_WITH_MPS
+      // During beam decoding, split_heads represents beams as the query
+      // dimension. Fuse QK, softmax, and PV for this exact contiguous layout.
+      // Keep the path opt-in while it is benchmarked against the established
+      // implementation; CT2_MPS_USE_FUSED_ATTENTION=1 enables it.
+      const bool standard_layout = !interleaved_queries
+                                   && queries.rank() == 4
+                                   && keys.rank() == 4
+                                   && values.rank() == 4
+                                   && queries.dim(0) == keys.dim(0)
+                                   && queries.dim(0) == values.dim(0)
+                                   && queries.dim(1) == keys.dim(1)
+                                   && queries.dim(1) == values.dim(1)
+                                   && keys.dim(2) == values.dim(2)
+                                   && queries.dim(3) == keys.dim(3)
+                                   && queries.dim(3) == values.dim(3);
+      const bool interleaved_layout = interleaved_queries
+                                      && queries.rank() == 4
+                                      && keys.rank() == 4
+                                      && values.rank() == 4
+                                      && queries.dim(0) == keys.dim(0)
+                                      && queries.dim(0) == values.dim(0)
+                                      && queries.dim(2) == keys.dim(1)
+                                      && queries.dim(2) == values.dim(1)
+                                      && keys.dim(2) == values.dim(2)
+                                      && queries.dim(3) == keys.dim(3)
+                                      && queries.dim(3) == values.dim(3);
+      if (mps_fused_attention_enabled()
+          && queries.device() == Device::MPS
+          && queries.dtype() == DataType::FLOAT16
+          && (standard_layout || interleaved_layout)
+          && !relative_position_keys
+          && !relative_asymmetric_position_keys
+          && !relative_position_values
+          && !relative_attention_bias
+          && !alibi
+          && !attention) {
+        output.resize_as(queries);
+        const dim_t num_heads = interleaved_layout ? queries.dim(2) : queries.dim(1);
+        const dim_t query_length = interleaved_layout ? queries.dim(1) : queries.dim(2);
+        const dim_t matrix_batch = queries.dim(0) * num_heads;
+        if (mps::fused_attention(DataType::FLOAT16,
+                                 queries.data<float16_t>(),
+                                 keys.data<float16_t>(),
+                                 values.data<float16_t>(),
+                                 values_lengths ? values_lengths->data<int32_t>() : nullptr,
+                                 output.data<float16_t>(),
+                                 matrix_batch,
+                                 query_length,
+                                 keys.dim(2),
+                                 queries.dim(3),
+                                 queries_scale,
+                                 interleaved_layout ? num_heads : 0))
+          return;
+      }
+#endif
+
+      // The interleaved layout is only selected for the fused MPS path. Keep a
+      // correct generic fallback if a future model shape falls outside the
+      // specialized kernel's limits.
+      if (interleaved_queries) {
+        StorageView standard_queries(queries.dtype(), queries.device());
+        StorageView standard_output(queries.dtype(), queries.device());
+        transpose_op(queries, standard_queries);
+        dot_product_attention(standard_queries,
+                              keys,
+                              values,
+                              values_lengths,
+                              relative_position_keys,
+                              relative_asymmetric_position_keys,
+                              relative_position_values,
+                              relative_attention_bias,
+                              relative_left_max_position,
+                              relative_right_max_position,
+                              maximum_relative_position,
+                              standard_output,
+                              attention,
+                              return_normalized_attention,
+                              queries_scale,
+                              is_decoder,
+                              with_cache,
+                              beam_size,
+                              alibi,
+                              position_bias,
+                              false);
+        transpose_op(standard_output, output);
+        return;
+      }
 
       std::unique_ptr<const StorageView> relative_positions;
       if (relative_position_keys || relative_position_values || relative_asymmetric_position_keys) {
@@ -379,7 +484,9 @@ namespace ctranslate2 {
         StorageView* cached_values,
         const Padder* queries_padder,
         const Padder* values_padder,
-        dim_t& beam_size) const {
+        dim_t& beam_size,
+        bool use_interleaved_beam_layout,
+        bool* interleaved_beam_layout) const {
 
       queries_proj = std::move(fused_proj);
 
@@ -436,7 +543,19 @@ namespace ctranslate2 {
       if (queries_proj.dim(1) == 1 && cached_keys)
         beam_size = queries_proj.dim(0) / cached_keys->dim(0);
 
-      split_heads(queries_proj, _num_heads, queries_padder, beam_size);
+      if (use_interleaved_beam_layout && beam_size > 1) {
+        // Keep the projection's natural [batch, beam, heads, depth] order.
+        // The fused attention kernel understands this layout, and its output
+        // can be flattened directly back to [batch * beam, 1, model_depth].
+        queries_proj.reshape({queries_proj.dim(0) / beam_size,
+                              beam_size,
+                              _num_heads,
+                              _d_head});
+        if (interleaved_beam_layout)
+          *interleaved_beam_layout = true;
+      } else {
+        split_heads(queries_proj, _num_heads, queries_padder, beam_size);
+      }
     }
 
     void MultiHeadAttention::operator()(const StorageView& queries,
@@ -468,14 +587,31 @@ namespace ctranslate2 {
       _linear[0](*q, fused_proj);
 
       dim_t beam_size = 1;
+      bool interleaved_beam_layout = false;
 
       bool prefilling = (_sliding_window > 0 && values_lengths);
 
       if (!_self_attention) {
 
+        bool use_interleaved_beam_layout = false;
+#ifdef CT2_WITH_MPS
+        use_interleaved_beam_layout = mps_fused_attention_enabled()
+                                      && device == Device::MPS
+                                      && dtype == DataType::FLOAT16
+                                      && !attention
+                                      && !queries_padder
+                                      && !_relative_position_keys
+                                      && !_relative_asymmetric_position_keys
+                                      && !_relative_position_values
+                                      && !_relative_attention_bias
+                                      && !_alibi;
+#endif
+
         process_cross_attention(queries, values, fused_proj, queries_proj, keys_proj,
                                 values_proj, cached_keys, cached_values,
-                                queries_padder, values_padder, beam_size);
+                                queries_padder, values_padder, beam_size,
+                                use_interleaved_beam_layout,
+                                &interleaved_beam_layout);
       } else {
 
         if (_num_heads_kv < _num_heads) {// MQA or GQA: queries stay in merged time/head format
@@ -582,7 +718,8 @@ namespace ctranslate2 {
                             bool(cached_keys),
                             beam_size,
                             _alibi,
-                            position_bias);
+                            position_bias,
+                            interleaved_beam_layout);
 
       if (prefilling && cached_keys && cached_keys->shape()[2] > _sliding_window) {
         // set only last sliding_window tokens to cached_keys and cached_values after computing attention
@@ -598,10 +735,16 @@ namespace ctranslate2 {
         context.reshape(queries.shape());
         if (queries_padder)
           queries_padder->remove_padding(context);
+      } else if (interleaved_beam_layout) {
+        context.reshape(queries.shape());
       } else {
         combine_heads(context, _num_heads, queries_padder, beam_size);
       }
-      _linear.back()(context, output, _layer_norm ? &queries : nullptr);
+      const bool fuse_post_norm = _layer_norm && !_pre_norm && !_tensor_parallel;
+      if (fuse_post_norm)
+        _linear.back().forward_with_post_layer_norm(context, queries, *_layer_norm, output);
+      else
+        _linear.back()(context, output, _layer_norm ? &queries : nullptr);
 
       if (_tensor_parallel) {
         Shape shape = output.shape();
@@ -610,7 +753,7 @@ namespace ctranslate2 {
         ops_reduce_all(output, tmp);
         output = std::move(tmp);
       }
-      if (_layer_norm && !_pre_norm)
+      if (_layer_norm && !_pre_norm && !fuse_post_norm)
         (*_layer_norm)(output, output);
     }
 
@@ -789,9 +932,13 @@ namespace ctranslate2 {
       values_matmul(attn, merged_values, context);
 
       combine_heads(context, _num_heads, queries_padder, /*beam_size=*/1);
-      _linear.back()(context, output, _layer_norm ? &queries : nullptr);
+      const bool fuse_post_norm = _layer_norm && !_pre_norm;
+      if (fuse_post_norm)
+        _linear.back().forward_with_post_layer_norm(context, queries, *_layer_norm, output);
+      else
+        _linear.back()(context, output, _layer_norm ? &queries : nullptr);
 
-      if (_layer_norm && !_pre_norm)
+      if (_layer_norm && !_pre_norm && !fuse_post_norm)
         (*_layer_norm)(output, output);
     }
 

--- a/src/layers/common.cc
+++ b/src/layers/common.cc
@@ -1,13 +1,42 @@
 #include "ctranslate2/layers/common.h"
 
 #include <cmath>
+#include <cstdlib>
 
 #include "ctranslate2/ops/activation.h"
 #include "cpu/backend.h"
 #include "dispatch.h"
 
+#ifdef CT2_WITH_MPS
+#  include "mps/kernels.h"
+#endif
+
 namespace ctranslate2 {
   namespace layers {
+
+#ifdef CT2_WITH_MPS
+    static int dense_mps_activation_code(const ops::ActivationType* activation) {
+      if (!activation)
+        return -1;
+      switch (*activation) {
+      case ops::ActivationType::ReLU:
+        return static_cast<int>(mps::UnaryOp::RELU);
+      case ops::ActivationType::GELUTanh:
+        return static_cast<int>(mps::UnaryOp::GELU_TANH);
+      case ops::ActivationType::Swish:
+        return static_cast<int>(mps::UnaryOp::SWISH);
+      case ops::ActivationType::GELU:
+        return static_cast<int>(mps::UnaryOp::GELU);
+      case ops::ActivationType::GELUSigmoid:
+        return static_cast<int>(mps::UnaryOp::GELU_SIGMOID);
+      case ops::ActivationType::Tanh:
+        return static_cast<int>(mps::UnaryOp::TANH);
+      case ops::ActivationType::Sigmoid:
+        return static_cast<int>(mps::UnaryOp::SIGMOID);
+      }
+      return -1;
+    }
+#endif
 
     StorageView
     make_sequence_inputs(const std::vector<std::vector<size_t>>& ids,
@@ -281,6 +310,7 @@ namespace ctranslate2 {
       , _partial_bias(_weight.device(), _bias ? _bias->dtype() : DataType::FLOAT32)
       , _partial_qscale(_weight.device(), DataType::FLOAT32)
       , _partial_u8_shift_compensation(_weight.device(), DataType::INT32)
+      , _mps_float16_weight(_weight.device(), DataType::FLOAT16)
       , _output_type(get_default_float_type(model.effective_compute_type()))
       , _quant_method(model.quant_method())
       , _quantized_gemm(_weight.dtype() == DataType::INT16 || _weight.dtype() == DataType::INT8)
@@ -352,9 +382,86 @@ namespace ctranslate2 {
       }
       if (_quantized_gemm) {
         const auto device = input.device();
+
+#ifdef CT2_WITH_MPS
+        static const bool cache_int8_as_float16 = []() {
+          const char* value = std::getenv("CT2_MPS_CACHE_INT8_FP16");
+          return !value || value[0] == '\0' || std::string(value) != "0";
+        }();
+        if (cache_int8_as_float16
+            && !affected_by_tp
+            && device == Device::MPS
+            && _mps_float16_weight.empty()
+            && _partial_weight.empty()
+            && _weight.dtype() == DataType::INT8
+            && _output_type == DataType::FLOAT16
+            && qscale
+            && !_packed_weight) {
+          // Dense replicas execute on one worker. Lazily encode the one-time
+          // expansion here so it shares that worker's Metal stream with the
+          // first consuming GEMM; constructing it on the model-loading thread
+          // would leave an unsynchronized cross-stream dependency.
+          ops::Dequantize()(_weight, *qscale, _mps_float16_weight);
+        }
+
+        if (!affected_by_tp
+            && device == Device::MPS
+            && _mps_float16_weight
+            && _partial_weight.empty()
+            && input.dtype() == DataType::FLOAT16
+            && (!bias || bias->dtype() == DataType::FLOAT16)
+            && (!residual || residual->dtype() == DataType::FLOAT16)) {
+          const ops::Gemm float16_gemm(/*alpha=*/1,
+                                       /*beta=*/0,
+                                       /*trans_a=*/false,
+                                       /*trans_b=*/true,
+                                       /*a_is_packed=*/false,
+                                       /*b_is_packed=*/false,
+                                       _activation_type);
+          float16_gemm(input,
+                       _mps_float16_weight,
+                       output,
+                       nullptr,
+                       bias,
+                       residual);
+          return;
+        }
+
+        if (!affected_by_tp
+            && device == Device::MPS
+            && input.dtype() == DataType::FLOAT16
+            && _weight.dtype() == DataType::INT8
+            && _output_type == DataType::FLOAT16
+            && qscale
+            && (!bias || bias->dtype() == DataType::FLOAT16)
+            && (!residual || residual->dtype() == DataType::FLOAT16)) {
+          const dim_t k = input.dim(-1);
+          const dim_t n = weight->dim(0);
+          const dim_t m = input.size() / k;
+          if ((!bias || bias->size() == n)
+              && (!residual || residual->size() == m * n)) {
+            Shape output_shape(input.shape());
+            output_shape.back() = n;
+            output.resize(std::move(output_shape));
+            if (mps::gemm_weight_only_int8_with_epilogue(
+                  input.data<float16_t>(),
+                  weight->data<int8_t>(),
+                  qscale->data<float>(),
+                  qscale->size(),
+                  bias ? bias->data<float16_t>() : nullptr,
+                  residual ? residual->data<float16_t>() : nullptr,
+                  output.data<float16_t>(),
+                  m,
+                  n,
+                  k,
+                  dense_mps_activation_code(_activation_type)))
+              return;
+          }
+        }
+#endif
+
         StorageView qinput(_weight.dtype(), device);
         StorageView qinput_scale(_qscale->dtype(), device);
-        StorageView qoutput(DataType::INT32, device);
         const StorageView* pinput = &input;
 
         if (affected_by_tp) {
@@ -389,6 +496,7 @@ namespace ctranslate2 {
           _quantize_op(input, qinput, qinput_scale);
         }
 
+        StorageView qoutput(DataType::INT32, device);
         _gemm_op(qinput, *weight, qoutput, compensation);
         _dequantize_op(qoutput,
                        qinput_scale,
@@ -441,6 +549,34 @@ namespace ctranslate2 {
       }
     }
 
+    void Dense::forward_with_post_layer_norm(const StorageView& input,
+                                             const StorageView& residual,
+                                             const LayerNorm& layer_norm,
+                                             StorageView& output) const {
+#ifdef CT2_WITH_MPS
+      static const bool use_fused_post_norm = []() {
+        const char* value = std::getenv("CT2_MPS_USE_FUSED_POST_NORM");
+        return value && value[0] != '\0' && value[0] != '0';
+      }();
+
+      const StorageView* weight = _partial_weight.empty() ? &_weight : &_partial_weight;
+      const StorageView* bias = _partial_bias.empty() ? _bias : &_partial_bias;
+      if (use_fused_post_norm
+          && input.device() == Device::MPS
+          && input.dtype() == DataType::FLOAT16
+          && !_quantized_gemm
+          && !_qzero
+          && !_activation_type
+          && bias) {
+        _gemm_op(input, *weight, output);
+        if (layer_norm.apply_fused_bias_residual(output, *bias, residual, output))
+          return;
+      }
+#endif
+      (*this)(input, output, &residual);
+      layer_norm(output, output);
+    }
+
 
     LayerNorm::LayerNorm(const models::Model& model, const std::string& scope)
       : _beta(model.get_variable_if_exists(scope + "/beta"))
@@ -469,6 +605,47 @@ namespace ctranslate2 {
         const ops::RMSNorm norm_op(_epsilon, _use_residual);
         norm_op(_gamma, input, output);
       }
+    }
+
+    bool LayerNorm::apply_fused_bias_residual(const StorageView& input,
+                                              const StorageView& bias,
+                                              const StorageView& residual,
+                                              StorageView& output) const {
+#ifdef CT2_WITH_MPS
+      if (!_beta
+          || input.device() != Device::MPS
+          || input.dtype() != DataType::FLOAT16
+          || bias.dtype() != input.dtype()
+          || residual.dtype() != input.dtype()
+          || _gamma.dtype() != input.dtype()
+          || _beta->dtype() != input.dtype()
+          || input.empty()
+          || input.rank() == 0
+          || bias.size() != input.dim(-1)
+          || residual.size() != input.size()
+          || _gamma.size() != bias.size()
+          || _beta->size() != bias.size())
+        return false;
+
+      output.resize_as(input);
+      return mps::fused_bias_residual_layer_norm(
+        input.dtype(),
+        input.data<float16_t>(),
+        bias.data<float16_t>(),
+        residual.data<float16_t>(),
+        _gamma.data<float16_t>(),
+        _beta->data<float16_t>(),
+        output.data<float16_t>(),
+        input.size() / input.dim(-1),
+        input.dim(-1),
+        _epsilon);
+#else
+      (void)input;
+      (void)bias;
+      (void)residual;
+      (void)output;
+      return false;
+#endif
     }
 
 

--- a/src/layers/common.cc
+++ b/src/layers/common.cc
@@ -310,7 +310,6 @@ namespace ctranslate2 {
       , _partial_bias(_weight.device(), _bias ? _bias->dtype() : DataType::FLOAT32)
       , _partial_qscale(_weight.device(), DataType::FLOAT32)
       , _partial_u8_shift_compensation(_weight.device(), DataType::INT32)
-      , _mps_float16_weight(_weight.device(), DataType::FLOAT16)
       , _output_type(get_default_float_type(model.effective_compute_type()))
       , _quant_method(model.quant_method())
       , _quantized_gemm(_weight.dtype() == DataType::INT16 || _weight.dtype() == DataType::INT8)
@@ -384,49 +383,6 @@ namespace ctranslate2 {
         const auto device = input.device();
 
 #ifdef CT2_WITH_MPS
-        static const bool cache_int8_as_float16 = []() {
-          const char* value = std::getenv("CT2_MPS_CACHE_INT8_FP16");
-          return !value || value[0] == '\0' || std::string(value) != "0";
-        }();
-        if (cache_int8_as_float16
-            && !affected_by_tp
-            && device == Device::MPS
-            && _mps_float16_weight.empty()
-            && _partial_weight.empty()
-            && _weight.dtype() == DataType::INT8
-            && _output_type == DataType::FLOAT16
-            && qscale
-            && !_packed_weight) {
-          // Dense replicas execute on one worker. Lazily encode the one-time
-          // expansion here so it shares that worker's Metal stream with the
-          // first consuming GEMM; constructing it on the model-loading thread
-          // would leave an unsynchronized cross-stream dependency.
-          ops::Dequantize()(_weight, *qscale, _mps_float16_weight);
-        }
-
-        if (!affected_by_tp
-            && device == Device::MPS
-            && _mps_float16_weight
-            && _partial_weight.empty()
-            && input.dtype() == DataType::FLOAT16
-            && (!bias || bias->dtype() == DataType::FLOAT16)
-            && (!residual || residual->dtype() == DataType::FLOAT16)) {
-          const ops::Gemm float16_gemm(/*alpha=*/1,
-                                       /*beta=*/0,
-                                       /*trans_a=*/false,
-                                       /*trans_b=*/true,
-                                       /*a_is_packed=*/false,
-                                       /*b_is_packed=*/false,
-                                       _activation_type);
-          float16_gemm(input,
-                       _mps_float16_weight,
-                       output,
-                       nullptr,
-                       bias,
-                       residual);
-          return;
-        }
-
         if (!affected_by_tp
             && device == Device::MPS
             && input.dtype() == DataType::FLOAT16

--- a/src/layers/transformer.cc
+++ b/src/layers/transformer.cc
@@ -36,7 +36,11 @@ namespace ctranslate2 {
         ops::Mul()(linear, inner, inner);
       }
 
-      _ff2(inner, output, _layer_norm ? &input : nullptr);
+      const bool fuse_post_norm = _layer_norm && !_pre_norm && !_tensor_parallel;
+      if (fuse_post_norm)
+        _ff2.forward_with_post_layer_norm(inner, input, *_layer_norm, output);
+      else
+        _ff2(inner, output, _layer_norm ? &input : nullptr);
 
       if (_tensor_parallel) {
         Shape shape = output.shape();
@@ -46,7 +50,7 @@ namespace ctranslate2 {
         output = std::move(tmp);
       }
 
-      if (_layer_norm && !_pre_norm)
+      if (_layer_norm && !_pre_norm && !fuse_post_norm)
         (*_layer_norm)(output, output);
     }
 

--- a/src/models/model.cc
+++ b/src/models/model.cc
@@ -881,6 +881,18 @@ namespace ctranslate2 {
         spdlog::info(" - Selected compute type: {}",
                      compute_type_to_str(model->effective_compute_type()));
 
+#ifdef CT2_WITH_MPS
+        if (device == Device::MPS
+            && (model->requested_compute_type() == ComputeType::INT8
+                || model->requested_compute_type() == ComputeType::INT8_FLOAT16)
+            && model->effective_compute_type() == ComputeType::FLOAT16) {
+          spdlog::warn("Requested {} on MPS resolves to float16 because native INT8 "
+                       "is experimental and slower on current Apple GPUs. Set "
+                       "CT2_MPS_CACHE_INT8_FP16=0 to explicitly enable native INT8.",
+                       compute_type_to_str(model->requested_compute_type()));
+        }
+#endif
+
         if (model->requested_compute_type() == ComputeType::DEFAULT
             && model->effective_compute_type() != model->saved_compute_type())
           spdlog::warn("The compute type inferred from the saved model is {}, "

--- a/src/mps/allocator.mm
+++ b/src/mps/allocator.mm
@@ -1,0 +1,57 @@
+#ifdef __APPLE__
+
+#import <Metal/Metal.h>
+#import <Foundation/Foundation.h>
+
+#include <mutex>
+#include <unordered_map>
+
+#include "ctranslate2/allocator.h"
+#include "ctranslate2/devices.h"
+#include "mps/utils.h"
+
+namespace ctranslate2 {
+
+  class MPSAllocator : public Allocator {
+  public:
+    void* allocate(size_t size, int device_index) override {
+      (void)device_index;
+      void* buf = mps::allocate_buffer(size);
+      id<MTLBuffer> mtl_buf = (__bridge id<MTLBuffer>)buf;
+      void* contents = [mtl_buf contents];
+      std::lock_guard<std::mutex> lock(_mutex);
+      _ptr_to_buffer[contents] = mtl_buf;
+      return contents;
+    }
+
+    void free(void* ptr, int device_index) override {
+      (void)device_index;
+      if (!ptr)
+        return;
+      id<MTLBuffer> mtl_buf = nil;
+      {
+        std::lock_guard<std::mutex> lock(_mutex);
+        auto it = _ptr_to_buffer.find(ptr);
+        if (it != _ptr_to_buffer.end()) {
+          mtl_buf = it->second;
+          _ptr_to_buffer.erase(it);
+        }
+      }
+      if (mtl_buf)
+        mps::free_buffer((__bridge void*)mtl_buf);
+    }
+
+  private:
+    std::mutex _mutex;
+    std::unordered_map<void*, id<MTLBuffer>> _ptr_to_buffer;
+  };
+
+  template<>
+  Allocator& get_allocator<Device::MPS>() {
+    static MPSAllocator allocator;
+    return allocator;
+  }
+
+}
+
+#endif  // __APPLE__

--- a/src/mps/kernels.h
+++ b/src/mps/kernels.h
@@ -1,0 +1,254 @@
+#pragma once
+
+#ifdef __APPLE__
+
+#include "ctranslate2/types.h"
+
+namespace ctranslate2 {
+  namespace mps {
+
+    enum class UnaryOp {
+      EXP,
+      LOG,
+      COS,
+      SIN,
+      TANH,
+      RELU,
+      GELU,
+      GELU_TANH,
+      GELU_SIGMOID,
+      SIGMOID,
+      SWISH,
+    };
+
+    enum class BinaryOp {
+      ADD,
+      SUB,
+      MUL,
+      MAX,
+      MIN,
+    };
+
+    void gemm(DataType dtype,
+              bool transpose_a,
+              bool transpose_b,
+              dim_t m,
+              dim_t n,
+              dim_t k,
+              float alpha,
+              const void* a,
+              dim_t lda,
+              const void* b,
+              dim_t ldb,
+              float beta,
+              void* c,
+              dim_t ldc);
+
+    void gemm_batch_strided(DataType dtype,
+                            bool transpose_a,
+                            bool transpose_b,
+                            dim_t m,
+                            dim_t n,
+                            dim_t k,
+                            float alpha,
+                            const void* a,
+                            dim_t lda,
+                            dim_t stridea,
+                            const void* b,
+                            dim_t ldb,
+                            dim_t strideb,
+                            float beta,
+                            void* c,
+                            dim_t ldc,
+                            dim_t stridec,
+                            dim_t batch_size);
+
+    void gemv(DataType dtype,
+              bool transpose_a,
+              bool transpose_b,
+              dim_t m,
+              dim_t k,
+              float alpha,
+              const void* a,
+              dim_t lda,
+              dim_t stridea,
+              const void* b,
+              dim_t ldb,
+              dim_t strideb,
+              float beta,
+              void* c,
+              dim_t ldc,
+              dim_t stridec,
+              dim_t batch_size);
+
+    void gemv_row(DataType dtype,
+                  bool transpose_a,
+                  bool transpose_b,
+                  dim_t n,
+                  dim_t k,
+                  float alpha,
+                  const void* a,
+                  dim_t lda,
+                  dim_t stridea,
+                  const void* b,
+                  dim_t ldb,
+                  dim_t strideb,
+                  float beta,
+                  void* c,
+                  dim_t ldc,
+                  dim_t stridec,
+                  dim_t batch_size);
+
+    bool supports_gemm_type(DataType dtype);
+
+    // Drops cached output-major weight metadata before the backing allocation
+    // is released. The argument is the opaque MTLBuffer returned by utils.
+    void invalidate_packed_weight_cache(void* metal_buffer);
+
+    void fill(DataType dtype, const void* value, void* y, dim_t size);
+    void indexed_fill(DataType dtype,
+                      const void* value,
+                      void* y,
+                      const int32_t* indices,
+                      dim_t size);
+    void prepare_length_mask(const int32_t* lengths,
+                             dim_t batch_size,
+                             dim_t num_heads,
+                             dim_t num_queries,
+                             bool mask_future,
+                             bool multi_query,
+                             int32_t* mask);
+    void unary(DataType dtype, UnaryOp op, const void* x, void* y, dim_t size);
+    void binary(DataType dtype, BinaryOp op, const void* a, const void* b, void* c, dim_t size);
+    void scalar(DataType dtype, BinaryOp op, float a, const void* x, void* y, dim_t size);
+
+    void gather(DataType dtype,
+                const void* data,
+                const int32_t* indices,
+                void* output,
+                dim_t copy_size,
+                dim_t batch_stride,
+                dim_t num_indices,
+                dim_t num_indices_per_batch);
+
+    void tile(DataType dtype,
+              const void* input,
+              void* output,
+              dim_t outer_size,
+              dim_t inner_size,
+              dim_t num_tiles);
+
+    void bias_add(DataType dtype,
+                  const void* bias,
+                  const void* value,
+                  const void* residual,
+                  void* output,
+                  dim_t bias_size,
+                  dim_t value_size,
+                  dim_t block,
+                  int activation);
+
+    void batch_broadcast(DataType dtype,
+                         BinaryOp op,
+                         const void* a,
+                         const void* b,
+                         void* c,
+                         dim_t a_size,
+                         dim_t b_size);
+
+    void depth_broadcast(DataType dtype,
+                         BinaryOp op,
+                         const void* a,
+                         const void* b,
+                         void* c,
+                         dim_t a_size,
+                         dim_t b_size);
+
+    void block_broadcast(DataType dtype,
+                         BinaryOp op,
+                         const void* a,
+                         const void* b,
+                         void* c,
+                         dim_t block,
+                         dim_t a_size,
+                         dim_t b_size);
+
+    void transpose_2d(DataType dtype, const void* a, dim_t rows, dim_t cols, void* b);
+    void transpose_3d(DataType dtype, const void* a, const dim_t* dims, const dim_t* perm, void* b);
+    void transpose_4d(DataType dtype, const void* a, const dim_t* dims, const dim_t* perm, void* b);
+
+    void softmax(DataType dtype,
+                 const void* input,
+                 const int32_t* lengths,
+                 void* output,
+                 dim_t batch_size,
+                 dim_t depth,
+                 bool log);
+
+    void mean(DataType dtype,
+              const void* input,
+              void* output,
+              dim_t outer_size,
+              dim_t axis_size,
+              dim_t inner_size,
+              bool get_sum);
+
+    void layer_norm(DataType dtype,
+                    const void* input,
+                    const void* gamma,
+                    const void* beta,
+                    void* output,
+                    dim_t outer_size,
+                    dim_t axis_size,
+                    dim_t inner_size,
+                    float epsilon);
+
+    void rms_norm(DataType dtype,
+                  const void* input,
+                  const void* gamma,
+                  void* output,
+                  dim_t batch_size,
+                  dim_t depth,
+                  float epsilon,
+                  bool use_residual);
+
+    void rotary(DataType dtype,
+                const void* input,
+                const void* sin,
+                const void* cos,
+                void* output,
+                dim_t batch_size,
+                dim_t max_time,
+                dim_t ndims,
+                dim_t depth,
+                bool interleave);
+
+    void im2col_conv1d(DataType dtype,
+                       const void* input,
+                       void* output,
+                       dim_t batch_size,
+                       dim_t groups,
+                       dim_t input_length,
+                       dim_t kernel_size,
+                       dim_t stride,
+                       dim_t padding,
+                       dim_t dilation,
+                       dim_t output_length,
+                       dim_t k,
+                       dim_t in_batch_stride,
+                       dim_t in_group_stride);
+
+    bool supports_topk(DataType dtype, dim_t k);
+
+    void topk(DataType dtype,
+              const void* input,
+              void* values,
+              int32_t* indices,
+              dim_t batch_size,
+              dim_t depth,
+              dim_t k);
+
+  }
+}
+
+#endif

--- a/src/mps/kernels.h
+++ b/src/mps/kernels.h
@@ -63,6 +63,38 @@ namespace ctranslate2 {
                             dim_t stridec,
                             dim_t batch_size);
 
+    void gemm_int8(bool transpose_a,
+                   bool transpose_b,
+                   dim_t m,
+                   dim_t n,
+                   dim_t k,
+                   float alpha,
+                   const int8_t* a,
+                   dim_t lda,
+                   const int8_t* b,
+                   dim_t ldb,
+                   float beta,
+                   int32_t* c,
+                   dim_t ldc);
+
+    void gemm_int8_batch_strided(bool transpose_a,
+                                 bool transpose_b,
+                                 dim_t m,
+                                 dim_t n,
+                                 dim_t k,
+                                 float alpha,
+                                 const int8_t* a,
+                                 dim_t lda,
+                                 dim_t stridea,
+                                 const int8_t* b,
+                                 dim_t ldb,
+                                 dim_t strideb,
+                                 float beta,
+                                 int32_t* c,
+                                 dim_t ldc,
+                                 dim_t stridec,
+                                 dim_t batch_size);
+
     void gemv(DataType dtype,
               bool transpose_a,
               bool transpose_b,
@@ -121,6 +153,35 @@ namespace ctranslate2 {
     void unary(DataType dtype, UnaryOp op, const void* x, void* y, dim_t size);
     void binary(DataType dtype, BinaryOp op, const void* a, const void* b, void* c, dim_t size);
     void scalar(DataType dtype, BinaryOp op, float a, const void* x, void* y, dim_t size);
+
+    void quantize(DataType dtype,
+                  const void* input,
+                  int8_t* output,
+                  float* scales,
+                  dim_t batch_size,
+                  dim_t depth,
+                  bool round_before_cast);
+
+    void dequantize(DataType dtype,
+                    const int8_t* input,
+                    const float* scales,
+                    void* output,
+                    dim_t batch_size,
+                    dim_t depth);
+
+    void dequantize_gemm_output(DataType dtype,
+                                const int32_t* input,
+                                const float* a_scales,
+                                dim_t a_scale_size,
+                                const float* b_scales,
+                                dim_t b_scale_size,
+                                bool transpose_a,
+                                bool transpose_b,
+                                const void* bias,
+                                void* output,
+                                dim_t batch_size,
+                                dim_t depth,
+                                int activation);
 
     void gather(DataType dtype,
                 const void* data,
@@ -237,6 +298,47 @@ namespace ctranslate2 {
                        dim_t k,
                        dim_t in_batch_stride,
                        dim_t in_group_stride);
+
+    void median_filter(DataType dtype,
+                       const void* input,
+                       void* output,
+                       dim_t rows,
+                       dim_t depth,
+                       dim_t width);
+
+    void top_p_mask(DataType dtype,
+                    const void* input,
+                    const void* probabilities,
+                    void* output,
+                    dim_t batch_size,
+                    dim_t depth,
+                    float probability,
+                    float mask_value);
+
+    dim_t max_top_p_classes();
+
+    void multinomial(DataType dtype,
+                     const void* probabilities,
+                     int32_t* output,
+                     dim_t batch_size,
+                     dim_t depth,
+                     dim_t sample_size);
+
+    void gumbel_noise(DataType dtype,
+                      const void* input,
+                      void* output,
+                      dim_t size);
+
+    void alibi_add(DataType dtype,
+                   const void* input,
+                   const void* alibi,
+                   void* output,
+                   dim_t batch_size,
+                   dim_t num_heads,
+                   dim_t query_length,
+                   dim_t key_length,
+                   dim_t cached_key_length,
+                   dim_t alibi_offset);
 
     bool supports_topk(DataType dtype, dim_t k);
 

--- a/src/mps/kernels.h
+++ b/src/mps/kernels.h
@@ -129,7 +129,10 @@ namespace ctranslate2 {
                   void* c,
                   dim_t ldc,
                   dim_t stridec,
-                  dim_t batch_size);
+                  dim_t batch_size,
+                  const void* bias = nullptr,
+                  const void* residual = nullptr,
+                  int activation = -1);
 
     bool supports_gemm_type(DataType dtype);
 

--- a/src/mps/kernels.h
+++ b/src/mps/kernels.h
@@ -146,6 +146,14 @@ namespace ctranslate2 {
                       void* y,
                       const int32_t* indices,
                       dim_t size);
+    void penalize_previous_tokens(DataType dtype,
+                                  void* scores,
+                                  const void* previous_scores,
+                                  const int32_t* previous_ids,
+                                  float penalty,
+                                  dim_t batch_size,
+                                  dim_t length,
+                                  dim_t vocabulary_size);
     void prepare_length_mask(const int32_t* lengths,
                              dim_t batch_size,
                              dim_t num_heads,
@@ -194,6 +202,17 @@ namespace ctranslate2 {
                 dim_t batch_stride,
                 dim_t num_indices,
                 dim_t num_indices_per_batch);
+
+    // Concatenates two contiguous tensors along one logical axis in a single
+    // dispatch. a_block_size and b_block_size include the dimensions at and
+    // after that axis; outer_size is the product of dimensions before it.
+    void concat2(DataType dtype,
+                 const void* a,
+                 dim_t a_block_size,
+                 const void* b,
+                 dim_t b_block_size,
+                 void* output,
+                 dim_t outer_size);
 
     void tile(DataType dtype,
               const void* input,

--- a/src/mps/kernels.h
+++ b/src/mps/kernels.h
@@ -44,6 +44,26 @@ namespace ctranslate2 {
               void* c,
               dim_t ldc);
 
+    // Returns true when the optimized FP16 Dense kernel handled the complete
+    // GEMM epilogue. The activation value uses UnaryOp or -1 for none.
+    bool gemm_with_epilogue(DataType dtype,
+                            bool transpose_a,
+                            bool transpose_b,
+                            dim_t m,
+                            dim_t n,
+                            dim_t k,
+                            float alpha,
+                            const void* a,
+                            dim_t lda,
+                            const void* b,
+                            dim_t ldb,
+                            float beta,
+                            void* c,
+                            dim_t ldc,
+                            const void* bias,
+                            const void* residual,
+                            int activation);
+
     void gemm_batch_strided(DataType dtype,
                             bool transpose_a,
                             bool transpose_b,
@@ -94,6 +114,21 @@ namespace ctranslate2 {
                                  dim_t ldc,
                                  dim_t stridec,
                                  dim_t batch_size);
+
+    // Weight-only INT8 Dense for FP16 activations. Weights stay compressed in
+    // device memory and are converted in registers, avoiding dynamic
+    // activation quantization and the INT32 output tensor.
+    bool gemm_weight_only_int8_with_epilogue(const void* a,
+                                             const int8_t* b,
+                                             const float* b_scales,
+                                             dim_t b_scale_size,
+                                             const void* bias,
+                                             const void* residual,
+                                             void* output,
+                                             dim_t m,
+                                             dim_t n,
+                                             dim_t k,
+                                             int activation);
 
     void gemv(DataType dtype,
               bool transpose_a,
@@ -214,6 +249,24 @@ namespace ctranslate2 {
                  void* output,
                  dim_t outer_size);
 
+    void split2(DataType dtype,
+                const void* input,
+                void* a,
+                dim_t a_block_size,
+                void* b,
+                dim_t b_block_size,
+                dim_t outer_size);
+
+    void split3(DataType dtype,
+                const void* input,
+                void* a,
+                dim_t a_block_size,
+                void* b,
+                dim_t b_block_size,
+                void* c,
+                dim_t c_block_size,
+                dim_t outer_size);
+
     void tile(DataType dtype,
               const void* input,
               void* output,
@@ -268,6 +321,22 @@ namespace ctranslate2 {
                  dim_t depth,
                  bool log);
 
+    // Computes softmax(scale * Q * K^T) * V for contiguous FP16 attention
+    // matrices. Returns false when the shape is outside the specialized
+    // decoder path so callers can use the generic operators.
+    bool fused_attention(DataType dtype,
+                         const void* queries,
+                         const void* keys,
+                         const void* values,
+                         const int32_t* lengths,
+                         void* output,
+                         dim_t batch_size,
+                         dim_t query_length,
+                         dim_t key_length,
+                         dim_t depth,
+                         float scale,
+                         dim_t interleaved_num_heads = 0);
+
     void mean(DataType dtype,
               const void* input,
               void* output,
@@ -285,6 +354,33 @@ namespace ctranslate2 {
                     dim_t axis_size,
                     dim_t inner_size,
                     float epsilon);
+
+    // Applies the FP16 dense post-norm epilogue in one dispatch. The input is
+    // first rounded after bias and residual addition, matching the established
+    // BiasAdd -> LayerNorm path. Returns false for unsupported layouts.
+    bool fused_bias_residual_layer_norm(DataType dtype,
+                                        const void* input,
+                                        const void* bias,
+                                        const void* residual,
+                                        const void* gamma,
+                                        const void* beta,
+                                        void* output,
+                                        dim_t rows,
+                                        dim_t depth,
+                                        float epsilon);
+
+    // Fuses per-beam log-softmax, previous beam-score addition, and the
+    // cross-beam TopK used by deterministic beam search. Returns false when
+    // the shape or dtype is outside the specialized path.
+    bool fused_beam_search_topk(DataType dtype,
+                                const void* logits,
+                                const void* beam_scores,
+                                void* values,
+                                int32_t* indices,
+                                dim_t batch_size,
+                                dim_t beam_size,
+                                dim_t vocabulary_size,
+                                dim_t k);
 
     void rms_norm(DataType dtype,
                   const void* input,

--- a/src/mps/kernels.mm
+++ b/src/mps/kernels.mm
@@ -128,6 +128,9 @@ struct GemvArgs {
   uint transpose_b;
   float alpha;
   float beta;
+  uint has_bias;
+  uint has_residual;
+  int activation;
 };
 
 struct GenericGemmArgs {
@@ -553,51 +556,77 @@ GEMV_ROW_KERNEL(gemv_row_f32, float, load_value<float>, store_value<float>)
 GEMV_ROW_KERNEL(gemv_row_f16, half, load_value<half>, store_value<half>)
 GEMV_ROW_KERNEL(gemv_row_bf16, ushort, load_value_bf16, store_value_bf16)
 
-// Output-major FP16 matvec adapted from the dispatch geometry used by MLX's
-// gemv kernel (Apache-2.0, MLX commit recorded in the benchmark report).  One
-// 256-thread group contains 8 SIMD groups and produces 4 outputs per SIMD
-// group, reducing threadgroup launch count by 32x for large projections.
+// Output-major FP16 matvec load and dispatch geometry adapted from Apple MLX's
+// gemv kernel. Copyright (c) 2023-2024 Apple Inc., Apache License 2.0.
+// One SIMD group computes 4 output rows while loading each input-vector block
+// only once. This is especially important for the hundreds of small decoder
+// projections issued for every generated token.
 kernel void gemv_row_output_major_f16(
     device const half* a [[buffer(0)]],
     device const half* b [[buffer(1)]],
     device half* c [[buffer(2)]],
     constant GemvArgs& args [[buffer(3)]],
+    device const half* bias [[buffer(4)]],
+    device const half* residual [[buffer(5)]],
     uint3 group [[threadgroup_position_in_grid]],
     uint lane [[thread_index_in_simdgroup]],
-    uint simd_id [[simdgroup_index_in_threadgroup]]) {
+    uint simd_id [[simdgroup_index_in_threadgroup]],
+    uint simd_groups [[simdgroups_per_threadgroup]]) {
   const uint batch = group.y;
-  const uint first_output = group.x * 32u + simd_id * 4u;
+  const uint first_output = (group.x * simd_groups + simd_id) * 4u;
   const ulong a_base = args.stridea == 0 ? 0 : ulong(batch) * args.stridea;
   const ulong b_base = args.strideb == 0 ? 0 : ulong(batch) * args.strideb;
   const ulong c_base = args.stridec == 0 ? 0 : ulong(batch) * args.stridec;
+
+  float sums[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+  if (args.transpose_a == 0 && (args.k & 3ul) == 0) {
+    device const half4* av = reinterpret_cast<device const half4*>(a + a_base);
+    const uint vectors = uint(args.k >> 2);
+    for (uint p = lane; p < vectors; p += 32u) {
+      const float4 input = float4(av[p]);
+      for (uint output_delta = 0; output_delta < 4; ++output_delta) {
+        const uint output = first_output + output_delta;
+        if (output < args.n) {
+          const ulong weight_row = b_base + ulong(output) * args.ldb;
+          device const half4* weights =
+              reinterpret_cast<device const half4*>(b + weight_row);
+          sums[output_delta] += dot(input, float4(weights[p]));
+        }
+      }
+    }
+  } else {
+    for (ulong p = lane; p < args.k; p += 32ul) {
+      const ulong ai = args.transpose_a ? p * args.lda : p;
+      const float input = float(a[a_base + ai]);
+      for (uint output_delta = 0; output_delta < 4; ++output_delta) {
+        const uint output = first_output + output_delta;
+        if (output < args.n) {
+          const ulong weight_row = b_base + ulong(output) * args.ldb;
+          sums[output_delta] += input * float(b[weight_row + p]);
+        }
+      }
+    }
+  }
 
   for (uint output_delta = 0; output_delta < 4; ++output_delta) {
     const uint output = first_output + output_delta;
     if (output >= args.n)
       continue;
-
-    float sum = 0.0f;
-    const ulong weight_row = b_base + ulong(output) * args.ldb;
-    if (args.transpose_a == 0 && (args.k & 1ul) == 0) {
-      device const half2* av = reinterpret_cast<device const half2*>(a + a_base);
-      device const half2* bv = reinterpret_cast<device const half2*>(b + weight_row);
-      const uint pairs = uint(args.k >> 1);
-      for (uint p = lane; p < pairs; p += 32u) {
-        const half2 ah = av[p];
-        const half2 bh = bv[p];
-        sum += float(ah.x) * float(bh.x) + float(ah.y) * float(bh.y);
-      }
-    } else {
-      for (ulong p = lane; p < args.k; p += 32ul) {
-        const ulong ai = args.transpose_a ? p * args.lda : p;
-        sum += float(a[a_base + ai]) * float(b[weight_row + p]);
-      }
-    }
-    sum = simd_sum(sum);
-    if (lane == 0) {
+    const float sum = simd_sum(sums[output_delta]);
+    if (lane == 0u) {
       const ulong ci = c_base + output;
       const float previous = args.beta == 0.0f ? 0.0f : float(c[ci]);
-      c[ci] = half(args.alpha * sum + args.beta * previous);
+      // Match the unfused path's FP16 GEMV store before applying its epilogue.
+      // This preserves the model's existing numerical behavior while avoiding
+      // a second dispatch and an intermediate output read/write.
+      float result = float(half(args.alpha * sum + args.beta * previous));
+      if (args.has_bias)
+        result += float(bias[output]);
+      if (args.has_residual)
+        result += float(residual[ci]);
+      if (args.activation >= 0)
+        result = apply_unary(result, uint(args.activation));
+      c[ci] = half(result);
     }
   }
 }
@@ -1641,6 +1670,9 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         uint32_t transpose_b;
         float alpha;
         float beta;
+        uint32_t has_bias;
+        uint32_t has_residual;
+        int32_t activation;
       };
 
       struct GenericGemmArgs {
@@ -2088,7 +2120,7 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         // Dispatches in a reused compute encoder need an explicit visibility
         // boundary when a later primitive consumes a buffer written here.
         [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-        record_compute_dispatch();
+        record_compute_dispatch(name.c_str());
       }
 
       static void run_rows(const std::string& name,
@@ -2119,7 +2151,7 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         MTLSize group = MTLSizeMake(threads, 1, 1);
         [encoder dispatchThreadgroups:grid threadsPerThreadgroup:group];
         [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-        record_compute_dispatch();
+        record_compute_dispatch(name.c_str());
       }
 
       static NSUInteger reduction_threads(dim_t size) {
@@ -2397,7 +2429,7 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                                                 static_cast<NSUInteger>(batch_size))
                threadsPerThreadgroup:MTLSizeMake(16, 16, 1)];
       [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-      record_compute_dispatch();
+      record_compute_dispatch(storage_kernel_name("tiled_gemm", dtype).c_str());
     }
 
     static void generic_gemm(DataType dtype,
@@ -2529,7 +2561,7 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                                                   static_cast<NSUInteger>(batch_size))
                  threadsPerThreadgroup:MTLSizeMake(16, 16, 1)];
         [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-        record_compute_dispatch();
+        record_compute_dispatch("tiled_gemm_i8_i32");
       } else {
         const GenericGemmArgs args{static_cast<uint64_t>(m),
                                    static_cast<uint64_t>(n),
@@ -2636,7 +2668,10 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                           transpose_a ? 1u : 0u,
                           transpose_b ? 1u : 0u,
                           alpha,
-                          beta};
+                          beta,
+                          0,
+                          0,
+                          -1};
 
       run_rows(storage_kernel_name("gemv", dtype),
                static_cast<uint64_t>(batch_size * m),
@@ -2666,11 +2701,17 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                   void* c,
                   dim_t ldc,
                   dim_t stridec,
-                  dim_t batch_size) {
+                  dim_t batch_size,
+                  const void* bias,
+                  const void* residual,
+                  int activation) {
       if (batch_size <= 0 || n == 0)
         return;
       if (dtype != DataType::FLOAT32 && dtype != DataType::FLOAT16 && dtype != DataType::BFLOAT16)
         throw std::invalid_argument("unsupported MPS row GEMV dtype");
+      if ((bias || residual || activation >= 0)
+          && (dtype != DataType::FLOAT16 || !transpose_b))
+        throw std::invalid_argument("fused MPS row GEMV requires FP16 output-major weights");
 
       const size_t element_size = dtype_size(dtype);
       const size_t a_elements = transpose_a
@@ -2694,7 +2735,10 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                           transpose_a ? 1u : 0u,
                           transpose_b ? 1u : 0u,
                           alpha,
-                          beta};
+                          beta,
+                          bias ? 1u : 0u,
+                          residual ? 1u : 0u,
+                          activation};
 
       // Dense linear weights are stored by CTranslate2 as [N, K] and called
       // with transpose_b=true, which is already the packed output-major layout
@@ -2723,12 +2767,26 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                    strided_array_bytes(c_elements, stridec, batch_size, element_size),
                    2);
         [encoder setBytes:&args length:sizeof(args) atIndex:3];
-        [encoder dispatchThreadgroups:MTLSizeMake((static_cast<NSUInteger>(n) + 31) / 32,
+        set_buffer(encoder,
+                   bias ? bias : c,
+                   bias ? static_cast<size_t>(n) * element_size : element_size,
+                   4);
+        set_buffer(encoder,
+                   residual ? residual : c,
+                   residual
+                     ? strided_array_bytes(c_elements, stridec, batch_size, element_size)
+                     : element_size,
+                   5);
+        const NSUInteger simd_groups = n >= 4096 ? 8 : 4;
+        const NSUInteger outputs_per_group = simd_groups * 4;
+        [encoder dispatchThreadgroups:MTLSizeMake((static_cast<NSUInteger>(n)
+                                                   + outputs_per_group - 1)
+                                                  / outputs_per_group,
                                                   static_cast<NSUInteger>(batch_size),
                                                   1)
-                 threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+                 threadsPerThreadgroup:MTLSizeMake(simd_groups * 32, 1, 1)];
         [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-        record_compute_dispatch();
+        record_compute_dispatch("gemv_row_output_major_f16");
         record_profile_event(ProfileEvent::Gemv);
         return;
       }
@@ -2891,7 +2949,7 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                          leftMatrix:mat_a
                         rightMatrix:mat_b
                         resultMatrix:mat_c];
-      record_compute_dispatch();
+      record_compute_dispatch("mps_matrix_gemm");
       record_profile_event(ProfileEvent::Gemm);
 
 #if !__has_feature(objc_arc)
@@ -3091,7 +3149,7 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                          leftMatrix:mat_a
                         rightMatrix:mat_b
                         resultMatrix:mat_c];
-      record_compute_dispatch();
+      record_compute_dispatch("mps_matrix_batched_gemm");
       record_profile_event(ProfileEvent::Gemm);
 
 #if !__has_feature(objc_arc)
@@ -3145,7 +3203,7 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       [encoder dispatchThreadgroups:MTLSizeMake(static_cast<NSUInteger>(batch_size), 1, 1)
                threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
       [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-      record_compute_dispatch();
+      record_compute_dispatch(kernel_name("argmax", dtype).c_str());
       record_profile_event(ProfileEvent::TopKGpu);
     }
 
@@ -3179,7 +3237,7 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       [encoder dispatchThreadgroups:MTLSizeMake(static_cast<NSUInteger>(batch_size), 1, 1)
                threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
       [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-      record_compute_dispatch();
+      record_compute_dispatch(kernel_name("small_topk", dtype).c_str());
       record_profile_event(ProfileEvent::TopKGpu);
     }
 
@@ -3270,7 +3328,7 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                              inputMatrix:input_matrix
                        resultIndexMatrix:indices_matrix
                        resultValueMatrix:values_matrix];
-      record_compute_dispatch();
+      record_compute_dispatch("mps_matrix_topk");
       record_profile_event(ProfileEvent::TopKGpu);
 
 #if !__has_feature(objc_arc)
@@ -3928,7 +3986,7 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       [encoder dispatchThreadgroups:MTLSizeMake(static_cast<NSUInteger>(batch_size), 1, 1)
                threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
       [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-      record_compute_dispatch();
+      record_compute_dispatch(kernel_name("top_p_mask", dtype).c_str());
     }
 
     static std::atomic<uint64_t> g_random_counter{0};

--- a/src/mps/kernels.mm
+++ b/src/mps/kernels.mm
@@ -1,0 +1,3191 @@
+#ifdef __APPLE__
+#ifdef CT2_WITH_MPS
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "mps/kernels.h"
+#include "mps/utils.h"
+
+namespace ctranslate2 {
+  namespace mps {
+    namespace {
+
+      static constexpr const char* kMetalSource = R"METAL(
+#include <metal_stdlib>
+using namespace metal;
+
+struct ElementwiseArgs {
+  ulong size;
+  uint op;
+  float scalar;
+};
+
+struct FillArgs {
+  ulong size;
+  float float_value;
+  int int_value;
+};
+
+struct BroadcastArgs {
+  ulong a_size;
+  ulong b_size;
+  ulong block;
+  uint op;
+};
+
+struct Transpose2DArgs {
+  ulong rows;
+  ulong cols;
+};
+
+struct TransposeNDArgs {
+  ulong d0;
+  ulong d1;
+  ulong d2;
+  ulong d3;
+  ulong p0;
+  ulong p1;
+  ulong p2;
+  ulong p3;
+};
+
+struct SoftmaxArgs {
+  ulong batch_size;
+  ulong depth;
+  uint has_lengths;
+  uint log_output;
+};
+
+struct MeanArgs {
+  ulong outer_size;
+  ulong axis_size;
+  ulong inner_size;
+  uint get_sum;
+};
+
+struct NormArgs {
+  ulong outer_size;
+  ulong axis_size;
+  ulong inner_size;
+  float epsilon;
+  uint has_gamma;
+  uint has_beta;
+  uint use_residual;
+};
+
+struct RotaryArgs {
+  ulong size;
+  ulong max_time;
+  ulong ndims;
+  ulong depth;
+  uint interleave;
+};
+
+struct Im2Col1DArgs {
+  ulong total;
+  ulong batch_size;
+  ulong groups;
+  ulong input_length;
+  ulong kernel_size;
+  ulong stride;
+  ulong padding;
+  ulong dilation;
+  ulong output_length;
+  ulong k;
+  ulong in_batch_stride;
+  ulong in_group_stride;
+};
+
+struct GemvArgs {
+  ulong m;
+  ulong n;
+  ulong k;
+  ulong lda;
+  ulong ldb;
+  ulong ldc;
+  ulong stridea;
+  ulong strideb;
+  ulong stridec;
+  ulong batch_size;
+  uint transpose_a;
+  uint transpose_b;
+  float alpha;
+  float beta;
+};
+
+struct GenericGemmArgs {
+  ulong m;
+  ulong n;
+  ulong k;
+  ulong lda;
+  ulong ldb;
+  ulong ldc;
+  ulong stridea;
+  ulong strideb;
+  ulong stridec;
+  ulong batch_size;
+  uint transpose_a;
+  uint transpose_b;
+  float alpha;
+  float beta;
+};
+
+struct TiledGemmArgs {
+  uint m;
+  uint n;
+  uint k;
+  uint lda;
+  uint ldb;
+  uint ldc;
+  uint stridea;
+  uint strideb;
+  uint stridec;
+  uint batch_size;
+  uint transpose_a;
+  uint transpose_b;
+  float alpha;
+  float beta;
+};
+
+struct SmallTopKArgs {
+  uint batch_size;
+  uint depth;
+  uint k;
+};
+
+struct IndexedFillArgs {
+  uint size;
+  float float_value;
+  int int_value;
+};
+
+struct LengthMaskArgs {
+  uint batch_size;
+  uint num_heads;
+  uint num_queries;
+  uint mask_future;
+  uint multi_query;
+};
+
+struct GatherArgs {
+  ulong copy_size;
+  ulong batch_stride;
+  ulong num_indices;
+  ulong num_indices_per_batch;
+};
+
+struct TileArgs {
+  ulong outer_size;
+  ulong inner_size;
+  ulong num_tiles;
+};
+
+struct BiasAddArgs {
+  ulong bias_size;
+  ulong value_size;
+  ulong block;
+  uint block_broadcast;
+  uint has_residual;
+  int activation;
+};
+
+static inline ushort f32_to_bf16(float x) {
+  uint bits = as_type<uint>(x);
+  uint rounding_bias = 0x00007fffu + ((bits >> 16) & 1u);
+  return ushort((bits + rounding_bias) >> 16);
+}
+
+static inline float bf16_to_f32(ushort x) {
+  return as_type<float>(uint(x) << 16);
+}
+
+static inline float erf_approx(float x) {
+  const float sign = x < 0.0f ? -1.0f : 1.0f;
+  const float ax = fabs(x);
+  const float t = 1.0f / (1.0f + 0.3275911f * ax);
+  const float p = (((((1.061405429f * t - 1.453152027f) * t) + 1.421413741f) * t
+                    - 0.284496736f) * t + 0.254829592f) * t;
+  return sign * (1.0f - p * exp(-ax * ax));
+}
+
+static inline float apply_unary(float x, uint op) {
+  switch (op) {
+    case 0: return exp(x);
+    case 1: return log(x);
+    case 2: return cos(x);
+    case 3: return sin(x);
+    case 4: return tanh(x);
+    case 5: return max(x, 0.0f);
+    case 6: return 0.5f * x * (1.0f + erf_approx(x * 0.7071067811865475f));
+    case 7: return 0.5f * x * (1.0f + tanh(0.7978845608028654f * (x + 0.044715f * x * x * x)));
+    case 8: return x / (1.0f + exp(-1.702f * x));
+    case 9: return 1.0f / (1.0f + exp(-x));
+    case 10: return x / (1.0f + exp(-x));
+    default: return x;
+  }
+}
+
+static inline float apply_binary(float a, float b, uint op) {
+  switch (op) {
+    case 0: return a + b;
+    case 1: return a - b;
+    case 2: return a * b;
+    case 3: return max(a, b);
+    case 4: return min(a, b);
+    default: return a;
+  }
+}
+
+kernel void fill_f32(device float* y [[buffer(0)]],
+                     constant FillArgs& args [[buffer(1)]],
+                     uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  y[gid] = args.float_value;
+}
+
+kernel void fill_f16(device half* y [[buffer(0)]],
+                     constant FillArgs& args [[buffer(1)]],
+                     uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  y[gid] = half(args.float_value);
+}
+
+kernel void fill_bf16(device ushort* y [[buffer(0)]],
+                      constant FillArgs& args [[buffer(1)]],
+                      uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  y[gid] = f32_to_bf16(args.float_value);
+}
+
+kernel void fill_i8(device char* y [[buffer(0)]],
+                    constant FillArgs& args [[buffer(1)]],
+                    uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  y[gid] = char(args.int_value);
+}
+
+kernel void fill_i16(device short* y [[buffer(0)]],
+                     constant FillArgs& args [[buffer(1)]],
+                     uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  y[gid] = short(args.int_value);
+}
+
+kernel void fill_i32(device int* y [[buffer(0)]],
+                     constant FillArgs& args [[buffer(1)]],
+                     uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  y[gid] = args.int_value;
+}
+
+#define INDEXED_FILL_KERNEL(NAME, TYPE, VALUE)                                        \
+kernel void NAME(device TYPE* y [[buffer(0)]],                                        \
+                 device const int* indices [[buffer(1)]],                             \
+                 constant IndexedFillArgs& args [[buffer(2)]],                        \
+                 uint gid [[thread_position_in_grid]]) {                              \
+  if (gid < args.size) y[indices[gid]] = VALUE;                                       \
+}
+
+INDEXED_FILL_KERNEL(indexed_fill_f32, float, args.float_value)
+INDEXED_FILL_KERNEL(indexed_fill_f16, half, half(args.float_value))
+INDEXED_FILL_KERNEL(indexed_fill_bf16, ushort, f32_to_bf16(args.float_value))
+INDEXED_FILL_KERNEL(indexed_fill_i8, char, char(args.int_value))
+INDEXED_FILL_KERNEL(indexed_fill_i16, short, short(args.int_value))
+INDEXED_FILL_KERNEL(indexed_fill_i32, int, args.int_value)
+
+kernel void prepare_length_mask(device const int* lengths [[buffer(0)]],
+                                device int* mask [[buffer(1)]],
+                                constant LengthMaskArgs& args [[buffer(2)]],
+                                uint gid [[thread_position_in_grid]]) {
+  const uint per_batch = args.num_heads * args.num_queries;
+  const uint total = args.batch_size * per_batch;
+  if (gid >= total) return;
+  const uint batch = gid / per_batch;
+  const uint local = gid - batch * per_batch;
+  const int length = lengths[batch];
+  if (args.mask_future) {
+    const uint query = args.multi_query ? local / args.num_heads
+                                        : local % args.num_queries;
+    mask[gid] = min(length, int(query + 1));
+  } else {
+    mask[gid] = length;
+  }
+}
+
+kernel void unary_f32(device const float* x [[buffer(0)]],
+                      device float* y [[buffer(1)]],
+                      constant ElementwiseArgs& args [[buffer(2)]],
+                      uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  y[gid] = apply_unary(x[gid], args.op);
+}
+
+kernel void unary_f16(device const half* x [[buffer(0)]],
+                      device half* y [[buffer(1)]],
+                      constant ElementwiseArgs& args [[buffer(2)]],
+                      uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  y[gid] = half(apply_unary(float(x[gid]), args.op));
+}
+
+kernel void unary_bf16(device const ushort* x [[buffer(0)]],
+                       device ushort* y [[buffer(1)]],
+                       constant ElementwiseArgs& args [[buffer(2)]],
+                       uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  y[gid] = f32_to_bf16(apply_unary(bf16_to_f32(x[gid]), args.op));
+}
+
+kernel void binary_f32(device const float* a [[buffer(0)]],
+                       device const float* b [[buffer(1)]],
+                       device float* c [[buffer(2)]],
+                       constant ElementwiseArgs& args [[buffer(3)]],
+                       uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  c[gid] = apply_binary(a[gid], b[gid], args.op);
+}
+
+kernel void binary_f16(device const half* a [[buffer(0)]],
+                       device const half* b [[buffer(1)]],
+                       device half* c [[buffer(2)]],
+                       constant ElementwiseArgs& args [[buffer(3)]],
+                       uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  c[gid] = half(apply_binary(float(a[gid]), float(b[gid]), args.op));
+}
+
+kernel void binary_bf16(device const ushort* a [[buffer(0)]],
+                        device const ushort* b [[buffer(1)]],
+                        device ushort* c [[buffer(2)]],
+                        constant ElementwiseArgs& args [[buffer(3)]],
+                        uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  c[gid] = f32_to_bf16(apply_binary(bf16_to_f32(a[gid]), bf16_to_f32(b[gid]), args.op));
+}
+
+kernel void scalar_f32(device const float* x [[buffer(0)]],
+                       device float* y [[buffer(1)]],
+                       constant ElementwiseArgs& args [[buffer(2)]],
+                       uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  y[gid] = apply_binary(args.scalar, x[gid], args.op);
+}
+
+kernel void scalar_f16(device const half* x [[buffer(0)]],
+                       device half* y [[buffer(1)]],
+                       constant ElementwiseArgs& args [[buffer(2)]],
+                       uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  y[gid] = half(apply_binary(args.scalar, float(x[gid]), args.op));
+}
+
+kernel void scalar_bf16(device const ushort* x [[buffer(0)]],
+                        device ushort* y [[buffer(1)]],
+                        constant ElementwiseArgs& args [[buffer(2)]],
+                        uint gid [[thread_position_in_grid]]) {
+  if ((ulong)gid >= args.size) return;
+  y[gid] = f32_to_bf16(apply_binary(args.scalar, bf16_to_f32(x[gid]), args.op));
+}
+
+template <typename T>
+static inline float load_value(device const T* x, ulong i) { return float(x[i]); }
+
+static inline float load_value_bf16(device const ushort* x, ulong i) { return bf16_to_f32(x[i]); }
+
+template <typename T>
+static inline void store_value(device T* y, ulong i, float v) { y[i] = T(v); }
+
+static inline void store_value_bf16(device ushort* y, ulong i, float v) { y[i] = f32_to_bf16(v); }
+
+#define GEMV_KERNEL(NAME, TYPE, LOAD, STORE)                                            \
+kernel void NAME(device const TYPE* a [[buffer(0)]],                                    \
+                 device const TYPE* b [[buffer(1)]],                                    \
+                 device TYPE* c [[buffer(2)]],                                          \
+                 constant GemvArgs& args [[buffer(3)]],                                 \
+                 threadgroup float* scratch [[threadgroup(0)]],                         \
+                 uint row_id [[threadgroup_position_in_grid]],                          \
+                 uint tid [[thread_index_in_threadgroup]],                              \
+                 uint nt [[threads_per_threadgroup]],                                   \
+                 uint lane [[thread_index_in_simdgroup]],                               \
+                 uint simd_id [[simdgroup_index_in_threadgroup]],                       \
+                 uint simd_groups [[simdgroups_per_threadgroup]]) {                     \
+  ulong out_id = (ulong)row_id;                                                          \
+  ulong rows = args.batch_size * args.m;                                                 \
+  if (out_id >= rows) return;                                                            \
+  ulong batch = out_id / args.m;                                                         \
+  ulong row = out_id - batch * args.m;                                                   \
+  ulong a_base = args.stridea == 0 ? 0 : batch * args.stridea;                           \
+  ulong b_base = args.strideb == 0 ? 0 : batch * args.strideb;                           \
+  ulong c_base = args.stridec == 0 ? 0 : batch * args.stridec;                           \
+  float sum = 0.0f;                                                                      \
+  for (ulong p = (ulong)tid; p < args.k; p += (ulong)nt) {                               \
+    ulong ai = args.transpose_a ? (p * args.lda + row) : (row * args.lda + p);           \
+    ulong bi = args.transpose_b ? p : (p * args.ldb);                                    \
+    sum += LOAD(a, a_base + ai) * LOAD(b, b_base + bi);                                  \
+  }                                                                                      \
+  float partial = simd_sum(sum);                                                         \
+  if (lane == 0) scratch[simd_id] = partial;                                             \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                       \
+  if (simd_id == 0) {                                                                    \
+    float total = tid < simd_groups ? scratch[tid] : 0.0f;                               \
+    total = simd_sum(total);                                                             \
+    if (lane != 0) return;                                                               \
+    ulong ci = c_base + row * args.ldc;                                                  \
+    float old_value = args.beta == 0.0f ? 0.0f : LOAD(c, ci);                            \
+    STORE(c, ci, args.alpha * total + args.beta * old_value);                            \
+  }                                                                                      \
+}
+
+GEMV_KERNEL(gemv_f32, float, load_value<float>, store_value<float>)
+GEMV_KERNEL(gemv_f16, half, load_value<half>, store_value<half>)
+GEMV_KERNEL(gemv_bf16, ushort, load_value_bf16, store_value_bf16)
+
+#define GEMV_ROW_KERNEL(NAME, TYPE, LOAD, STORE)                                        \
+kernel void NAME(device const TYPE* a [[buffer(0)]],                                    \
+                 device const TYPE* b [[buffer(1)]],                                    \
+                 device TYPE* c [[buffer(2)]],                                          \
+                 constant GemvArgs& args [[buffer(3)]],                                 \
+                 threadgroup float* scratch [[threadgroup(0)]],                         \
+                 uint output_id [[threadgroup_position_in_grid]],                       \
+                 uint tid [[thread_index_in_threadgroup]],                              \
+                 uint nt [[threads_per_threadgroup]],                                   \
+                 uint lane [[thread_index_in_simdgroup]],                               \
+                 uint simd_id [[simdgroup_index_in_threadgroup]],                       \
+                 uint simd_groups [[simdgroups_per_threadgroup]]) {                     \
+  ulong out_id = (ulong)output_id;                                                       \
+  ulong outputs = args.batch_size * args.n;                                              \
+  if (out_id >= outputs) return;                                                         \
+  ulong batch = out_id / args.n;                                                         \
+  ulong column = out_id - batch * args.n;                                                \
+  ulong a_base = args.stridea == 0 ? 0 : batch * args.stridea;                           \
+  ulong b_base = args.strideb == 0 ? 0 : batch * args.strideb;                           \
+  ulong c_base = args.stridec == 0 ? 0 : batch * args.stridec;                           \
+  float sum = 0.0f;                                                                      \
+  for (ulong p = (ulong)tid; p < args.k; p += (ulong)nt) {                               \
+    ulong ai = args.transpose_a ? p * args.lda : p;                                      \
+    ulong bi = args.transpose_b ? column * args.ldb + p : p * args.ldb + column;         \
+    sum += LOAD(a, a_base + ai) * LOAD(b, b_base + bi);                                  \
+  }                                                                                      \
+  float partial = simd_sum(sum);                                                         \
+  if (lane == 0) scratch[simd_id] = partial;                                             \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                       \
+  if (simd_id == 0) {                                                                    \
+    float total = tid < simd_groups ? scratch[tid] : 0.0f;                               \
+    total = simd_sum(total);                                                             \
+    if (lane != 0) return;                                                               \
+    ulong ci = c_base + column;                                                          \
+    float old_value = args.beta == 0.0f ? 0.0f : LOAD(c, ci);                            \
+    STORE(c, ci, args.alpha * total + args.beta * old_value);                            \
+  }                                                                                      \
+}
+
+GEMV_ROW_KERNEL(gemv_row_f32, float, load_value<float>, store_value<float>)
+GEMV_ROW_KERNEL(gemv_row_f16, half, load_value<half>, store_value<half>)
+GEMV_ROW_KERNEL(gemv_row_bf16, ushort, load_value_bf16, store_value_bf16)
+
+// Output-major FP16 matvec adapted from the dispatch geometry used by MLX's
+// gemv kernel (Apache-2.0, MLX commit recorded in the benchmark report).  One
+// 256-thread group contains 8 SIMD groups and produces 4 outputs per SIMD
+// group, reducing threadgroup launch count by 32x for large projections.
+kernel void gemv_row_output_major_f16(
+    device const half* a [[buffer(0)]],
+    device const half* b [[buffer(1)]],
+    device half* c [[buffer(2)]],
+    constant GemvArgs& args [[buffer(3)]],
+    uint3 group [[threadgroup_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]],
+    uint simd_id [[simdgroup_index_in_threadgroup]]) {
+  const uint batch = group.y;
+  const uint first_output = group.x * 32u + simd_id * 4u;
+  const ulong a_base = args.stridea == 0 ? 0 : ulong(batch) * args.stridea;
+  const ulong b_base = args.strideb == 0 ? 0 : ulong(batch) * args.strideb;
+  const ulong c_base = args.stridec == 0 ? 0 : ulong(batch) * args.stridec;
+
+  for (uint output_delta = 0; output_delta < 4; ++output_delta) {
+    const uint output = first_output + output_delta;
+    if (output >= args.n)
+      continue;
+
+    float sum = 0.0f;
+    const ulong weight_row = b_base + ulong(output) * args.ldb;
+    if (args.transpose_a == 0 && (args.k & 1ul) == 0) {
+      device const half2* av = reinterpret_cast<device const half2*>(a + a_base);
+      device const half2* bv = reinterpret_cast<device const half2*>(b + weight_row);
+      const uint pairs = uint(args.k >> 1);
+      for (uint p = lane; p < pairs; p += 32u) {
+        const half2 ah = av[p];
+        const half2 bh = bv[p];
+        sum += float(ah.x) * float(bh.x) + float(ah.y) * float(bh.y);
+      }
+    } else {
+      for (ulong p = lane; p < args.k; p += 32ul) {
+        const ulong ai = args.transpose_a ? p * args.lda : p;
+        sum += float(a[a_base + ai]) * float(b[weight_row + p]);
+      }
+    }
+    sum = simd_sum(sum);
+    if (lane == 0) {
+      const ulong ci = c_base + output;
+      const float previous = args.beta == 0.0f ? 0.0f : float(c[ci]);
+      c[ci] = half(args.alpha * sum + args.beta * previous);
+    }
+  }
+}
+
+#define GENERIC_GEMM_KERNEL(NAME, TYPE, LOAD, STORE)                                  \
+kernel void NAME(device const TYPE* a [[buffer(0)]],                                  \
+                 device const TYPE* b [[buffer(1)]],                                  \
+                 device TYPE* c [[buffer(2)]],                                        \
+                 constant GenericGemmArgs& args [[buffer(3)]],                        \
+                 uint gid [[thread_position_in_grid]]) {                              \
+  ulong index = (ulong)gid;                                                            \
+  ulong matrix_size = args.m * args.n;                                                 \
+  ulong total = args.batch_size * matrix_size;                                         \
+  if (index >= total) return;                                                          \
+  ulong batch = index / matrix_size;                                                   \
+  ulong matrix_index = index - batch * matrix_size;                                    \
+  ulong row = matrix_index / args.n;                                                   \
+  ulong column = matrix_index - row * args.n;                                          \
+  ulong a_base = args.stridea == 0 ? 0 : batch * args.stridea;                         \
+  ulong b_base = args.strideb == 0 ? 0 : batch * args.strideb;                         \
+  ulong c_base = args.stridec == 0 ? 0 : batch * args.stridec;                         \
+  float sum = 0.0f;                                                                    \
+  for (ulong p = 0; p < args.k; ++p) {                                                 \
+    ulong ai = args.transpose_a ? p * args.lda + row : row * args.lda + p;             \
+    ulong bi = args.transpose_b ? column * args.ldb + p : p * args.ldb + column;       \
+    sum += LOAD(a, a_base + ai) * LOAD(b, b_base + bi);                                \
+  }                                                                                    \
+  ulong ci = c_base + row * args.ldc + column;                                         \
+  float old_value = args.beta == 0.0f ? 0.0f : LOAD(c, ci);                            \
+  STORE(c, ci, args.alpha * sum + args.beta * old_value);                              \
+}
+
+GENERIC_GEMM_KERNEL(generic_gemm_f32, float, load_value<float>, store_value<float>)
+GENERIC_GEMM_KERNEL(generic_gemm_f16, half, load_value<half>, store_value<half>)
+
+#define TILED_GEMM_KERNEL(NAME, TYPE, LOAD, STORE)                                   \
+kernel void NAME(device const TYPE* a [[buffer(0)]],                                 \
+                 device const TYPE* b [[buffer(1)]],                                 \
+                 device TYPE* c [[buffer(2)]],                                       \
+                 constant TiledGemmArgs& args [[buffer(3)]],                         \
+                 threadgroup float* tiles [[threadgroup(0)]],                        \
+                 uint3 group [[threadgroup_position_in_grid]],                       \
+                 uint3 tid [[thread_position_in_threadgroup]]) {                     \
+  const uint row = group.y * 16u + tid.y;                                             \
+  const uint column = group.x * 16u + tid.x;                                          \
+  const uint batch = group.z;                                                         \
+  const uint a_base = args.stridea == 0 ? 0 : batch * args.stridea;                  \
+  const uint b_base = args.strideb == 0 ? 0 : batch * args.strideb;                  \
+  const uint c_base = args.stridec == 0 ? 0 : batch * args.stridec;                  \
+  threadgroup float* tile_a = tiles;                                                  \
+  threadgroup float* tile_b = tiles + 256;                                            \
+  float sum = 0.0f;                                                                   \
+  for (uint base_k = 0; base_k < args.k; base_k += 16u) {                             \
+    const uint ak = base_k + tid.x;                                                   \
+    const uint bk = base_k + tid.y;                                                   \
+    float av = 0.0f;                                                                  \
+    float bv = 0.0f;                                                                  \
+    if (row < args.m && ak < args.k) {                                                \
+      const uint ai = args.transpose_a ? ak * args.lda + row                         \
+                                       : row * args.lda + ak;                         \
+      av = LOAD(a, a_base + ai);                                                      \
+    }                                                                                 \
+    if (column < args.n && bk < args.k) {                                             \
+      const uint bi = args.transpose_b ? column * args.ldb + bk                      \
+                                       : bk * args.ldb + column;                      \
+      bv = LOAD(b, b_base + bi);                                                      \
+    }                                                                                 \
+    tile_a[tid.y * 16u + tid.x] = av;                                                 \
+    tile_b[tid.y * 16u + tid.x] = bv;                                                 \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                  \
+    for (uint p = 0; p < 16u; ++p)                                                   \
+      sum += tile_a[tid.y * 16u + p] * tile_b[p * 16u + tid.x];                      \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                  \
+  }                                                                                   \
+  if (row < args.m && column < args.n) {                                              \
+    const uint ci = c_base + row * args.ldc + column;                                 \
+    const float previous = args.beta == 0.0f ? 0.0f : LOAD(c, ci);                   \
+    STORE(c, ci, args.alpha * sum + args.beta * previous);                            \
+  }                                                                                   \
+}
+
+TILED_GEMM_KERNEL(tiled_gemm_f32, float, load_value<float>, store_value<float>)
+TILED_GEMM_KERNEL(tiled_gemm_f16, half, load_value<half>, store_value<half>)
+
+static inline bool topk_better(float av, uint ai, float bv, uint bi) {
+  return av > bv || (av == bv && ai < bi);
+}
+
+#define SMALL_TOPK_KERNEL(NAME, TYPE, LOAD, STORE)                                    \
+kernel void NAME(device const TYPE* input [[buffer(0)]],                              \
+                 device TYPE* values [[buffer(1)]],                                   \
+                 device int* indices [[buffer(2)]],                                   \
+                 constant SmallTopKArgs& args [[buffer(3)]],                          \
+                 threadgroup float* shared_values [[threadgroup(0)]],                 \
+                 threadgroup uint* shared_indices [[threadgroup(1)]],                 \
+                 uint row [[threadgroup_position_in_grid]],                           \
+                 uint tid [[thread_index_in_threadgroup]],                            \
+                 uint nt [[threads_per_threadgroup]]) {                               \
+  if (row >= args.batch_size) return;                                                  \
+  float local_values[8];                                                              \
+  uint local_indices[8];                                                              \
+  for (uint rank = 0; rank < 8; ++rank) {                                             \
+    local_values[rank] = -INFINITY;                                                   \
+    local_indices[rank] = UINT_MAX;                                                   \
+  }                                                                                   \
+  const uint row_offset = row * args.depth;                                           \
+  for (uint column = tid; column < args.depth; column += nt) {                        \
+    const float candidate = LOAD(input, row_offset + column);                         \
+    uint insert = args.k;                                                             \
+    for (uint rank = 0; rank < args.k; ++rank) {                                      \
+      if (topk_better(candidate, column, local_values[rank], local_indices[rank])) {   \
+        insert = rank;                                                                \
+        break;                                                                        \
+      }                                                                               \
+    }                                                                                 \
+    if (insert < args.k) {                                                            \
+      for (uint rank = args.k - 1; rank > insert; --rank) {                          \
+        local_values[rank] = local_values[rank - 1];                                  \
+        local_indices[rank] = local_indices[rank - 1];                                \
+      }                                                                               \
+      local_values[insert] = candidate;                                               \
+      local_indices[insert] = column;                                                 \
+    }                                                                                 \
+  }                                                                                   \
+  for (uint rank = 0; rank < args.k; ++rank) {                                        \
+    shared_values[tid] = local_values[0];                                             \
+    shared_indices[tid] = local_indices[0];                                           \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                  \
+    for (uint stride = nt >> 1; stride > 0; stride >>= 1) {                          \
+      if (tid < stride && topk_better(shared_values[tid + stride],                    \
+                                      shared_indices[tid + stride],                   \
+                                      shared_values[tid],                             \
+                                      shared_indices[tid])) {                         \
+        shared_values[tid] = shared_values[tid + stride];                             \
+        shared_indices[tid] = shared_indices[tid + stride];                           \
+      }                                                                               \
+      threadgroup_barrier(mem_flags::mem_threadgroup);                                \
+    }                                                                                 \
+    if (tid == 0) {                                                                   \
+      STORE(values, row * args.k + rank, shared_values[0]);                           \
+      indices[row * args.k + rank] = int(shared_indices[0]);                         \
+    }                                                                                 \
+    const uint selected = shared_indices[0];                                          \
+    if (local_indices[0] == selected) {                                               \
+      for (uint next = 1; next < args.k; ++next) {                                   \
+        local_values[next - 1] = local_values[next];                                 \
+        local_indices[next - 1] = local_indices[next];                               \
+      }                                                                               \
+      local_values[args.k - 1] = -INFINITY;                                           \
+      local_indices[args.k - 1] = UINT_MAX;                                           \
+    }                                                                                 \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                  \
+  }                                                                                   \
+}
+
+SMALL_TOPK_KERNEL(small_topk_f32, float, load_value<float>, store_value<float>)
+SMALL_TOPK_KERNEL(small_topk_f16, half, load_value<half>, store_value<half>)
+
+#define GATHER_KERNEL(NAME, TYPE)                                                     \
+kernel void NAME(device const TYPE* input [[buffer(0)]],                              \
+                 device const int* indices [[buffer(1)]],                             \
+                 device TYPE* output [[buffer(2)]],                                   \
+                 constant GatherArgs& args [[buffer(3)]],                             \
+                 uint gid [[thread_position_in_grid]]) {                              \
+  ulong out = (ulong)gid;                                                              \
+  ulong total = args.num_indices * args.copy_size;                                     \
+  if (out >= total) return;                                                            \
+  ulong index_id = out / args.copy_size;                                               \
+  ulong within = out - index_id * args.copy_size;                                      \
+  ulong batch = index_id / args.num_indices_per_batch;                                 \
+  ulong source = batch * args.batch_stride + ulong(indices[index_id]) * args.copy_size;\
+  output[out] = input[source + within];                                                 \
+}
+
+GATHER_KERNEL(gather_f32, float)
+GATHER_KERNEL(gather_f16, half)
+GATHER_KERNEL(gather_bf16, ushort)
+GATHER_KERNEL(gather_i8, char)
+GATHER_KERNEL(gather_i16, short)
+GATHER_KERNEL(gather_i32, int)
+
+#define TILE_KERNEL(NAME, TYPE)                                                       \
+kernel void NAME(device const TYPE* input [[buffer(0)]],                              \
+                 device TYPE* output [[buffer(1)]],                                   \
+                 constant TileArgs& args [[buffer(2)]],                               \
+                 uint gid [[thread_position_in_grid]]) {                              \
+  ulong out = (ulong)gid;                                                              \
+  ulong group = args.num_tiles * args.inner_size;                                      \
+  ulong total = args.outer_size * group;                                               \
+  if (out >= total) return;                                                            \
+  ulong outer = out / group;                                                           \
+  ulong within = out % args.inner_size;                                                \
+  output[out] = input[outer * args.inner_size + within];                               \
+}
+
+TILE_KERNEL(tile_f32, float)
+TILE_KERNEL(tile_f16, half)
+TILE_KERNEL(tile_bf16, ushort)
+TILE_KERNEL(tile_i8, char)
+TILE_KERNEL(tile_i16, short)
+TILE_KERNEL(tile_i32, int)
+
+#define BIAS_ADD_KERNEL(NAME, TYPE, LOAD, STORE)                                      \
+kernel void NAME(device const TYPE* bias [[buffer(0)]],                               \
+                 device const TYPE* value [[buffer(1)]],                              \
+                 device const TYPE* residual [[buffer(2)]],                           \
+                 device TYPE* output [[buffer(3)]],                                   \
+                 constant BiasAddArgs& args [[buffer(4)]],                            \
+                 uint gid [[thread_position_in_grid]]) {                              \
+  ulong i = (ulong)gid;                                                                \
+  if (i >= args.value_size) return;                                                    \
+  /* The CPU block-broadcast mapping simplifies to i % bias_size. */                   \
+  ulong bias_index = i % args.bias_size;                                               \
+  float result = LOAD(value, i) + LOAD(bias, bias_index);                              \
+  if (args.has_residual) result += LOAD(residual, i);                                  \
+  if (args.activation >= 0) result = apply_unary(result, uint(args.activation));       \
+  STORE(output, i, result);                                                            \
+}
+
+BIAS_ADD_KERNEL(bias_add_f32, float, load_value<float>, store_value<float>)
+BIAS_ADD_KERNEL(bias_add_f16, half, load_value<half>, store_value<half>)
+BIAS_ADD_KERNEL(bias_add_bf16, ushort, load_value_bf16, store_value_bf16)
+
+#define BROADCAST_KERNEL(NAME, TYPE, LOAD, STORE)                                      \
+kernel void NAME(device const TYPE* a [[buffer(0)]],                                   \
+                 device const TYPE* b [[buffer(1)]],                                   \
+                 device TYPE* c [[buffer(2)]],                                         \
+                 constant BroadcastArgs& args [[buffer(3)]],                           \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  ulong i = (ulong)gid;                                                                 \
+  if (i >= args.b_size) return;                                                         \
+  ulong ai = 0;                                                                         \
+  if (args.block == 0) {                                                                \
+    ai = i % args.a_size;                                                               \
+  } else if (args.block == 1) {                                                         \
+    ulong depth = args.a_size == 0 ? 0 : args.b_size / args.a_size;                     \
+    ai = depth == 0 ? 0 : i / depth;                                                    \
+  } else {                                                                              \
+    /* Preserve the offset within each block; this is equivalent to i % a_size. */      \
+    ai = i % args.a_size;                                                               \
+  }                                                                                     \
+  STORE(c, i, apply_binary(LOAD(a, ai), LOAD(b, i), args.op));                          \
+}
+
+BROADCAST_KERNEL(broadcast_f32, float, load_value<float>, store_value<float>)
+BROADCAST_KERNEL(broadcast_f16, half, load_value<half>, store_value<half>)
+BROADCAST_KERNEL(broadcast_bf16, ushort, load_value_bf16, store_value_bf16)
+
+#define TRANSPOSE_2D_KERNEL(NAME, TYPE)                                                \
+kernel void NAME(device const TYPE* a [[buffer(0)]],                                   \
+                 device TYPE* b [[buffer(1)]],                                         \
+                 constant Transpose2DArgs& args [[buffer(2)]],                         \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  ulong i = (ulong)gid;                                                                 \
+  ulong size = args.rows * args.cols;                                                   \
+  if (i >= size) return;                                                                \
+  ulong r = i / args.cols;                                                              \
+  ulong c = i - r * args.cols;                                                         \
+  b[c * args.rows + r] = a[i];                                                         \
+}
+
+TRANSPOSE_2D_KERNEL(transpose_2d_f32, float)
+TRANSPOSE_2D_KERNEL(transpose_2d_f16, half)
+TRANSPOSE_2D_KERNEL(transpose_2d_bf16, ushort)
+
+#define TRANSPOSE_3D_KERNEL(NAME, TYPE)                                                \
+kernel void NAME(device const TYPE* a [[buffer(0)]],                                   \
+                 device TYPE* b [[buffer(1)]],                                         \
+                 constant TransposeNDArgs& args [[buffer(2)]],                         \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  ulong bd0 = args.p0 == 0 ? args.d0 : (args.p0 == 1 ? args.d1 : args.d2);             \
+  ulong bd1 = args.p1 == 0 ? args.d0 : (args.p1 == 1 ? args.d1 : args.d2);             \
+  ulong bd2 = args.p2 == 0 ? args.d0 : (args.p2 == 1 ? args.d1 : args.d2);             \
+  ulong size = bd0 * bd1 * bd2;                                                        \
+  ulong idx = (ulong)gid;                                                               \
+  if (idx >= size) return;                                                              \
+  ulong i0 = idx / (bd1 * bd2);                                                        \
+  ulong rem = idx - i0 * bd1 * bd2;                                                    \
+  ulong i1 = rem / bd2;                                                                \
+  ulong i2 = rem - i1 * bd2;                                                           \
+  ulong src[3] = {0, 0, 0};                                                            \
+  src[args.p0] = i0;                                                                    \
+  src[args.p1] = i1;                                                                    \
+  src[args.p2] = i2;                                                                    \
+  ulong aidx = src[0] * args.d1 * args.d2 + src[1] * args.d2 + src[2];                 \
+  b[idx] = a[aidx];                                                                     \
+}
+
+TRANSPOSE_3D_KERNEL(transpose_3d_f32, float)
+TRANSPOSE_3D_KERNEL(transpose_3d_f16, half)
+TRANSPOSE_3D_KERNEL(transpose_3d_bf16, ushort)
+
+#define TRANSPOSE_4D_KERNEL(NAME, TYPE)                                                \
+kernel void NAME(device const TYPE* a [[buffer(0)]],                                   \
+                 device TYPE* b [[buffer(1)]],                                         \
+                 constant TransposeNDArgs& args [[buffer(2)]],                         \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  ulong dims[4] = {args.d0, args.d1, args.d2, args.d3};                                \
+  ulong perm[4] = {args.p0, args.p1, args.p2, args.p3};                                \
+  ulong bd0 = dims[perm[0]];                                                           \
+  ulong bd1 = dims[perm[1]];                                                           \
+  ulong bd2 = dims[perm[2]];                                                           \
+  ulong bd3 = dims[perm[3]];                                                           \
+  ulong size = bd0 * bd1 * bd2 * bd3;                                                  \
+  ulong idx = (ulong)gid;                                                               \
+  if (idx >= size) return;                                                              \
+  ulong i0 = idx / (bd1 * bd2 * bd3);                                                  \
+  ulong rem0 = idx - i0 * bd1 * bd2 * bd3;                                             \
+  ulong i1 = rem0 / (bd2 * bd3);                                                       \
+  ulong rem1 = rem0 - i1 * bd2 * bd3;                                                  \
+  ulong i2 = rem1 / bd3;                                                               \
+  ulong i3 = rem1 - i2 * bd3;                                                          \
+  ulong src[4] = {0, 0, 0, 0};                                                         \
+  src[perm[0]] = i0;                                                                    \
+  src[perm[1]] = i1;                                                                    \
+  src[perm[2]] = i2;                                                                    \
+  src[perm[3]] = i3;                                                                    \
+  ulong aidx = src[0] * args.d1 * args.d2 * args.d3 + src[1] * args.d2 * args.d3 +     \
+               src[2] * args.d3 + src[3];                                             \
+  b[idx] = a[aidx];                                                                     \
+}
+
+TRANSPOSE_4D_KERNEL(transpose_4d_f32, float)
+TRANSPOSE_4D_KERNEL(transpose_4d_f16, half)
+TRANSPOSE_4D_KERNEL(transpose_4d_bf16, ushort)
+
+#define SOFTMAX_KERNEL(NAME, TYPE, LOAD, STORE)                                        \
+kernel void NAME(device const TYPE* x [[buffer(0)]],                                   \
+                 device const int* lengths [[buffer(1)]],                              \
+                 device TYPE* y [[buffer(2)]],                                         \
+                 constant SoftmaxArgs& args [[buffer(3)]],                             \
+                 threadgroup float* scratch [[threadgroup(0)]],                        \
+                 uint row [[threadgroup_position_in_grid]],                            \
+                 uint tid [[thread_index_in_threadgroup]],                             \
+                 uint nt [[threads_per_threadgroup]]) {                                \
+  if ((ulong)row >= args.batch_size) return;                                           \
+  ulong depth = args.depth;                                                            \
+  ulong offset = (ulong)row * depth;                                                   \
+  ulong valid = depth;                                                                 \
+  if (args.has_lengths) {                                                              \
+    int l = lengths[row];                                                              \
+    valid = l < 0 ? 0 : min((ulong)l, depth);                                          \
+    for (ulong i = (ulong)tid; i < depth; i += (ulong)nt) {                            \
+      if (i >= valid) STORE(y, offset + i, 0.0f);                                      \
+    }                                                                                  \
+  }                                                                                    \
+  if (valid == 0) return;                                                              \
+  float m = -INFINITY;                                                                 \
+  for (ulong i = (ulong)tid; i < valid; i += (ulong)nt) {                              \
+    m = max(m, LOAD(x, offset + i));                                                   \
+  }                                                                                    \
+  scratch[tid] = m;                                                                    \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                     \
+  for (uint stride = nt >> 1; stride > 0; stride >>= 1) {                              \
+    if (tid < stride) scratch[tid] = max(scratch[tid], scratch[tid + stride]);         \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                   \
+  }                                                                                    \
+  m = scratch[0];                                                                      \
+  /* All threads must capture the maximum before scratch is reused for sums. */         \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                     \
+  float s = 0.0f;                                                                      \
+  for (ulong i = (ulong)tid; i < valid; i += (ulong)nt) {                              \
+    s += exp(LOAD(x, offset + i) - m);                                                  \
+  }                                                                                    \
+  scratch[tid] = s;                                                                    \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                     \
+  for (uint stride = nt >> 1; stride > 0; stride >>= 1) {                              \
+    if (tid < stride) scratch[tid] += scratch[tid + stride];                           \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                   \
+  }                                                                                    \
+  float log_sum = log(scratch[0]);                                                     \
+  for (ulong i = (ulong)tid; i < valid; i += (ulong)nt) {                              \
+    float v = LOAD(x, offset + i) - m;                                                 \
+    STORE(y, offset + i, args.log_output ? (v - log_sum) : exp(v - log_sum));          \
+  }                                                                                    \
+}
+
+SOFTMAX_KERNEL(softmax_f32, float, load_value<float>, store_value<float>)
+SOFTMAX_KERNEL(softmax_f16, half, load_value<half>, store_value<half>)
+SOFTMAX_KERNEL(softmax_bf16, ushort, load_value_bf16, store_value_bf16)
+
+#define MEAN_KERNEL(NAME, TYPE, LOAD, STORE)                                           \
+kernel void NAME(device const TYPE* x [[buffer(0)]],                                   \
+                 device TYPE* y [[buffer(1)]],                                         \
+                 constant MeanArgs& args [[buffer(2)]],                                \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  ulong out_size = args.outer_size * args.inner_size;                                  \
+  ulong idx = (ulong)gid;                                                              \
+  if (idx >= out_size) return;                                                         \
+  ulong outer = idx / args.inner_size;                                                 \
+  ulong inner = idx - outer * args.inner_size;                                         \
+  float sum = 0.0f;                                                                    \
+  ulong base = outer * args.axis_size * args.inner_size + inner;                       \
+  for (ulong k = 0; k < args.axis_size; ++k) {                                         \
+    sum += LOAD(x, base + k * args.inner_size);                                        \
+  }                                                                                    \
+  STORE(y, idx, args.get_sum ? sum : sum / float(args.axis_size));                     \
+}
+
+MEAN_KERNEL(mean_f32, float, load_value<float>, store_value<float>)
+MEAN_KERNEL(mean_f16, half, load_value<half>, store_value<half>)
+MEAN_KERNEL(mean_bf16, ushort, load_value_bf16, store_value_bf16)
+
+#define MEAN_ROWS_KERNEL(NAME, TYPE, LOAD, STORE)                                      \
+kernel void NAME(device const TYPE* x [[buffer(0)]],                                   \
+                 device TYPE* y [[buffer(1)]],                                         \
+                 constant MeanArgs& args [[buffer(2)]],                                \
+                 threadgroup float* scratch [[threadgroup(0)]],                        \
+                 uint row [[threadgroup_position_in_grid]],                            \
+                 uint tid [[thread_index_in_threadgroup]],                             \
+                 uint nt [[threads_per_threadgroup]]) {                                \
+  if ((ulong)row >= args.outer_size) return;                                           \
+  ulong base = (ulong)row * args.axis_size;                                            \
+  float sum = 0.0f;                                                                    \
+  for (ulong k = (ulong)tid; k < args.axis_size; k += (ulong)nt)                       \
+    sum += LOAD(x, base + k);                                                          \
+  scratch[tid] = sum;                                                                  \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                     \
+  for (uint stride = nt >> 1; stride > 0; stride >>= 1) {                              \
+    if (tid < stride) scratch[tid] += scratch[tid + stride];                           \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                   \
+  }                                                                                    \
+  if (tid == 0)                                                                        \
+    STORE(y, row, args.get_sum ? scratch[0] : scratch[0] / float(args.axis_size));     \
+}
+
+MEAN_ROWS_KERNEL(mean_rows_f32, float, load_value<float>, store_value<float>)
+MEAN_ROWS_KERNEL(mean_rows_f16, half, load_value<half>, store_value<half>)
+MEAN_ROWS_KERNEL(mean_rows_bf16, ushort, load_value_bf16, store_value_bf16)
+
+#define ARGMAX_KERNEL(NAME, TYPE, LOAD, STORE)                                         \
+kernel void NAME(device const TYPE* x [[buffer(0)]],                                   \
+                 device TYPE* values [[buffer(1)]],                                    \
+                 device int* indices [[buffer(2)]],                                    \
+                 constant SoftmaxArgs& args [[buffer(3)]],                             \
+                 threadgroup float* scratch_values [[threadgroup(0)]],                 \
+                 threadgroup uint* scratch_indices [[threadgroup(1)]],                 \
+                 uint row [[threadgroup_position_in_grid]],                            \
+                 uint tid [[thread_index_in_threadgroup]],                             \
+                 uint nt [[threads_per_threadgroup]]) {                                \
+  if ((ulong)row >= args.batch_size) return;                                           \
+  ulong offset = (ulong)row * args.depth;                                              \
+  float best_value = -INFINITY;                                                        \
+  uint best_index = 0;                                                                 \
+  for (ulong i = (ulong)tid; i < args.depth; i += (ulong)nt) {                         \
+    float value = LOAD(x, offset + i);                                                 \
+    if (value > best_value || (value == best_value && uint(i) < best_index)) {         \
+      best_value = value;                                                              \
+      best_index = uint(i);                                                            \
+    }                                                                                  \
+  }                                                                                    \
+  scratch_values[tid] = best_value;                                                    \
+  scratch_indices[tid] = best_index;                                                   \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                     \
+  for (uint stride = nt >> 1; stride > 0; stride >>= 1) {                              \
+    if (tid < stride) {                                                                \
+      float other_value = scratch_values[tid + stride];                                \
+      uint other_index = scratch_indices[tid + stride];                                \
+      if (other_value > scratch_values[tid] ||                                         \
+          (other_value == scratch_values[tid] && other_index < scratch_indices[tid])) {\
+        scratch_values[tid] = other_value;                                             \
+        scratch_indices[tid] = other_index;                                            \
+      }                                                                                \
+    }                                                                                  \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                   \
+  }                                                                                    \
+  if (tid == 0) {                                                                      \
+    STORE(values, row, scratch_values[0]);                                             \
+    indices[row] = int(scratch_indices[0]);                                            \
+  }                                                                                    \
+}
+
+ARGMAX_KERNEL(argmax_f32, float, load_value<float>, store_value<float>)
+ARGMAX_KERNEL(argmax_f16, half, load_value<half>, store_value<half>)
+
+#define LAYER_NORM_KERNEL(NAME, TYPE, LOAD, STORE)                                     \
+kernel void NAME(device const TYPE* x [[buffer(0)]],                                   \
+                 device const TYPE* gamma [[buffer(1)]],                               \
+                 device const TYPE* beta [[buffer(2)]],                                \
+                 device TYPE* y [[buffer(3)]],                                         \
+                 constant NormArgs& args [[buffer(4)]],                                \
+                 threadgroup float* scratch [[threadgroup(0)]],                        \
+                 uint row [[threadgroup_position_in_grid]],                            \
+                 uint tid [[thread_index_in_threadgroup]],                             \
+                 uint nt [[threads_per_threadgroup]]) {                                \
+  ulong total = args.outer_size * args.inner_size;                                     \
+  if ((ulong)row >= total) return;                                                     \
+  ulong outer = (ulong)row / args.inner_size;                                          \
+  ulong inner = (ulong)row - outer * args.inner_size;                                  \
+  ulong base = outer * args.axis_size * args.inner_size + inner;                       \
+  float sum = 0.0f;                                                                    \
+  float sumsq = 0.0f;                                                                  \
+  for (ulong k = (ulong)tid; k < args.axis_size; k += (ulong)nt) {                     \
+    float v = LOAD(x, base + k * args.inner_size);                                     \
+    sum += v;                                                                          \
+    sumsq += v * v;                                                                    \
+  }                                                                                    \
+  scratch[tid] = sum;                                                                  \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                     \
+  for (uint stride = nt >> 1; stride > 0; stride >>= 1) {                              \
+    if (tid < stride) scratch[tid] += scratch[tid + stride];                           \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                   \
+  }                                                                                    \
+  float total_sum = scratch[0];                                                        \
+  /* Prevent thread 0 from replacing scratch[0] before peers read total_sum. */         \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                     \
+  scratch[tid] = sumsq;                                                                \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                     \
+  for (uint stride = nt >> 1; stride > 0; stride >>= 1) {                              \
+    if (tid < stride) scratch[tid] += scratch[tid + stride];                           \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                   \
+  }                                                                                    \
+  float mean = total_sum / float(args.axis_size);                                      \
+  float variance = max(scratch[0] / float(args.axis_size) - mean * mean, 0.0f);        \
+  float rstd = rsqrt(variance + args.epsilon);                                         \
+  for (ulong k = (ulong)tid; k < args.axis_size; k += (ulong)nt) {                     \
+    ulong index = base + k * args.inner_size;                                          \
+    float v = (LOAD(x, index) - mean) * rstd;                                          \
+    if (args.has_gamma) v *= LOAD(gamma, k);                                           \
+    if (args.has_beta) v += LOAD(beta, k);                                             \
+    STORE(y, index, v);                                                                \
+  }                                                                                    \
+}
+
+LAYER_NORM_KERNEL(layer_norm_f32, float, load_value<float>, store_value<float>)
+LAYER_NORM_KERNEL(layer_norm_f16, half, load_value<half>, store_value<half>)
+LAYER_NORM_KERNEL(layer_norm_bf16, ushort, load_value_bf16, store_value_bf16)
+
+#define RMS_NORM_KERNEL(NAME, TYPE, LOAD, STORE)                                       \
+kernel void NAME(device const TYPE* x [[buffer(0)]],                                   \
+                 device const TYPE* gamma [[buffer(1)]],                               \
+                 device TYPE* y [[buffer(2)]],                                         \
+                 constant NormArgs& args [[buffer(3)]],                                \
+                 threadgroup float* scratch [[threadgroup(0)]],                        \
+                 uint row [[threadgroup_position_in_grid]],                            \
+                 uint tid [[thread_index_in_threadgroup]],                             \
+                 uint nt [[threads_per_threadgroup]]) {                                \
+  if ((ulong)row >= args.outer_size) return;                                           \
+  ulong offset = (ulong)row * args.axis_size;                                          \
+  float sumsq = 0.0f;                                                                  \
+  for (ulong k = (ulong)tid; k < args.axis_size; k += (ulong)nt) {                     \
+    float v = LOAD(x, offset + k);                                                     \
+    sumsq += v * v;                                                                    \
+  }                                                                                    \
+  scratch[tid] = sumsq;                                                                \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                     \
+  for (uint stride = nt >> 1; stride > 0; stride >>= 1) {                              \
+    if (tid < stride) scratch[tid] += scratch[tid + stride];                           \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                   \
+  }                                                                                    \
+  float inv_rms = rsqrt(scratch[0] / float(args.axis_size) + args.epsilon);            \
+  for (ulong k = (ulong)tid; k < args.axis_size; k += (ulong)nt) {                     \
+    float g = LOAD(gamma, k);                                                          \
+    if (args.use_residual) g += 1.0f;                                                  \
+    STORE(y, offset + k, LOAD(x, offset + k) * inv_rms * g);                           \
+  }                                                                                    \
+}
+
+RMS_NORM_KERNEL(rms_norm_f32, float, load_value<float>, store_value<float>)
+RMS_NORM_KERNEL(rms_norm_f16, half, load_value<half>, store_value<half>)
+RMS_NORM_KERNEL(rms_norm_bf16, ushort, load_value_bf16, store_value_bf16)
+
+#define ROTARY_KERNEL(NAME, TYPE, LOAD, STORE)                                         \
+kernel void NAME(device const TYPE* input [[buffer(0)]],                               \
+                 device const TYPE* sinv [[buffer(1)]],                                \
+                 device const TYPE* cosv [[buffer(2)]],                                \
+                 device TYPE* output [[buffer(3)]],                                    \
+                 constant RotaryArgs& args [[buffer(4)]],                              \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  ulong idx = (ulong)gid;                                                              \
+  if (idx >= args.size) return;                                                        \
+  ulong i = idx % args.depth;                                                          \
+  ulong t = (idx / args.depth) % args.max_time;                                        \
+  if (i >= args.ndims) {                                                               \
+    output[idx] = input[idx];                                                          \
+    return;                                                                            \
+  }                                                                                    \
+  ulong pair = 0;                                                                      \
+  float rotated = 0.0f;                                                                \
+  if (args.interleave) {                                                               \
+    bool even = (i & 1ul) == 0ul;                                                      \
+    pair = even ? i + 1ul : i - 1ul;                                                   \
+    rotated = (even ? -LOAD(input, idx + 1ul) : LOAD(input, idx - 1ul));               \
+  } else {                                                                             \
+    ulong middle = args.ndims / 2ul;                                                   \
+    bool first = i < middle;                                                           \
+    pair = first ? i + middle : i - middle;                                            \
+    rotated = (first ? -LOAD(input, idx + middle) : LOAD(input, idx - middle));        \
+  }                                                                                    \
+  (void)pair;                                                                          \
+  float s = LOAD(sinv, t * args.ndims + i);                                            \
+  float c = LOAD(cosv, t * args.ndims + i);                                            \
+  STORE(output, idx, LOAD(input, idx) * c + rotated * s);                              \
+}
+
+ROTARY_KERNEL(rotary_f32, float, load_value<float>, store_value<float>)
+ROTARY_KERNEL(rotary_f16, half, load_value<half>, store_value<half>)
+ROTARY_KERNEL(rotary_bf16, ushort, load_value_bf16, store_value_bf16)
+
+#define IM2COL_KERNEL(NAME, TYPE)                                                      \
+kernel void NAME(device const TYPE* input [[buffer(0)]],                               \
+                 device TYPE* output [[buffer(1)]],                                    \
+                 constant Im2Col1DArgs& args [[buffer(2)]],                            \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  ulong idx = (ulong)gid;                                                              \
+  if (idx >= args.total) return;                                                       \
+  ulong c = idx % args.k;                                                              \
+  ulong t = (idx / args.k) % args.output_length;                                       \
+  ulong g = (idx / (args.k * args.output_length)) % args.groups;                       \
+  ulong b = idx / (args.groups * args.output_length * args.k);                         \
+  ulong c_offset = c / args.kernel_size;                                               \
+  ulong k_offset = c - c_offset * args.kernel_size;                                    \
+  long in_t = long(t) * long(args.stride) - long(args.padding) +                       \
+              long(args.dilation) * long(k_offset);                                    \
+  TYPE v = TYPE(0);                                                                    \
+  if (in_t >= 0 && in_t < long(args.input_length)) {                                   \
+    ulong input_idx = b * args.in_batch_stride + g * args.in_group_stride +            \
+                      c_offset * args.input_length + ulong(in_t);                      \
+    v = input[input_idx];                                                              \
+  }                                                                                    \
+  output[idx] = v;                                                                     \
+}
+
+IM2COL_KERNEL(im2col_conv1d_f32, float)
+IM2COL_KERNEL(im2col_conv1d_f16, half)
+IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
+
+)METAL";
+
+      struct ElementwiseArgs {
+        uint64_t size;
+        uint32_t op;
+        float scalar;
+      };
+
+      struct FillArgs {
+        uint64_t size;
+        float float_value;
+        int32_t int_value;
+      };
+
+      struct BroadcastArgs {
+        uint64_t a_size;
+        uint64_t b_size;
+        uint64_t block;
+        uint32_t op;
+      };
+
+      struct Transpose2DArgs {
+        uint64_t rows;
+        uint64_t cols;
+      };
+
+      struct TransposeNDArgs {
+        uint64_t d0;
+        uint64_t d1;
+        uint64_t d2;
+        uint64_t d3;
+        uint64_t p0;
+        uint64_t p1;
+        uint64_t p2;
+        uint64_t p3;
+      };
+
+      struct SoftmaxArgs {
+        uint64_t batch_size;
+        uint64_t depth;
+        uint32_t has_lengths;
+        uint32_t log_output;
+      };
+
+      struct MeanArgs {
+        uint64_t outer_size;
+        uint64_t axis_size;
+        uint64_t inner_size;
+        uint32_t get_sum;
+      };
+
+      struct NormArgs {
+        uint64_t outer_size;
+        uint64_t axis_size;
+        uint64_t inner_size;
+        float epsilon;
+        uint32_t has_gamma;
+        uint32_t has_beta;
+        uint32_t use_residual;
+      };
+
+      struct RotaryArgs {
+        uint64_t size;
+        uint64_t max_time;
+        uint64_t ndims;
+        uint64_t depth;
+        uint32_t interleave;
+      };
+
+      struct Im2Col1DArgs {
+        uint64_t total;
+        uint64_t batch_size;
+        uint64_t groups;
+        uint64_t input_length;
+        uint64_t kernel_size;
+        uint64_t stride;
+        uint64_t padding;
+        uint64_t dilation;
+        uint64_t output_length;
+        uint64_t k;
+        uint64_t in_batch_stride;
+        uint64_t in_group_stride;
+      };
+
+      struct GemvArgs {
+        uint64_t m;
+        uint64_t n;
+        uint64_t k;
+        uint64_t lda;
+        uint64_t ldb;
+        uint64_t ldc;
+        uint64_t stridea;
+        uint64_t strideb;
+        uint64_t stridec;
+        uint64_t batch_size;
+        uint32_t transpose_a;
+        uint32_t transpose_b;
+        float alpha;
+        float beta;
+      };
+
+      struct GenericGemmArgs {
+        uint64_t m;
+        uint64_t n;
+        uint64_t k;
+        uint64_t lda;
+        uint64_t ldb;
+        uint64_t ldc;
+        uint64_t stridea;
+        uint64_t strideb;
+        uint64_t stridec;
+        uint64_t batch_size;
+        uint32_t transpose_a;
+        uint32_t transpose_b;
+        float alpha;
+        float beta;
+      };
+
+      struct TiledGemmArgs {
+        uint32_t m;
+        uint32_t n;
+        uint32_t k;
+        uint32_t lda;
+        uint32_t ldb;
+        uint32_t ldc;
+        uint32_t stridea;
+        uint32_t strideb;
+        uint32_t stridec;
+        uint32_t batch_size;
+        uint32_t transpose_a;
+        uint32_t transpose_b;
+        float alpha;
+        float beta;
+      };
+
+      struct SmallTopKArgs {
+        uint32_t batch_size;
+        uint32_t depth;
+        uint32_t k;
+      };
+
+      struct IndexedFillArgs {
+        uint32_t size;
+        float float_value;
+        int32_t int_value;
+      };
+
+      struct LengthMaskArgs {
+        uint32_t batch_size;
+        uint32_t num_heads;
+        uint32_t num_queries;
+        uint32_t mask_future;
+        uint32_t multi_query;
+      };
+
+      struct GatherArgs {
+        uint64_t copy_size;
+        uint64_t batch_stride;
+        uint64_t num_indices;
+        uint64_t num_indices_per_batch;
+      };
+
+      struct TileArgs {
+        uint64_t outer_size;
+        uint64_t inner_size;
+        uint64_t num_tiles;
+      };
+
+      struct BiasAddArgs {
+        uint64_t bias_size;
+        uint64_t value_size;
+        uint64_t block;
+        uint32_t block_broadcast;
+        uint32_t has_residual;
+        int32_t activation;
+      };
+
+      static size_t dtype_size(DataType dtype) {
+        switch (dtype) {
+        case DataType::FLOAT32:
+          return sizeof(float);
+        case DataType::FLOAT16:
+        case DataType::BFLOAT16:
+          return 2;
+        case DataType::INT8:
+          return sizeof(int8_t);
+        case DataType::INT16:
+          return sizeof(int16_t);
+        case DataType::INT32:
+          return sizeof(int32_t);
+        default:
+          throw std::invalid_argument("unsupported MPS dtype");
+        }
+      }
+
+      static const char* dtype_suffix(DataType dtype) {
+        switch (dtype) {
+        case DataType::FLOAT32:
+          return "f32";
+        case DataType::FLOAT16:
+          return "f16";
+        case DataType::BFLOAT16:
+          return "bf16";
+        default:
+          throw std::invalid_argument("MPS Metal kernels only support floating point tensors");
+        }
+      }
+
+      static const char* storage_dtype_suffix(DataType dtype) {
+        switch (dtype) {
+        case DataType::FLOAT32:
+          return "f32";
+        case DataType::FLOAT16:
+          return "f16";
+        case DataType::BFLOAT16:
+          return "bf16";
+        case DataType::INT8:
+          return "i8";
+        case DataType::INT16:
+          return "i16";
+        case DataType::INT32:
+          return "i32";
+        default:
+          throw std::invalid_argument("unsupported MPS storage dtype");
+        }
+      }
+
+      static uint32_t op_code(BinaryOp op) {
+        switch (op) {
+        case BinaryOp::ADD:
+          return 0;
+        case BinaryOp::SUB:
+          return 1;
+        case BinaryOp::MUL:
+          return 2;
+        case BinaryOp::MAX:
+          return 3;
+        case BinaryOp::MIN:
+          return 4;
+        }
+        return 0;
+      }
+
+      static uint32_t op_code(UnaryOp op) {
+        switch (op) {
+        case UnaryOp::EXP:
+          return 0;
+        case UnaryOp::LOG:
+          return 1;
+        case UnaryOp::COS:
+          return 2;
+        case UnaryOp::SIN:
+          return 3;
+        case UnaryOp::TANH:
+          return 4;
+        case UnaryOp::RELU:
+          return 5;
+        case UnaryOp::GELU:
+          return 6;
+        case UnaryOp::GELU_TANH:
+          return 7;
+        case UnaryOp::GELU_SIGMOID:
+          return 8;
+        case UnaryOp::SIGMOID:
+          return 9;
+        case UnaryOp::SWISH:
+          return 10;
+        }
+        return 0;
+      }
+
+      static id<MTLLibrary> library() {
+        static id<MTLLibrary> lib = nil;
+        static std::once_flag library_once;
+        std::call_once(library_once, [&]() {
+          id<MTLDevice> device = (__bridge id<MTLDevice>)get_device();
+          if (!device)
+            throw std::runtime_error("MPS device not available");
+
+          NSError* error = nil;
+          NSString* source = [NSString stringWithUTF8String:kMetalSource];
+          MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+          lib = [device newLibraryWithSource:source options:options error:&error];
+#if !__has_feature(objc_arc)
+          [options release];
+#endif
+          if (!lib) {
+            std::string message = "failed to compile CTranslate2 MPS kernels";
+            if (error && [error localizedDescription])
+              message += ": " + std::string([[error localizedDescription] UTF8String]);
+            throw std::runtime_error(message);
+          }
+        });
+        return lib;
+      }
+
+      static id<MTLComputePipelineState> pipeline(const std::string& name) {
+        static std::unordered_map<std::string, id<MTLComputePipelineState>> cache;
+        static std::mutex cache_mutex;
+        static thread_local std::unordered_map<std::string, id<MTLComputePipelineState>> local_cache;
+
+        auto local_it = local_cache.find(name);
+        if (local_it != local_cache.end())
+          return local_it->second;
+
+        std::lock_guard<std::mutex> lock(cache_mutex);
+        auto it = cache.find(name);
+        if (it != cache.end()) {
+          local_cache.emplace(name, it->second);
+          return it->second;
+        }
+
+        id<MTLDevice> device = (__bridge id<MTLDevice>)get_device();
+        NSString* ns_name = [NSString stringWithUTF8String:name.c_str()];
+        id<MTLFunction> function = [library() newFunctionWithName:ns_name];
+        if (!function)
+          throw std::runtime_error("MPS kernel not found: " + name);
+
+        NSError* error = nil;
+        id<MTLComputePipelineState> state = [device newComputePipelineStateWithFunction:function error:&error];
+#if !__has_feature(objc_arc)
+        [function release];
+#endif
+        if (!state) {
+          std::string message = "failed to build MPS pipeline " + name;
+          if (error && [error localizedDescription])
+            message += ": " + std::string([[error localizedDescription] UTF8String]);
+          throw std::runtime_error(message);
+        }
+
+        cache.emplace(name, state);
+        local_cache.emplace(name, state);
+        return state;
+      }
+
+      static size_t dense_matrix_elements(dim_t rows, dim_t cols, dim_t ld) {
+        if (rows <= 0 || cols <= 0)
+          return 0;
+        return static_cast<size_t>((rows - 1) * ld + cols);
+      }
+
+      static size_t dense_matrix_bytes(dim_t rows, dim_t cols, dim_t ld, size_t element_size) {
+        return dense_matrix_elements(rows, cols, ld) * element_size;
+      }
+
+      static size_t strided_matrix_array_bytes(dim_t rows,
+                                               dim_t cols,
+                                               dim_t ld,
+                                               dim_t stride,
+                                               dim_t batch_size,
+                                               size_t element_size) {
+        if (batch_size <= 0)
+          return 0;
+        return (static_cast<size_t>(batch_size - 1) * static_cast<size_t>(stride)
+                + dense_matrix_elements(rows, cols, ld)) * element_size;
+      }
+
+      static size_t strided_array_bytes(size_t required_elements,
+                                        dim_t stride,
+                                        dim_t batch_size,
+                                        size_t element_size) {
+        if (batch_size <= 0)
+          return 0;
+        const size_t batch_offset = stride > 0 && batch_size > 1
+                                    ? static_cast<size_t>(batch_size - 1) * static_cast<size_t>(stride)
+                                    : 0;
+        return (batch_offset + required_elements) * element_size;
+      }
+
+      static id<MTLBuffer> mtl_buffer(const void* ptr, size_t bytes, NSUInteger& offset) {
+        size_t raw_offset = 0;
+        void* raw_buffer = get_buffer(ptr, bytes, &raw_offset);
+        if (!raw_buffer)
+          throw std::runtime_error("MPS pointer is not backed by a registered Metal buffer");
+        record_metal_buffer_use(raw_buffer);
+        offset = static_cast<NSUInteger>(raw_offset);
+        return (__bridge id<MTLBuffer>)raw_buffer;
+      }
+
+      static void set_buffer(id<MTLComputeCommandEncoder> encoder,
+                             const void* ptr,
+                             size_t bytes,
+                             NSUInteger index) {
+        NSUInteger offset = 0;
+        id<MTLBuffer> buffer = mtl_buffer(ptr, bytes, offset);
+        [encoder setBuffer:buffer offset:offset atIndex:index];
+      }
+
+      struct PackedWeightKey {
+        const void* address;
+        void* device;
+        DataType dtype;
+        dim_t n;
+        dim_t k;
+        dim_t ldb;
+        bool transpose_b;
+
+        bool operator==(const PackedWeightKey& other) const {
+          return address == other.address && device == other.device
+                 && dtype == other.dtype && n == other.n && k == other.k
+                 && ldb == other.ldb && transpose_b == other.transpose_b;
+        }
+      };
+
+      struct PackedWeightKeyHash {
+        size_t operator()(const PackedWeightKey& key) const {
+          size_t result = std::hash<const void*>()(key.address);
+          auto mix = [&result](size_t value) {
+            result ^= value + 0x9e3779b97f4a7c15ULL + (result << 6) + (result >> 2);
+          };
+          mix(std::hash<void*>()(key.device));
+          mix(static_cast<size_t>(key.dtype));
+          mix(static_cast<size_t>(key.n));
+          mix(static_cast<size_t>(key.k));
+          mix(static_cast<size_t>(key.ldb));
+          mix(static_cast<size_t>(key.transpose_b));
+          return result;
+        }
+      };
+
+      struct PackedWeightInfo {
+        id<MTLBuffer> buffer;
+        NSUInteger offset;
+      };
+
+      using PackedWeightMap =
+        std::unordered_map<PackedWeightKey, PackedWeightInfo, PackedWeightKeyHash>;
+
+      static PackedWeightMap& packed_weight_cache() {
+        // Intentionally leak this process-lifetime cache. Model weights normally
+        // outlive worker threads, and avoiding static destruction order hazards
+        // is more important than reclaiming a tiny metadata map at process exit.
+        static PackedWeightMap* cache = new PackedWeightMap;
+        return *cache;
+      }
+
+      static std::mutex& packed_weight_mutex() {
+        static std::mutex* mutex = new std::mutex;
+        return *mutex;
+      }
+
+      static PackedWeightInfo output_major_weight(DataType dtype,
+                                                   const void* address,
+                                                   dim_t n,
+                                                   dim_t k,
+                                                   dim_t ldb,
+                                                   size_t bytes) {
+        const PackedWeightKey key{address, get_device(), dtype, n, k, ldb, true};
+        std::lock_guard<std::mutex> lock(packed_weight_mutex());
+        auto& cache = packed_weight_cache();
+        const auto found = cache.find(key);
+        if (found != cache.end())
+          return found->second;
+
+        NSUInteger offset = 0;
+        id<MTLBuffer> buffer = mtl_buffer(address, bytes, offset);
+#if !__has_feature(objc_arc)
+        [buffer retain];
+#endif
+        const PackedWeightInfo info{buffer, offset};
+        cache.emplace(key, info);
+        return info;
+      }
+
+      static void run_1d(const std::string& name,
+                         uint64_t size,
+                         const std::vector<std::pair<const void*, size_t>>& buffers,
+                         const void* args,
+                         size_t args_size,
+                         NSUInteger args_index) {
+        if (size == 0)
+          return;
+
+        id<MTLComputePipelineState> state = pipeline(name);
+        id<MTLComputeCommandEncoder> encoder =
+          (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+        [encoder setComputePipelineState:state];
+
+        for (NSUInteger i = 0; i < buffers.size(); ++i)
+          set_buffer(encoder, buffers[i].first, buffers[i].second, i);
+        if (args)
+          [encoder setBytes:args length:args_size atIndex:args_index];
+
+        const NSUInteger simd_width = std::max<NSUInteger>(1, state.threadExecutionWidth);
+        NSUInteger threads = std::min<NSUInteger>(256, state.maxTotalThreadsPerThreadgroup);
+        if (threads >= simd_width)
+          threads = std::max<NSUInteger>(simd_width, (threads / simd_width) * simd_width);
+        MTLSize grid = MTLSizeMake(static_cast<NSUInteger>(size), 1, 1);
+        MTLSize group = MTLSizeMake(threads, 1, 1);
+        [encoder dispatchThreads:grid threadsPerThreadgroup:group];
+        // Dispatches in a reused compute encoder need an explicit visibility
+        // boundary when a later primitive consumes a buffer written here.
+        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+        record_compute_dispatch();
+      }
+
+      static void run_rows(const std::string& name,
+                           uint64_t rows,
+                           NSUInteger threads,
+                           const std::vector<std::pair<const void*, size_t>>& buffers,
+                           const void* args,
+                           size_t args_size,
+                           NSUInteger args_index) {
+        if (rows == 0)
+          return;
+
+        id<MTLComputePipelineState> state = pipeline(name);
+        id<MTLComputeCommandEncoder> encoder =
+          (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+        [encoder setComputePipelineState:state];
+
+        for (NSUInteger i = 0; i < buffers.size(); ++i)
+          set_buffer(encoder, buffers[i].first, buffers[i].second, i);
+        [encoder setBytes:args length:args_size atIndex:args_index];
+
+        while (threads > state.maxTotalThreadsPerThreadgroup)
+          threads >>= 1;
+        threads = std::max<NSUInteger>(1, threads);
+        [encoder setThreadgroupMemoryLength:((threads * sizeof(float) + 15) / 16) * 16
+                                    atIndex:0];
+        MTLSize grid = MTLSizeMake(static_cast<NSUInteger>(rows), 1, 1);
+        MTLSize group = MTLSizeMake(threads, 1, 1);
+        [encoder dispatchThreadgroups:grid threadsPerThreadgroup:group];
+        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+        record_compute_dispatch();
+      }
+
+      static NSUInteger reduction_threads(dim_t size) {
+        NSUInteger threads = 1;
+        while (threads < static_cast<NSUInteger>(size) && threads < 256)
+          threads <<= 1;
+        return threads;
+      }
+
+      static MPSDataType mps_matrix_data_type(DataType dtype) {
+        switch (dtype) {
+        case DataType::FLOAT32:
+          return MPSDataTypeFloat32;
+        case DataType::FLOAT16:
+          return MPSDataTypeFloat16;
+        default:
+          throw std::invalid_argument("MPSMatrix GEMM only supports float32 and float16");
+        }
+      }
+
+      static std::string kernel_name(const char* base, DataType dtype) {
+        return std::string(base) + "_" + dtype_suffix(dtype);
+      }
+
+      static std::string storage_kernel_name(const char* base, DataType dtype) {
+        return std::string(base) + "_" + storage_dtype_suffix(dtype);
+      }
+
+      struct GemmKey {
+        DataType dtype;
+        bool transpose_a;
+        bool transpose_b;
+        dim_t m;
+        dim_t n;
+        dim_t k;
+        dim_t batch_size;
+        uint32_t alpha_bits;
+        uint32_t beta_bits;
+
+        bool operator==(const GemmKey& other) const {
+          return dtype == other.dtype
+                 && transpose_a == other.transpose_a
+                 && transpose_b == other.transpose_b
+                 && m == other.m
+                 && n == other.n
+                 && k == other.k
+                 && batch_size == other.batch_size
+                 && alpha_bits == other.alpha_bits
+                 && beta_bits == other.beta_bits;
+        }
+      };
+
+      struct GemmKeyHash {
+        size_t operator()(const GemmKey& key) const {
+          size_t h = static_cast<size_t>(key.dtype);
+          auto mix = [&h](size_t v) {
+            h ^= v + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+          };
+          mix(static_cast<size_t>(key.transpose_a));
+          mix(static_cast<size_t>(key.transpose_b));
+          mix(static_cast<size_t>(key.m));
+          mix(static_cast<size_t>(key.n));
+          mix(static_cast<size_t>(key.k));
+          mix(static_cast<size_t>(key.batch_size));
+          mix(static_cast<size_t>(key.alpha_bits));
+          mix(static_cast<size_t>(key.beta_bits));
+          return h;
+        }
+      };
+
+      static uint32_t float_bits(float value) {
+        uint32_t bits = 0;
+        std::memcpy(&bits, &value, sizeof(bits));
+        return bits;
+      }
+
+      static MPSMatrixMultiplication* gemm_kernel(id<MTLDevice> device,
+                                                  DataType dtype,
+                                                  bool transpose_a,
+                                                  bool transpose_b,
+                                                  dim_t m,
+                                                  dim_t n,
+                                                  dim_t k,
+                                                  dim_t batch_size,
+                                                  float alpha,
+                                                  float beta) {
+        static std::unordered_map<GemmKey, MPSMatrixMultiplication*, GemmKeyHash> cache;
+        static std::mutex cache_mutex;
+        static thread_local std::unordered_map<GemmKey,
+                                               MPSMatrixMultiplication*,
+                                               GemmKeyHash> local_cache;
+
+        const GemmKey key{dtype,
+                          transpose_a,
+                          transpose_b,
+                          m,
+                          n,
+                          k,
+                          batch_size,
+                          float_bits(alpha),
+                          float_bits(beta)};
+
+        auto local_it = local_cache.find(key);
+        if (local_it != local_cache.end())
+          return local_it->second;
+
+        std::lock_guard<std::mutex> lock(cache_mutex);
+        auto it = cache.find(key);
+        if (it != cache.end()) {
+          local_cache.emplace(key, it->second);
+          return it->second;
+        }
+
+        MPSMatrixMultiplication* matmul =
+          [[MPSMatrixMultiplication alloc] initWithDevice:device
+                                            transposeLeft:transpose_a
+                                           transposeRight:transpose_b
+                                               resultRows:static_cast<NSUInteger>(m)
+                                            resultColumns:static_cast<NSUInteger>(n)
+                                          interiorColumns:static_cast<NSUInteger>(k)
+                                                    alpha:alpha
+                                                     beta:beta];
+        [matmul setBatchSize:static_cast<NSUInteger>(batch_size)];
+        cache.emplace(key, matmul);
+        local_cache.emplace(key, matmul);
+        return matmul;
+      }
+
+      static bool log_gemm_enabled() {
+        static const bool enabled = []() {
+          const char* value = std::getenv("CT2_MPS_LOG_GEMM");
+          return value && value[0] != '\0' && std::string(value) != "0";
+        }();
+        return enabled;
+      }
+
+      static bool custom_gemv_enabled() {
+        static const bool enabled = []() {
+          const char* value = std::getenv("CT2_MPS_USE_GEMV");
+          return !value || value[0] == '\0' || std::string(value) != "0";
+        }();
+        return enabled;
+      }
+
+      static bool gpu_topk_enabled() {
+        static const bool enabled = []() {
+          const char* value = std::getenv("CT2_MPS_USE_TOPK");
+          return !value || value[0] == '\0' || std::string(value) != "0";
+        }();
+        return enabled;
+      }
+
+      static void log_gemm(DataType dtype,
+                           bool transpose_a,
+                           bool transpose_b,
+                           dim_t m,
+                           dim_t n,
+                           dim_t k,
+                           dim_t lda,
+                           dim_t ldb,
+                           dim_t ldc,
+                           dim_t batch_size,
+                           dim_t stridea,
+                           dim_t strideb,
+                           dim_t stridec,
+                           const char* path) {
+        if (!log_gemm_enabled())
+          return;
+        std::fprintf(stderr,
+                     "CT2 MPS GEMM dtype=%s m=%lld n=%lld k=%lld trans_a=%d "
+                     "trans_b=%d lda=%lld ldb=%lld ldc=%lld batch=%lld "
+                     "stridea=%lld strideb=%lld stridec=%lld path=%s\n",
+                     dtype_name(dtype).c_str(),
+                     static_cast<long long>(m),
+                     static_cast<long long>(n),
+                     static_cast<long long>(k),
+                     transpose_a,
+                     transpose_b,
+                     static_cast<long long>(lda),
+                     static_cast<long long>(ldb),
+                     static_cast<long long>(ldc),
+                     static_cast<long long>(batch_size),
+                     static_cast<long long>(stridea),
+                     static_cast<long long>(strideb),
+                     static_cast<long long>(stridec),
+                     path);
+      }
+
+    }  // namespace
+
+    void invalidate_packed_weight_cache(void* metal_buffer) {
+      if (!metal_buffer)
+        return;
+      id<MTLBuffer> buffer = (__bridge id<MTLBuffer>)metal_buffer;
+      std::lock_guard<std::mutex> lock(packed_weight_mutex());
+      auto& cache = packed_weight_cache();
+      for (auto it = cache.begin(); it != cache.end();) {
+        if (it->second.buffer == buffer) {
+#if !__has_feature(objc_arc)
+          [it->second.buffer release];
+#endif
+          it = cache.erase(it);
+        } else {
+          ++it;
+        }
+      }
+    }
+
+    bool supports_gemm_type(DataType dtype) {
+      return dtype == DataType::FLOAT32 || dtype == DataType::FLOAT16;
+    }
+
+    static bool mps_matrix_layout_supported(dim_t rows,
+                                            dim_t columns,
+                                            dim_t leading_dimension,
+                                            size_t element_size) {
+      if (rows <= 0 || columns <= 0 || leading_dimension < columns)
+        return false;
+      const size_t row_bytes = static_cast<size_t>(leading_dimension) * element_size;
+      return row_bytes % 16 == 0;
+    }
+
+    static bool fits_u32(dim_t value) {
+      return value >= 0 && static_cast<uint64_t>(value) <= UINT32_MAX;
+    }
+
+    static void tiled_gemm(DataType dtype,
+                           bool transpose_a,
+                           bool transpose_b,
+                           dim_t m,
+                           dim_t n,
+                           dim_t k,
+                           float alpha,
+                           const void* a,
+                           dim_t lda,
+                           dim_t stridea,
+                           const void* b,
+                           dim_t ldb,
+                           dim_t strideb,
+                           float beta,
+                           void* c,
+                           dim_t ldc,
+                           dim_t stridec,
+                           dim_t batch_size,
+                           size_t a_bytes,
+                           size_t b_bytes,
+                           size_t c_bytes) {
+      const TiledGemmArgs args{static_cast<uint32_t>(m),
+                               static_cast<uint32_t>(n),
+                               static_cast<uint32_t>(k),
+                               static_cast<uint32_t>(lda),
+                               static_cast<uint32_t>(ldb),
+                               static_cast<uint32_t>(ldc),
+                               static_cast<uint32_t>(std::max<dim_t>(stridea, 0)),
+                               static_cast<uint32_t>(std::max<dim_t>(strideb, 0)),
+                               static_cast<uint32_t>(std::max<dim_t>(stridec, 0)),
+                               static_cast<uint32_t>(batch_size),
+                               transpose_a ? 1u : 0u,
+                               transpose_b ? 1u : 0u,
+                               alpha,
+                               beta};
+      id<MTLComputePipelineState> state = pipeline(storage_kernel_name("tiled_gemm", dtype));
+      id<MTLComputeCommandEncoder> encoder =
+        (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+      [encoder setComputePipelineState:state];
+      set_buffer(encoder, a, a_bytes, 0);
+      set_buffer(encoder, b, b_bytes, 1);
+      set_buffer(encoder, c, c_bytes, 2);
+      [encoder setBytes:&args length:sizeof(args) atIndex:3];
+      [encoder setThreadgroupMemoryLength:512 * sizeof(float) atIndex:0];
+      [encoder dispatchThreadgroups:MTLSizeMake((static_cast<NSUInteger>(n) + 15) / 16,
+                                                (static_cast<NSUInteger>(m) + 15) / 16,
+                                                static_cast<NSUInteger>(batch_size))
+               threadsPerThreadgroup:MTLSizeMake(16, 16, 1)];
+      [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+      record_compute_dispatch();
+    }
+
+    static void generic_gemm(DataType dtype,
+                             bool transpose_a,
+                             bool transpose_b,
+                             dim_t m,
+                             dim_t n,
+                             dim_t k,
+                             float alpha,
+                             const void* a,
+                             dim_t lda,
+                             dim_t stridea,
+                             const void* b,
+                             dim_t ldb,
+                             dim_t strideb,
+                             float beta,
+                             void* c,
+                             dim_t ldc,
+                             dim_t stridec,
+                             dim_t batch_size) {
+      const size_t element_size = dtype_size(dtype);
+      const dim_t a_rows = transpose_a ? k : m;
+      const dim_t a_cols = transpose_a ? m : k;
+      const dim_t b_rows = transpose_b ? n : k;
+      const dim_t b_cols = transpose_b ? k : n;
+      const size_t a_elements = dense_matrix_elements(a_rows, a_cols, lda);
+      const size_t b_elements = dense_matrix_elements(b_rows, b_cols, ldb);
+      const size_t c_elements = dense_matrix_elements(m, n, ldc);
+      const size_t a_bytes = strided_array_bytes(a_elements, stridea, batch_size, element_size);
+      const size_t b_bytes = strided_array_bytes(b_elements, strideb, batch_size, element_size);
+      const size_t c_bytes = strided_array_bytes(c_elements, stridec, batch_size, element_size);
+      if (fits_u32(m) && fits_u32(n) && fits_u32(k)
+          && fits_u32(lda) && fits_u32(ldb) && fits_u32(ldc)
+          && fits_u32(std::max<dim_t>(stridea, 0))
+          && fits_u32(std::max<dim_t>(strideb, 0))
+          && fits_u32(std::max<dim_t>(stridec, 0))
+          && fits_u32(batch_size)) {
+        tiled_gemm(dtype, transpose_a, transpose_b, m, n, k, alpha,
+                   a, lda, stridea, b, ldb, strideb, beta,
+                   c, ldc, stridec, batch_size, a_bytes, b_bytes, c_bytes);
+        record_profile_event(ProfileEvent::Gemm);
+        return;
+      }
+      const GenericGemmArgs args{static_cast<uint64_t>(m),
+                                 static_cast<uint64_t>(n),
+                                 static_cast<uint64_t>(k),
+                                 static_cast<uint64_t>(lda),
+                                 static_cast<uint64_t>(ldb),
+                                 static_cast<uint64_t>(ldc),
+                                 static_cast<uint64_t>(std::max<dim_t>(stridea, 0)),
+                                 static_cast<uint64_t>(std::max<dim_t>(strideb, 0)),
+                                 static_cast<uint64_t>(std::max<dim_t>(stridec, 0)),
+                                 static_cast<uint64_t>(batch_size),
+                                 transpose_a ? 1u : 0u,
+                                 transpose_b ? 1u : 0u,
+                                 alpha,
+                                 beta};
+      run_1d(storage_kernel_name("generic_gemm", dtype),
+             static_cast<uint64_t>(batch_size * m * n),
+             {{a, a_bytes}, {b, b_bytes}, {c, c_bytes}},
+             &args,
+             sizeof(args),
+             3);
+      record_profile_event(ProfileEvent::Gemm);
+    }
+
+    void gemv(DataType dtype,
+              bool transpose_a,
+              bool transpose_b,
+              dim_t m,
+              dim_t k,
+              float alpha,
+              const void* a,
+              dim_t lda,
+              dim_t stridea,
+              const void* b,
+              dim_t ldb,
+              dim_t strideb,
+              float beta,
+              void* c,
+              dim_t ldc,
+              dim_t stridec,
+              dim_t batch_size) {
+      if (batch_size <= 0 || m == 0)
+        return;
+      if (dtype != DataType::FLOAT32 && dtype != DataType::FLOAT16 && dtype != DataType::BFLOAT16)
+        throw std::invalid_argument("unsupported MPS GEMV dtype");
+
+      const size_t element_size = dtype_size(dtype);
+      const dim_t a_rows = transpose_a ? k : m;
+      const dim_t a_cols = transpose_a ? m : k;
+      const size_t a_elements = dense_matrix_elements(a_rows, a_cols, lda);
+      const size_t b_elements = transpose_b ? static_cast<size_t>(k) : dense_matrix_elements(k, 1, ldb);
+      const size_t c_elements = dense_matrix_elements(m, 1, ldc);
+
+      const GemvArgs args{static_cast<uint64_t>(m),
+                          1,
+                          static_cast<uint64_t>(k),
+                          static_cast<uint64_t>(lda),
+                          static_cast<uint64_t>(ldb),
+                          static_cast<uint64_t>(ldc),
+                          static_cast<uint64_t>(std::max<dim_t>(stridea, 0)),
+                          static_cast<uint64_t>(std::max<dim_t>(strideb, 0)),
+                          static_cast<uint64_t>(std::max<dim_t>(stridec, 0)),
+                          static_cast<uint64_t>(batch_size),
+                          transpose_a ? 1u : 0u,
+                          transpose_b ? 1u : 0u,
+                          alpha,
+                          beta};
+
+      run_rows(storage_kernel_name("gemv", dtype),
+               static_cast<uint64_t>(batch_size * m),
+               reduction_threads(k),
+               {{a, strided_array_bytes(a_elements, stridea, batch_size, element_size)},
+                {b, strided_array_bytes(b_elements, strideb, batch_size, element_size)},
+                {c, strided_array_bytes(c_elements, stridec, batch_size, element_size)}},
+               &args,
+               sizeof(args),
+               3);
+      record_profile_event(ProfileEvent::Gemv);
+    }
+
+    void gemv_row(DataType dtype,
+                  bool transpose_a,
+                  bool transpose_b,
+                  dim_t n,
+                  dim_t k,
+                  float alpha,
+                  const void* a,
+                  dim_t lda,
+                  dim_t stridea,
+                  const void* b,
+                  dim_t ldb,
+                  dim_t strideb,
+                  float beta,
+                  void* c,
+                  dim_t ldc,
+                  dim_t stridec,
+                  dim_t batch_size) {
+      if (batch_size <= 0 || n == 0)
+        return;
+      if (dtype != DataType::FLOAT32 && dtype != DataType::FLOAT16 && dtype != DataType::BFLOAT16)
+        throw std::invalid_argument("unsupported MPS row GEMV dtype");
+
+      const size_t element_size = dtype_size(dtype);
+      const size_t a_elements = transpose_a
+                                ? dense_matrix_elements(k, 1, lda)
+                                : static_cast<size_t>(k);
+      const dim_t b_rows = transpose_b ? n : k;
+      const dim_t b_cols = transpose_b ? k : n;
+      const size_t b_elements = dense_matrix_elements(b_rows, b_cols, ldb);
+      const size_t c_elements = dense_matrix_elements(1, n, ldc);
+
+      const GemvArgs args{1,
+                          static_cast<uint64_t>(n),
+                          static_cast<uint64_t>(k),
+                          static_cast<uint64_t>(lda),
+                          static_cast<uint64_t>(ldb),
+                          static_cast<uint64_t>(ldc),
+                          static_cast<uint64_t>(std::max<dim_t>(stridea, 0)),
+                          static_cast<uint64_t>(std::max<dim_t>(strideb, 0)),
+                          static_cast<uint64_t>(std::max<dim_t>(stridec, 0)),
+                          static_cast<uint64_t>(batch_size),
+                          transpose_a ? 1u : 0u,
+                          transpose_b ? 1u : 0u,
+                          alpha,
+                          beta};
+
+      // Dense linear weights are stored by CTranslate2 as [N, K] and called
+      // with transpose_b=true, which is already the packed output-major layout
+      // required by the decode kernel.  Keep dynamic attention matrices on the
+      // generic path because their non-transposed layout changes every step.
+      if (dtype == DataType::FLOAT16 && transpose_b) {
+        id<MTLComputePipelineState> state = pipeline("gemv_row_output_major_f16");
+        id<MTLComputeCommandEncoder> encoder =
+          (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+        [encoder setComputePipelineState:state];
+        set_buffer(encoder,
+                   a,
+                   strided_array_bytes(a_elements, stridea, batch_size, element_size),
+                   0);
+        const size_t b_bytes =
+          strided_array_bytes(b_elements, strideb, batch_size, element_size);
+        if (batch_size == 1 && strideb == 0) {
+          const PackedWeightInfo packed = output_major_weight(dtype, b, n, k, ldb, b_bytes);
+          record_metal_buffer_use((__bridge void*)packed.buffer);
+          [encoder setBuffer:packed.buffer offset:packed.offset atIndex:1];
+        } else {
+          set_buffer(encoder, b, b_bytes, 1);
+        }
+        set_buffer(encoder,
+                   c,
+                   strided_array_bytes(c_elements, stridec, batch_size, element_size),
+                   2);
+        [encoder setBytes:&args length:sizeof(args) atIndex:3];
+        [encoder dispatchThreadgroups:MTLSizeMake((static_cast<NSUInteger>(n) + 31) / 32,
+                                                  static_cast<NSUInteger>(batch_size),
+                                                  1)
+                 threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+        record_compute_dispatch();
+        record_profile_event(ProfileEvent::Gemv);
+        return;
+      }
+
+      run_rows(storage_kernel_name("gemv_row", dtype),
+               static_cast<uint64_t>(batch_size * n),
+               reduction_threads(k),
+               {{a, strided_array_bytes(a_elements, stridea, batch_size, element_size)},
+                {b, strided_array_bytes(b_elements, strideb, batch_size, element_size)},
+                {c, strided_array_bytes(c_elements, stridec, batch_size, element_size)}},
+               &args,
+               sizeof(args),
+               3);
+      record_profile_event(ProfileEvent::Gemv);
+    }
+
+    void gemm(DataType dtype,
+              bool transpose_a,
+              bool transpose_b,
+              dim_t m,
+              dim_t n,
+              dim_t k,
+              float alpha,
+              const void* a,
+              dim_t lda,
+              const void* b,
+              dim_t ldb,
+              float beta,
+              void* c,
+              dim_t ldc) {
+      if (!supports_gemm_type(dtype))
+        throw std::invalid_argument("unsupported MPS GEMM dtype");
+      if (m == 0 || n == 0)
+        return;
+      if (m == 1 && custom_gemv_enabled()) {
+        log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+                 1, 0, 0, 0, "row_gemv");
+        gemv_row(dtype,
+                 transpose_a,
+                 transpose_b,
+                 n,
+                 k,
+                 alpha,
+                 a,
+                 lda,
+                 0,
+                 b,
+                 ldb,
+                 0,
+                 beta,
+                 c,
+                 ldc,
+                 0,
+                 1);
+        return;
+      }
+      if (n == 1 && custom_gemv_enabled()) {
+        log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+                 1, 0, 0, 0, "column_gemv");
+        gemv(dtype,
+             transpose_a,
+             transpose_b,
+             m,
+             k,
+             alpha,
+             a,
+             lda,
+             0,
+             b,
+             ldb,
+             0,
+             beta,
+             c,
+             ldc,
+             0,
+             1);
+        return;
+      }
+
+      const size_t element_size = dtype_size(dtype);
+      const dim_t a_rows = transpose_a ? k : m;
+      const dim_t a_cols = transpose_a ? m : k;
+      const dim_t b_rows = transpose_b ? n : k;
+      const dim_t b_cols = transpose_b ? k : n;
+
+      if (!mps_matrix_layout_supported(a_rows, a_cols, lda, element_size)
+          || !mps_matrix_layout_supported(b_rows, b_cols, ldb, element_size)
+          || !mps_matrix_layout_supported(m, n, ldc, element_size)) {
+        log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+                 1, 0, 0, 0, "generic_unaligned");
+        generic_gemm(dtype, transpose_a, transpose_b, m, n, k, alpha,
+                     a, lda, 0, b, ldb, 0, beta, c, ldc, 0, 1);
+        return;
+      }
+
+      log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+               1, 0, 0, 0, "mps_matrix");
+
+      id<MTLDevice> device = (__bridge id<MTLDevice>)get_device();
+      if (!device)
+        throw std::runtime_error("MPS device/queue not available");
+
+      NSUInteger offset_a = 0;
+      NSUInteger offset_b = 0;
+      NSUInteger offset_c = 0;
+      id<MTLBuffer> buf_a = mtl_buffer(a, dense_matrix_bytes(a_rows, a_cols, lda, element_size), offset_a);
+      id<MTLBuffer> buf_b = mtl_buffer(b, dense_matrix_bytes(b_rows, b_cols, ldb, element_size), offset_b);
+      id<MTLBuffer> buf_c = mtl_buffer(c, dense_matrix_bytes(m, n, ldc, element_size), offset_c);
+
+      const MPSDataType matrix_type = mps_matrix_data_type(dtype);
+      MPSMatrixDescriptor* desc_a =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(a_rows)
+                                              columns:static_cast<NSUInteger>(a_cols)
+                                             rowBytes:static_cast<NSUInteger>(lda * element_size)
+                                             dataType:matrix_type];
+      MPSMatrixDescriptor* desc_b =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(b_rows)
+                                              columns:static_cast<NSUInteger>(b_cols)
+                                             rowBytes:static_cast<NSUInteger>(ldb * element_size)
+                                             dataType:matrix_type];
+      MPSMatrixDescriptor* desc_c =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(m)
+                                              columns:static_cast<NSUInteger>(n)
+                                             rowBytes:static_cast<NSUInteger>(ldc * element_size)
+                                             dataType:matrix_type];
+
+      MPSMatrix* mat_a = [[MPSMatrix alloc] initWithBuffer:buf_a offset:offset_a descriptor:desc_a];
+      MPSMatrix* mat_b = [[MPSMatrix alloc] initWithBuffer:buf_b offset:offset_b descriptor:desc_b];
+      MPSMatrix* mat_c = [[MPSMatrix alloc] initWithBuffer:buf_c offset:offset_c descriptor:desc_c];
+      record_metal_object_use((__bridge void*)mat_a);
+      record_metal_object_use((__bridge void*)mat_b);
+      record_metal_object_use((__bridge void*)mat_c);
+
+      MPSMatrixMultiplication* matmul = gemm_kernel(device,
+                                                    dtype,
+                                                    transpose_a,
+                                                    transpose_b,
+                                                    m,
+                                                    n,
+                                                    k,
+                                                    1,
+                                                    alpha,
+                                                    beta);
+
+      end_active_encoder();
+      id<MTLCommandBuffer> active_command_buffer =
+        (__bridge id<MTLCommandBuffer>)command_buffer();
+      [matmul encodeToCommandBuffer:active_command_buffer
+                         leftMatrix:mat_a
+                        rightMatrix:mat_b
+                        resultMatrix:mat_c];
+      record_compute_dispatch();
+      record_profile_event(ProfileEvent::Gemm);
+
+#if !__has_feature(objc_arc)
+      [mat_a release];
+      [mat_b release];
+      [mat_c release];
+#endif
+    }
+
+    void gemm_batch_strided(DataType dtype,
+                            bool transpose_a,
+                            bool transpose_b,
+                            dim_t m,
+                            dim_t n,
+                            dim_t k,
+                            float alpha,
+                            const void* a,
+                            dim_t lda,
+                            dim_t stridea,
+                            const void* b,
+                            dim_t ldb,
+                            dim_t strideb,
+                            float beta,
+                            void* c,
+                            dim_t ldc,
+                            dim_t stridec,
+                            dim_t batch_size) {
+      if (batch_size <= 0 || m == 0 || n == 0)
+        return;
+      if (m == 1 && custom_gemv_enabled()) {
+        log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+                 batch_size, stridea, strideb, stridec, "batched_row_gemv");
+        gemv_row(dtype,
+                 transpose_a,
+                 transpose_b,
+                 n,
+                 k,
+                 alpha,
+                 a,
+                 lda,
+                 stridea,
+                 b,
+                 ldb,
+                 strideb,
+                 beta,
+                 c,
+                 ldc,
+                 stridec,
+                 batch_size);
+        return;
+      }
+      if (n == 1 && custom_gemv_enabled()) {
+        log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+                 batch_size, stridea, strideb, stridec, "batched_column_gemv");
+        gemv(dtype,
+             transpose_a,
+             transpose_b,
+             m,
+             k,
+             alpha,
+             a,
+             lda,
+             stridea,
+             b,
+             ldb,
+             strideb,
+             beta,
+             c,
+             ldc,
+             stridec,
+             batch_size);
+        return;
+      }
+      if (batch_size == 1) {
+        gemm(dtype,
+             transpose_a,
+             transpose_b,
+             m,
+             n,
+             k,
+             alpha,
+             a,
+             lda,
+             b,
+             ldb,
+             beta,
+             c,
+             ldc);
+        return;
+      }
+      if (!supports_gemm_type(dtype))
+        throw std::invalid_argument("unsupported MPS batched GEMM dtype");
+
+      const dim_t a_rows = transpose_a ? k : m;
+      const dim_t a_cols = transpose_a ? m : k;
+      const dim_t b_rows = transpose_b ? n : k;
+      const dim_t b_cols = transpose_b ? k : n;
+      const size_t a_elements = dense_matrix_elements(a_rows, a_cols, lda);
+      const size_t b_elements = dense_matrix_elements(b_rows, b_cols, ldb);
+      const size_t c_elements = dense_matrix_elements(m, n, ldc);
+      const size_t element_size = dtype_size(dtype);
+
+      if (stridea < 0 || strideb < 0 || stridec <= 0)
+        throw std::invalid_argument("MPS batched GEMM received an invalid negative/output stride");
+      const bool invalid_dense_stride =
+          (stridea > 0 && static_cast<size_t>(stridea) < a_elements)
+          || (strideb > 0 && static_cast<size_t>(strideb) < b_elements)
+          || static_cast<size_t>(stridec) < c_elements;
+      const bool unsupported_mps_layout =
+        !mps_matrix_layout_supported(a_rows, a_cols, lda, element_size)
+        || !mps_matrix_layout_supported(b_rows, b_cols, ldb, element_size)
+        || !mps_matrix_layout_supported(m, n, ldc, element_size)
+        || stridea == 0
+        || strideb == 0
+        || (static_cast<size_t>(stridea) * element_size) % 16 != 0
+        || (static_cast<size_t>(strideb) * element_size) % 16 != 0
+        || (static_cast<size_t>(stridec) * element_size) % 16 != 0;
+      if (invalid_dense_stride || unsupported_mps_layout) {
+        log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+                 batch_size, stridea, strideb, stridec, "generic_batched");
+        generic_gemm(dtype, transpose_a, transpose_b, m, n, k, alpha,
+                     a, lda, stridea, b, ldb, strideb, beta,
+                     c, ldc, stridec, batch_size);
+        return;
+      }
+
+      log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+               batch_size, stridea, strideb, stridec, "mps_matrix_batched");
+
+      id<MTLDevice> device = (__bridge id<MTLDevice>)get_device();
+      if (!device)
+        throw std::runtime_error("MPS device/queue not available");
+
+      NSUInteger offset_a = 0;
+      NSUInteger offset_b = 0;
+      NSUInteger offset_c = 0;
+      id<MTLBuffer> buf_a =
+        mtl_buffer(a, strided_matrix_array_bytes(a_rows, a_cols, lda, stridea, batch_size, element_size), offset_a);
+      id<MTLBuffer> buf_b =
+        mtl_buffer(b, strided_matrix_array_bytes(b_rows, b_cols, ldb, strideb, batch_size, element_size), offset_b);
+      id<MTLBuffer> buf_c =
+        mtl_buffer(c, strided_matrix_array_bytes(m, n, ldc, stridec, batch_size, element_size), offset_c);
+
+      const MPSDataType matrix_type = mps_matrix_data_type(dtype);
+      MPSMatrixDescriptor* desc_a =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(a_rows)
+                                              columns:static_cast<NSUInteger>(a_cols)
+                                             matrices:static_cast<NSUInteger>(batch_size)
+                                             rowBytes:static_cast<NSUInteger>(lda * element_size)
+                                          matrixBytes:static_cast<NSUInteger>(stridea * element_size)
+                                             dataType:matrix_type];
+      MPSMatrixDescriptor* desc_b =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(b_rows)
+                                              columns:static_cast<NSUInteger>(b_cols)
+                                             matrices:static_cast<NSUInteger>(batch_size)
+                                             rowBytes:static_cast<NSUInteger>(ldb * element_size)
+                                          matrixBytes:static_cast<NSUInteger>(strideb * element_size)
+                                             dataType:matrix_type];
+      MPSMatrixDescriptor* desc_c =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(m)
+                                              columns:static_cast<NSUInteger>(n)
+                                             matrices:static_cast<NSUInteger>(batch_size)
+                                             rowBytes:static_cast<NSUInteger>(ldc * element_size)
+                                          matrixBytes:static_cast<NSUInteger>(stridec * element_size)
+                                             dataType:matrix_type];
+
+      MPSMatrix* mat_a = [[MPSMatrix alloc] initWithBuffer:buf_a offset:offset_a descriptor:desc_a];
+      MPSMatrix* mat_b = [[MPSMatrix alloc] initWithBuffer:buf_b offset:offset_b descriptor:desc_b];
+      MPSMatrix* mat_c = [[MPSMatrix alloc] initWithBuffer:buf_c offset:offset_c descriptor:desc_c];
+      record_metal_object_use((__bridge void*)mat_a);
+      record_metal_object_use((__bridge void*)mat_b);
+      record_metal_object_use((__bridge void*)mat_c);
+      MPSMatrixMultiplication* matmul = gemm_kernel(device,
+                                                    dtype,
+                                                    transpose_a,
+                                                    transpose_b,
+                                                    m,
+                                                    n,
+                                                    k,
+                                                    batch_size,
+                                                    alpha,
+                                                    beta);
+
+      end_active_encoder();
+      id<MTLCommandBuffer> active_command_buffer =
+        (__bridge id<MTLCommandBuffer>)command_buffer();
+      [matmul encodeToCommandBuffer:active_command_buffer
+                         leftMatrix:mat_a
+                        rightMatrix:mat_b
+                        resultMatrix:mat_c];
+      record_compute_dispatch();
+      record_profile_event(ProfileEvent::Gemm);
+
+#if !__has_feature(objc_arc)
+      [mat_a release];
+      [mat_b release];
+      [mat_c release];
+#endif
+    }
+
+    bool supports_topk(DataType dtype, dim_t k) {
+      if (!gpu_topk_enabled()
+          || (dtype != DataType::FLOAT32 && dtype != DataType::FLOAT16)
+          || k <= 0
+          || k > 16)
+        return false;
+      // The custom reduction supports the search-critical k values without
+      // MPSMatrix's 16-byte result-row restriction. Larger aligned results use
+      // MPSMatrixFindTopK.
+      return k <= 8 || (static_cast<size_t>(k) * dtype_size(dtype)) % 16 == 0;
+    }
+
+    static void argmax(DataType dtype,
+                       const void* input,
+                       void* values,
+                       int32_t* indices,
+                       dim_t batch_size,
+                       dim_t depth) {
+      const size_t element_size = dtype_size(dtype);
+      const SoftmaxArgs args{static_cast<uint64_t>(batch_size),
+                             static_cast<uint64_t>(depth),
+                             0,
+                             0};
+      id<MTLComputePipelineState> state = pipeline(kernel_name("argmax", dtype));
+      id<MTLComputeCommandEncoder> encoder =
+        (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+      [encoder setComputePipelineState:state];
+      set_buffer(encoder, input, static_cast<size_t>(batch_size * depth) * element_size, 0);
+      set_buffer(encoder, values, static_cast<size_t>(batch_size) * element_size, 1);
+      set_buffer(encoder, indices, static_cast<size_t>(batch_size) * sizeof(int32_t), 2);
+      [encoder setBytes:&args length:sizeof(args) atIndex:3];
+      NSUInteger threads = reduction_threads(depth);
+      while (threads > state.maxTotalThreadsPerThreadgroup)
+        threads >>= 1;
+      const NSUInteger scratch_bytes = ((threads * sizeof(float) + 15) / 16) * 16;
+      [encoder setThreadgroupMemoryLength:scratch_bytes atIndex:0];
+      [encoder setThreadgroupMemoryLength:scratch_bytes atIndex:1];
+      [encoder dispatchThreadgroups:MTLSizeMake(static_cast<NSUInteger>(batch_size), 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
+      [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+      record_compute_dispatch();
+      record_profile_event(ProfileEvent::TopKGpu);
+    }
+
+    static void small_topk(DataType dtype,
+                           const void* input,
+                           void* values,
+                           int32_t* indices,
+                           dim_t batch_size,
+                           dim_t depth,
+                           dim_t k) {
+      if (batch_size > UINT32_MAX || depth > UINT32_MAX || k > 8)
+        throw std::invalid_argument("small MPS TopK dimensions are too large");
+      const size_t element_size = dtype_size(dtype);
+      const SmallTopKArgs args{static_cast<uint32_t>(batch_size),
+                               static_cast<uint32_t>(depth),
+                               static_cast<uint32_t>(k)};
+      id<MTLComputePipelineState> state = pipeline(storage_kernel_name("small_topk", dtype));
+      id<MTLComputeCommandEncoder> encoder =
+        (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+      [encoder setComputePipelineState:state];
+      set_buffer(encoder, input, static_cast<size_t>(batch_size * depth) * element_size, 0);
+      set_buffer(encoder, values, static_cast<size_t>(batch_size * k) * element_size, 1);
+      set_buffer(encoder, indices, static_cast<size_t>(batch_size * k) * sizeof(int32_t), 2);
+      [encoder setBytes:&args length:sizeof(args) atIndex:3];
+      NSUInteger threads = 256;
+      while (threads > state.maxTotalThreadsPerThreadgroup)
+        threads >>= 1;
+      const NSUInteger scratch_bytes = ((threads * sizeof(float) + 15) / 16) * 16;
+      [encoder setThreadgroupMemoryLength:scratch_bytes atIndex:0];
+      [encoder setThreadgroupMemoryLength:scratch_bytes atIndex:1];
+      [encoder dispatchThreadgroups:MTLSizeMake(static_cast<NSUInteger>(batch_size), 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
+      [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+      record_compute_dispatch();
+      record_profile_event(ProfileEvent::TopKGpu);
+    }
+
+    void topk(DataType dtype,
+              const void* input,
+              void* values,
+              int32_t* indices,
+              dim_t batch_size,
+              dim_t depth,
+              dim_t k) {
+      if (!supports_topk(dtype, k))
+        throw std::invalid_argument("unsupported MPS TopK configuration");
+      if (batch_size == 0 || depth == 0 || k == 0)
+        return;
+      if (k == 1) {
+        argmax(dtype, input, values, indices, batch_size, depth);
+        return;
+      }
+      if (k <= 8) {
+        small_topk(dtype, input, values, indices, batch_size, depth, k);
+        return;
+      }
+
+      id<MTLDevice> device = (__bridge id<MTLDevice>)get_device();
+      if (!device)
+        throw std::runtime_error("MPS device/queue not available");
+
+      const size_t element_size = dtype_size(dtype);
+      NSUInteger input_offset = 0;
+      NSUInteger values_offset = 0;
+      NSUInteger indices_offset = 0;
+      id<MTLBuffer> input_buffer =
+        mtl_buffer(input, static_cast<size_t>(batch_size * depth) * element_size, input_offset);
+      id<MTLBuffer> values_buffer =
+        mtl_buffer(values, static_cast<size_t>(batch_size * k) * element_size, values_offset);
+      id<MTLBuffer> indices_buffer =
+        mtl_buffer(indices, static_cast<size_t>(batch_size * k) * sizeof(uint32_t), indices_offset);
+
+      MPSMatrixDescriptor* input_desc =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(batch_size)
+                                              columns:static_cast<NSUInteger>(depth)
+                                             rowBytes:static_cast<NSUInteger>(depth * element_size)
+                                             dataType:mps_matrix_data_type(dtype)];
+      MPSMatrixDescriptor* values_desc =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(batch_size)
+                                              columns:static_cast<NSUInteger>(k)
+                                             rowBytes:static_cast<NSUInteger>(k * element_size)
+                                             dataType:mps_matrix_data_type(dtype)];
+      MPSMatrixDescriptor* indices_desc =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(batch_size)
+                                              columns:static_cast<NSUInteger>(k)
+                                             rowBytes:static_cast<NSUInteger>(k * sizeof(uint32_t))
+                                             dataType:MPSDataTypeUInt32];
+
+      MPSMatrix* input_matrix = [[MPSMatrix alloc] initWithBuffer:input_buffer
+                                                          offset:input_offset
+                                                      descriptor:input_desc];
+      MPSMatrix* values_matrix = [[MPSMatrix alloc] initWithBuffer:values_buffer
+                                                            offset:values_offset
+                                                        descriptor:values_desc];
+      MPSMatrix* indices_matrix = [[MPSMatrix alloc] initWithBuffer:indices_buffer
+                                                             offset:indices_offset
+                                                         descriptor:indices_desc];
+      record_metal_object_use((__bridge void*)input_matrix);
+      record_metal_object_use((__bridge void*)values_matrix);
+      record_metal_object_use((__bridge void*)indices_matrix);
+
+      static thread_local std::unordered_map<dim_t, MPSMatrixFindTopK*> topk_cache;
+      MPSMatrixFindTopK* topk_kernel = nil;
+      auto cache_it = topk_cache.find(k);
+      if (cache_it == topk_cache.end()) {
+        topk_kernel = [[MPSMatrixFindTopK alloc]
+          initWithDevice:device
+          numberOfTopKValues:static_cast<NSUInteger>(k)];
+        if (!topk_kernel)
+          throw std::runtime_error("failed to create MPS TopK kernel");
+        topk_cache.emplace(k, topk_kernel);
+      } else {
+        topk_kernel = cache_it->second;
+      }
+      topk_kernel.sourceRows = static_cast<NSUInteger>(batch_size);
+      topk_kernel.sourceColumns = static_cast<NSUInteger>(depth);
+
+      end_active_encoder();
+      id<MTLCommandBuffer> active_command_buffer =
+        (__bridge id<MTLCommandBuffer>)command_buffer();
+      [topk_kernel encodeToCommandBuffer:active_command_buffer
+                             inputMatrix:input_matrix
+                       resultIndexMatrix:indices_matrix
+                       resultValueMatrix:values_matrix];
+      record_compute_dispatch();
+      record_profile_event(ProfileEvent::TopKGpu);
+
+#if !__has_feature(objc_arc)
+      [input_matrix release];
+      [values_matrix release];
+      [indices_matrix release];
+#endif
+    }
+
+    void fill(DataType dtype, const void* value, void* y, dim_t size) {
+      if (size == 0)
+        return;
+
+      FillArgs args{static_cast<uint64_t>(size), 0.0f, 0};
+      switch (dtype) {
+      case DataType::FLOAT32:
+        args.float_value = *static_cast<const float*>(value);
+        break;
+      case DataType::FLOAT16:
+        args.float_value = static_cast<float>(*static_cast<const float16_t*>(value));
+        break;
+      case DataType::BFLOAT16:
+        args.float_value = static_cast<float>(*static_cast<const bfloat16_t*>(value));
+        break;
+      case DataType::INT8:
+        args.int_value = static_cast<int32_t>(*static_cast<const int8_t*>(value));
+        break;
+      case DataType::INT16:
+        args.int_value = static_cast<int32_t>(*static_cast<const int16_t*>(value));
+        break;
+      case DataType::INT32:
+        args.int_value = *static_cast<const int32_t*>(value);
+        break;
+      default:
+        throw std::invalid_argument("unsupported MPS fill dtype");
+      }
+
+      run_1d(storage_kernel_name("fill", dtype),
+             size,
+             {{y, static_cast<size_t>(size) * dtype_size(dtype)}},
+             &args,
+             sizeof(args),
+             1);
+    }
+
+    void indexed_fill(DataType dtype,
+                      const void* value,
+                      void* y,
+                      const int32_t* indices,
+                      dim_t size) {
+      if (size == 0)
+        return;
+      if (size > UINT32_MAX)
+        throw std::invalid_argument("MPS indexed fill is too large");
+      IndexedFillArgs args{static_cast<uint32_t>(size), 0.0f, 0};
+      switch (dtype) {
+      case DataType::FLOAT32:
+        args.float_value = *static_cast<const float*>(value);
+        break;
+      case DataType::FLOAT16:
+        args.float_value = static_cast<float>(*static_cast<const float16_t*>(value));
+        break;
+      case DataType::BFLOAT16:
+        args.float_value = static_cast<float>(*static_cast<const bfloat16_t*>(value));
+        break;
+      case DataType::INT8:
+        args.int_value = *static_cast<const int8_t*>(value);
+        break;
+      case DataType::INT16:
+        args.int_value = *static_cast<const int16_t*>(value);
+        break;
+      case DataType::INT32:
+        args.int_value = *static_cast<const int32_t*>(value);
+        break;
+      default:
+        throw std::invalid_argument("unsupported MPS indexed fill dtype");
+      }
+      run_1d(storage_kernel_name("indexed_fill", dtype),
+             size,
+             {{y, dtype_size(dtype)},
+              {indices, static_cast<size_t>(size) * sizeof(int32_t)}},
+             &args,
+             sizeof(args),
+             2);
+    }
+
+    void prepare_length_mask(const int32_t* lengths,
+                             dim_t batch_size,
+                             dim_t num_heads,
+                             dim_t num_queries,
+                             bool mask_future,
+                             bool multi_query,
+                             int32_t* mask) {
+      if (!fits_u32(batch_size) || !fits_u32(num_heads) || !fits_u32(num_queries))
+        throw std::invalid_argument("MPS length mask dimensions are too large");
+      const uint64_t total = static_cast<uint64_t>(batch_size)
+                             * static_cast<uint64_t>(num_heads)
+                             * static_cast<uint64_t>(num_queries);
+      const LengthMaskArgs args{static_cast<uint32_t>(batch_size),
+                                static_cast<uint32_t>(num_heads),
+                                static_cast<uint32_t>(num_queries),
+                                mask_future ? 1u : 0u,
+                                multi_query ? 1u : 0u};
+      run_1d("prepare_length_mask",
+             total,
+             {{lengths, static_cast<size_t>(batch_size) * sizeof(int32_t)},
+              {mask, static_cast<size_t>(total) * sizeof(int32_t)}},
+             &args,
+             sizeof(args),
+             2);
+    }
+
+    void unary(DataType dtype, UnaryOp op, const void* x, void* y, dim_t size) {
+      const size_t bytes = static_cast<size_t>(size) * dtype_size(dtype);
+      const ElementwiseArgs args{static_cast<uint64_t>(size), op_code(op), 0};
+      run_1d(kernel_name("unary", dtype), size, {{x, bytes}, {y, bytes}}, &args, sizeof(args), 2);
+    }
+
+    void binary(DataType dtype, BinaryOp op, const void* a, const void* b, void* c, dim_t size) {
+      const size_t bytes = static_cast<size_t>(size) * dtype_size(dtype);
+      const ElementwiseArgs args{static_cast<uint64_t>(size), op_code(op), 0};
+      run_1d(kernel_name("binary", dtype), size, {{a, bytes}, {b, bytes}, {c, bytes}}, &args, sizeof(args), 3);
+    }
+
+    void scalar(DataType dtype, BinaryOp op, float a, const void* x, void* y, dim_t size) {
+      const size_t bytes = static_cast<size_t>(size) * dtype_size(dtype);
+      const ElementwiseArgs args{static_cast<uint64_t>(size), op_code(op), a};
+      run_1d(kernel_name("scalar", dtype), size, {{x, bytes}, {y, bytes}}, &args, sizeof(args), 2);
+    }
+
+    void gather(DataType dtype,
+                const void* data,
+                const int32_t* indices,
+                void* output,
+                dim_t copy_size,
+                dim_t batch_stride,
+                dim_t num_indices,
+                dim_t num_indices_per_batch) {
+      if (num_indices == 0 || copy_size == 0)
+        return;
+      const dim_t batch_size = num_indices / num_indices_per_batch;
+      const size_t element_size = dtype_size(dtype);
+      const uint64_t output_size = static_cast<uint64_t>(num_indices * copy_size);
+      const GatherArgs args{static_cast<uint64_t>(copy_size),
+                            static_cast<uint64_t>(batch_stride),
+                            static_cast<uint64_t>(num_indices),
+                            static_cast<uint64_t>(num_indices_per_batch)};
+      run_1d(storage_kernel_name("gather", dtype),
+             output_size,
+             {{data, static_cast<size_t>(batch_size * batch_stride) * element_size},
+              {indices, static_cast<size_t>(num_indices) * sizeof(int32_t)},
+              {output, static_cast<size_t>(output_size) * element_size}},
+             &args,
+             sizeof(args),
+             3);
+    }
+
+    void tile(DataType dtype,
+              const void* input,
+              void* output,
+              dim_t outer_size,
+              dim_t inner_size,
+              dim_t num_tiles) {
+      const uint64_t output_size =
+        static_cast<uint64_t>(outer_size * inner_size * num_tiles);
+      if (output_size == 0)
+        return;
+      const size_t element_size = dtype_size(dtype);
+      const TileArgs args{static_cast<uint64_t>(outer_size),
+                          static_cast<uint64_t>(inner_size),
+                          static_cast<uint64_t>(num_tiles)};
+      run_1d(storage_kernel_name("tile", dtype),
+             output_size,
+             {{input, static_cast<size_t>(outer_size * inner_size) * element_size},
+              {output, static_cast<size_t>(output_size) * element_size}},
+             &args,
+             sizeof(args),
+             2);
+    }
+
+    void bias_add(DataType dtype,
+                  const void* bias,
+                  const void* value,
+                  const void* residual,
+                  void* output,
+                  dim_t bias_size,
+                  dim_t value_size,
+                  dim_t block,
+                  int activation) {
+      if (value_size == 0)
+        return;
+      const size_t element_size = dtype_size(dtype);
+      const void* residual_or_dummy = residual ? residual : value;
+      const BiasAddArgs args{static_cast<uint64_t>(bias_size),
+                             static_cast<uint64_t>(value_size),
+                             static_cast<uint64_t>(block),
+                             block > 0 ? 1u : 0u,
+                             residual ? 1u : 0u,
+                             activation};
+      run_1d(kernel_name("bias_add", dtype),
+             value_size,
+             {{bias, static_cast<size_t>(bias_size) * element_size},
+              {value, static_cast<size_t>(value_size) * element_size},
+              {residual_or_dummy, residual ? static_cast<size_t>(value_size) * element_size
+                                           : element_size},
+              {output, static_cast<size_t>(value_size) * element_size}},
+             &args,
+             sizeof(args),
+             4);
+    }
+
+    void batch_broadcast(DataType dtype,
+                         BinaryOp op,
+                         const void* a,
+                         const void* b,
+                         void* c,
+                         dim_t a_size,
+                         dim_t b_size) {
+      const size_t element_size = dtype_size(dtype);
+      const BroadcastArgs args{static_cast<uint64_t>(a_size),
+                               static_cast<uint64_t>(b_size),
+                               0,
+                               op_code(op)};
+      run_1d(kernel_name("broadcast", dtype),
+             b_size,
+             {{a, static_cast<size_t>(a_size) * element_size},
+              {b, static_cast<size_t>(b_size) * element_size},
+              {c, static_cast<size_t>(b_size) * element_size}},
+             &args,
+             sizeof(args),
+             3);
+    }
+
+    void depth_broadcast(DataType dtype,
+                         BinaryOp op,
+                         const void* a,
+                         const void* b,
+                         void* c,
+                         dim_t a_size,
+                         dim_t b_size) {
+      const size_t element_size = dtype_size(dtype);
+      const BroadcastArgs args{static_cast<uint64_t>(a_size),
+                               static_cast<uint64_t>(b_size),
+                               1,
+                               op_code(op)};
+      run_1d(kernel_name("broadcast", dtype),
+             b_size,
+             {{a, static_cast<size_t>(a_size) * element_size},
+              {b, static_cast<size_t>(b_size) * element_size},
+              {c, static_cast<size_t>(b_size) * element_size}},
+             &args,
+             sizeof(args),
+             3);
+    }
+
+    void block_broadcast(DataType dtype,
+                         BinaryOp op,
+                         const void* a,
+                         const void* b,
+                         void* c,
+                         dim_t block,
+                         dim_t a_size,
+                         dim_t b_size) {
+      const size_t element_size = dtype_size(dtype);
+      const BroadcastArgs args{static_cast<uint64_t>(a_size),
+                               static_cast<uint64_t>(b_size),
+                               static_cast<uint64_t>(block),
+                               op_code(op)};
+      run_1d(kernel_name("broadcast", dtype),
+             b_size,
+             {{a, static_cast<size_t>(a_size) * element_size},
+              {b, static_cast<size_t>(b_size) * element_size},
+              {c, static_cast<size_t>(b_size) * element_size}},
+             &args,
+             sizeof(args),
+             3);
+    }
+
+    void transpose_2d(DataType dtype, const void* a, dim_t rows, dim_t cols, void* b) {
+      const uint64_t size = static_cast<uint64_t>(rows * cols);
+      const size_t bytes = static_cast<size_t>(size) * dtype_size(dtype);
+      const Transpose2DArgs args{static_cast<uint64_t>(rows), static_cast<uint64_t>(cols)};
+      run_1d(kernel_name("transpose_2d", dtype), size, {{a, bytes}, {b, bytes}}, &args, sizeof(args), 2);
+    }
+
+    void transpose_3d(DataType dtype, const void* a, const dim_t* dims, const dim_t* perm, void* b) {
+      const uint64_t size = static_cast<uint64_t>(dims[0] * dims[1] * dims[2]);
+      const size_t bytes = static_cast<size_t>(size) * dtype_size(dtype);
+      const TransposeNDArgs args{static_cast<uint64_t>(dims[0]),
+                                 static_cast<uint64_t>(dims[1]),
+                                 static_cast<uint64_t>(dims[2]),
+                                 1,
+                                 static_cast<uint64_t>(perm[0]),
+                                 static_cast<uint64_t>(perm[1]),
+                                 static_cast<uint64_t>(perm[2]),
+                                 3};
+      run_1d(kernel_name("transpose_3d", dtype), size, {{a, bytes}, {b, bytes}}, &args, sizeof(args), 2);
+    }
+
+    void transpose_4d(DataType dtype, const void* a, const dim_t* dims, const dim_t* perm, void* b) {
+      const uint64_t size = static_cast<uint64_t>(dims[0] * dims[1] * dims[2] * dims[3]);
+      const size_t bytes = static_cast<size_t>(size) * dtype_size(dtype);
+      const TransposeNDArgs args{static_cast<uint64_t>(dims[0]),
+                                 static_cast<uint64_t>(dims[1]),
+                                 static_cast<uint64_t>(dims[2]),
+                                 static_cast<uint64_t>(dims[3]),
+                                 static_cast<uint64_t>(perm[0]),
+                                 static_cast<uint64_t>(perm[1]),
+                                 static_cast<uint64_t>(perm[2]),
+                                 static_cast<uint64_t>(perm[3])};
+      run_1d(kernel_name("transpose_4d", dtype), size, {{a, bytes}, {b, bytes}}, &args, sizeof(args), 2);
+    }
+
+    void softmax(DataType dtype,
+                 const void* input,
+                 const int32_t* lengths,
+                 void* output,
+                 dim_t batch_size,
+                 dim_t depth,
+                 bool log) {
+      const size_t element_size = dtype_size(dtype);
+      const size_t bytes = static_cast<size_t>(batch_size * depth) * element_size;
+      const SoftmaxArgs args{static_cast<uint64_t>(batch_size),
+                             static_cast<uint64_t>(depth),
+                             lengths ? 1u : 0u,
+                             log ? 1u : 0u};
+      const void* lengths_or_dummy = lengths ? static_cast<const void*>(lengths) : input;
+      const size_t lengths_bytes = lengths ? static_cast<size_t>(batch_size) * sizeof(int32_t) : element_size;
+      run_rows(kernel_name("softmax", dtype),
+               batch_size,
+               reduction_threads(depth),
+               {{input, bytes}, {lengths_or_dummy, lengths_bytes}, {output, bytes}},
+               &args,
+               sizeof(args),
+               3);
+    }
+
+    void mean(DataType dtype,
+              const void* input,
+              void* output,
+              dim_t outer_size,
+              dim_t axis_size,
+              dim_t inner_size,
+              bool get_sum) {
+      const size_t element_size = dtype_size(dtype);
+      const uint64_t output_size = static_cast<uint64_t>(outer_size * inner_size);
+      const MeanArgs args{static_cast<uint64_t>(outer_size),
+                          static_cast<uint64_t>(axis_size),
+                          static_cast<uint64_t>(inner_size),
+                          get_sum ? 1u : 0u};
+      if (inner_size == 1) {
+        run_rows(kernel_name("mean_rows", dtype),
+                 outer_size,
+                 reduction_threads(axis_size),
+                 {{input, static_cast<size_t>(outer_size * axis_size) * element_size},
+                  {output, static_cast<size_t>(outer_size) * element_size}},
+                 &args,
+                 sizeof(args),
+                 2);
+        return;
+      }
+      run_1d(kernel_name("mean", dtype),
+             output_size,
+             {{input, static_cast<size_t>(outer_size * axis_size * inner_size) * element_size},
+              {output, static_cast<size_t>(output_size) * element_size}},
+             &args,
+             sizeof(args),
+             2);
+    }
+
+    void layer_norm(DataType dtype,
+                    const void* input,
+                    const void* gamma,
+                    const void* beta,
+                    void* output,
+                    dim_t outer_size,
+                    dim_t axis_size,
+                    dim_t inner_size,
+                    float epsilon) {
+      const size_t element_size = dtype_size(dtype);
+      const size_t tensor_bytes = static_cast<size_t>(outer_size * axis_size * inner_size) * element_size;
+      const size_t param_bytes = static_cast<size_t>(axis_size) * element_size;
+      const void* gamma_or_dummy = gamma ? gamma : input;
+      const void* beta_or_dummy = beta ? beta : input;
+      const NormArgs args{static_cast<uint64_t>(outer_size),
+                          static_cast<uint64_t>(axis_size),
+                          static_cast<uint64_t>(inner_size),
+                          epsilon,
+                          gamma ? 1u : 0u,
+                          beta ? 1u : 0u,
+                          0u};
+      run_rows(kernel_name("layer_norm", dtype),
+               outer_size * inner_size,
+               reduction_threads(axis_size),
+               {{input, tensor_bytes},
+                {gamma_or_dummy, gamma ? param_bytes : element_size},
+                {beta_or_dummy, beta ? param_bytes : element_size},
+                {output, tensor_bytes}},
+               &args,
+               sizeof(args),
+               4);
+    }
+
+    void rms_norm(DataType dtype,
+                  const void* input,
+                  const void* gamma,
+                  void* output,
+                  dim_t batch_size,
+                  dim_t depth,
+                  float epsilon,
+                  bool use_residual) {
+      const size_t element_size = dtype_size(dtype);
+      const size_t tensor_bytes = static_cast<size_t>(batch_size * depth) * element_size;
+      const size_t gamma_bytes = static_cast<size_t>(depth) * element_size;
+      const NormArgs args{static_cast<uint64_t>(batch_size),
+                          static_cast<uint64_t>(depth),
+                          1,
+                          epsilon,
+                          1u,
+                          0u,
+                          use_residual ? 1u : 0u};
+      run_rows(kernel_name("rms_norm", dtype),
+               batch_size,
+               reduction_threads(depth),
+               {{input, tensor_bytes}, {gamma, gamma_bytes}, {output, tensor_bytes}},
+               &args,
+               sizeof(args),
+               3);
+    }
+
+    void rotary(DataType dtype,
+                const void* input,
+                const void* sin,
+                const void* cos,
+                void* output,
+                dim_t batch_size,
+                dim_t max_time,
+                dim_t ndims,
+                dim_t depth,
+                bool interleave) {
+      const size_t element_size = dtype_size(dtype);
+      const uint64_t size = static_cast<uint64_t>(batch_size * max_time * depth);
+      const RotaryArgs args{size,
+                            static_cast<uint64_t>(max_time),
+                            static_cast<uint64_t>(ndims),
+                            static_cast<uint64_t>(depth),
+                            interleave ? 1u : 0u};
+      run_1d(kernel_name("rotary", dtype),
+             size,
+             {{input, static_cast<size_t>(size) * element_size},
+              {sin, static_cast<size_t>(max_time * ndims) * element_size},
+              {cos, static_cast<size_t>(max_time * ndims) * element_size},
+              {output, static_cast<size_t>(size) * element_size}},
+             &args,
+             sizeof(args),
+             4);
+    }
+
+    void im2col_conv1d(DataType dtype,
+                       const void* input,
+                       void* output,
+                       dim_t batch_size,
+                       dim_t groups,
+                       dim_t input_length,
+                       dim_t kernel_size,
+                       dim_t stride,
+                       dim_t padding,
+                       dim_t dilation,
+                       dim_t output_length,
+                       dim_t k,
+                       dim_t in_batch_stride,
+                       dim_t in_group_stride) {
+      const size_t element_size = dtype_size(dtype);
+      const uint64_t total = static_cast<uint64_t>(batch_size * groups * output_length * k);
+      const Im2Col1DArgs args{total,
+                              static_cast<uint64_t>(batch_size),
+                              static_cast<uint64_t>(groups),
+                              static_cast<uint64_t>(input_length),
+                              static_cast<uint64_t>(kernel_size),
+                              static_cast<uint64_t>(stride),
+                              static_cast<uint64_t>(padding),
+                              static_cast<uint64_t>(dilation),
+                              static_cast<uint64_t>(output_length),
+                              static_cast<uint64_t>(k),
+                              static_cast<uint64_t>(in_batch_stride),
+                              static_cast<uint64_t>(in_group_stride)};
+      run_1d(kernel_name("im2col_conv1d", dtype),
+             total,
+             {{input, static_cast<size_t>(batch_size * in_batch_stride) * element_size},
+              {output, static_cast<size_t>(total) * element_size}},
+             &args,
+             sizeof(args),
+             2);
+    }
+
+  }
+}
+
+#endif
+#endif

--- a/src/mps/kernels.mm
+++ b/src/mps/kernels.mm
@@ -179,6 +179,13 @@ struct IndexedFillArgs {
   int int_value;
 };
 
+struct RepetitionPenaltyArgs {
+  uint total;
+  uint length;
+  uint vocabulary_size;
+  float penalty;
+};
+
 struct LengthMaskArgs {
   uint batch_size;
   uint num_heads;
@@ -192,6 +199,12 @@ struct GatherArgs {
   ulong batch_stride;
   ulong num_indices;
   ulong num_indices_per_batch;
+};
+
+struct Concat2Args {
+  ulong outer_size;
+  ulong a_block_size;
+  ulong b_block_size;
 };
 
 struct TileArgs {
@@ -365,6 +378,27 @@ INDEXED_FILL_KERNEL(indexed_fill_bf16, ushort, f32_to_bf16(args.float_value))
 INDEXED_FILL_KERNEL(indexed_fill_i8, char, char(args.int_value))
 INDEXED_FILL_KERNEL(indexed_fill_i16, short, short(args.int_value))
 INDEXED_FILL_KERNEL(indexed_fill_i32, int, args.int_value)
+
+#define REPETITION_PENALTY_KERNEL(NAME, TYPE, LOAD, STORE)                            \
+kernel void NAME(device TYPE* scores [[buffer(0)]],                                   \
+                 device const TYPE* previous_scores [[buffer(1)]],                   \
+                 device const int* previous_ids [[buffer(2)]],                       \
+                 constant RepetitionPenaltyArgs& args [[buffer(3)]],                 \
+                 uint gid [[thread_position_in_grid]]) {                             \
+  if (gid >= args.total) return;                                                      \
+  const uint batch = gid / args.length;                                               \
+  const int token = previous_ids[gid];                                                \
+  if (token < 0 || uint(token) >= args.vocabulary_size) return;                       \
+  const ulong write_index = ulong(batch) * ulong(args.vocabulary_size)               \
+                            + ulong(token);                                           \
+  const float score = LOAD(previous_scores[gid]);                                    \
+  scores[write_index] = STORE(score < 0.0f ? score * args.penalty                    \
+                                           : score / args.penalty);                  \
+}
+
+REPETITION_PENALTY_KERNEL(repetition_penalty_f32, float, float, float)
+REPETITION_PENALTY_KERNEL(repetition_penalty_f16, half, float, half)
+REPETITION_PENALTY_KERNEL(repetition_penalty_bf16, ushort, bf16_to_f32, f32_to_bf16)
 
 kernel void prepare_length_mask(device const int* lengths [[buffer(0)]],
                                 device int* mask [[buffer(1)]],
@@ -937,6 +971,30 @@ GATHER_KERNEL(gather_bf16, ushort)
 GATHER_KERNEL(gather_i8, char)
 GATHER_KERNEL(gather_i16, short)
 GATHER_KERNEL(gather_i32, int)
+
+#define CONCAT2_KERNEL(NAME, TYPE)                                                    \
+kernel void NAME(device const TYPE* a [[buffer(0)]],                                 \
+                 device const TYPE* b [[buffer(1)]],                                 \
+                 device TYPE* output [[buffer(2)]],                                  \
+                 constant Concat2Args& args [[buffer(3)]],                           \
+                 uint gid [[thread_position_in_grid]]) {                             \
+  const ulong out = ulong(gid);                                                      \
+  const ulong output_block = args.a_block_size + args.b_block_size;                  \
+  const ulong total = args.outer_size * output_block;                                \
+  if (out >= total) return;                                                          \
+  const ulong outer = out / output_block;                                            \
+  const ulong within = out - outer * output_block;                                   \
+  output[out] = within < args.a_block_size                                           \
+                  ? a[outer * args.a_block_size + within]                            \
+                  : b[outer * args.b_block_size + within - args.a_block_size];       \
+}
+
+CONCAT2_KERNEL(concat2_f32, float)
+CONCAT2_KERNEL(concat2_f16, half)
+CONCAT2_KERNEL(concat2_bf16, ushort)
+CONCAT2_KERNEL(concat2_i8, char)
+CONCAT2_KERNEL(concat2_i16, short)
+CONCAT2_KERNEL(concat2_i32, int)
 
 #define TILE_KERNEL(NAME, TYPE)                                                       \
 kernel void NAME(device const TYPE* input [[buffer(0)]],                              \
@@ -1721,6 +1779,13 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         int32_t int_value;
       };
 
+      struct RepetitionPenaltyArgs {
+        uint32_t total;
+        uint32_t length;
+        uint32_t vocabulary_size;
+        float penalty;
+      };
+
       struct LengthMaskArgs {
         uint32_t batch_size;
         uint32_t num_heads;
@@ -1734,6 +1799,12 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         uint64_t batch_stride;
         uint64_t num_indices;
         uint64_t num_indices_per_batch;
+      };
+
+      struct Concat2Args {
+        uint64_t outer_size;
+        uint64_t a_block_size;
+        uint64_t b_block_size;
       };
 
       struct TileArgs {
@@ -1902,22 +1973,24 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         static id<MTLLibrary> lib = nil;
         static std::once_flag library_once;
         std::call_once(library_once, [&]() {
-          id<MTLDevice> device = (__bridge id<MTLDevice>)get_device();
-          if (!device)
-            throw std::runtime_error("MPS device not available");
+          @autoreleasepool {
+            id<MTLDevice> device = (__bridge id<MTLDevice>)get_device();
+            if (!device)
+              throw std::runtime_error("MPS device not available");
 
-          NSError* error = nil;
-          NSString* source = [NSString stringWithUTF8String:kMetalSource];
-          MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
-          lib = [device newLibraryWithSource:source options:options error:&error];
+            NSError* error = nil;
+            NSString* source = [NSString stringWithUTF8String:kMetalSource];
+            MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+            lib = [device newLibraryWithSource:source options:options error:&error];
 #if !__has_feature(objc_arc)
-          [options release];
+            [options release];
 #endif
-          if (!lib) {
-            std::string message = "failed to compile CTranslate2 MPS kernels";
-            if (error && [error localizedDescription])
-              message += ": " + std::string([[error localizedDescription] UTF8String]);
-            throw std::runtime_error(message);
+            if (!lib) {
+              std::string message = "failed to compile CTranslate2 MPS kernels";
+              if (error && [error localizedDescription])
+                message += ": " + std::string([[error localizedDescription] UTF8String]);
+              throw std::runtime_error(message);
+            }
           }
         });
         return lib;
@@ -1940,8 +2013,11 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         }
 
         id<MTLDevice> device = (__bridge id<MTLDevice>)get_device();
-        NSString* ns_name = [NSString stringWithUTF8String:name.c_str()];
+        NSString* ns_name = [[NSString alloc] initWithUTF8String:name.c_str()];
         id<MTLFunction> function = [library() newFunctionWithName:ns_name];
+#if !__has_feature(objc_arc)
+        [ns_name release];
+#endif
         if (!function)
           throw std::runtime_error("MPS kernel not found: " + name);
 
@@ -1998,10 +2074,9 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
 
       static id<MTLBuffer> mtl_buffer(const void* ptr, size_t bytes, NSUInteger& offset) {
         size_t raw_offset = 0;
-        void* raw_buffer = get_buffer(ptr, bytes, &raw_offset);
+        void* raw_buffer = get_buffer_for_use(ptr, bytes, &raw_offset);
         if (!raw_buffer)
           throw std::runtime_error("MPS pointer is not backed by a registered Metal buffer");
-        record_metal_buffer_use(raw_buffer);
         offset = static_cast<NSUInteger>(raw_offset);
         return (__bridge id<MTLBuffer>)raw_buffer;
       }
@@ -2907,56 +2982,63 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       id<MTLBuffer> buf_b = mtl_buffer(b, dense_matrix_bytes(b_rows, b_cols, ldb, element_size), offset_b);
       id<MTLBuffer> buf_c = mtl_buffer(c, dense_matrix_bytes(m, n, ldc, element_size), offset_c);
 
-      const MPSDataType matrix_type = mps_matrix_data_type(dtype);
-      MPSMatrixDescriptor* desc_a =
-        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(a_rows)
-                                              columns:static_cast<NSUInteger>(a_cols)
-                                             rowBytes:static_cast<NSUInteger>(lda * element_size)
-                                             dataType:matrix_type];
-      MPSMatrixDescriptor* desc_b =
-        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(b_rows)
-                                              columns:static_cast<NSUInteger>(b_cols)
-                                             rowBytes:static_cast<NSUInteger>(ldb * element_size)
-                                             dataType:matrix_type];
-      MPSMatrixDescriptor* desc_c =
-        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(m)
-                                              columns:static_cast<NSUInteger>(n)
-                                             rowBytes:static_cast<NSUInteger>(ldc * element_size)
-                                             dataType:matrix_type];
+      @autoreleasepool {
+        const MPSDataType matrix_type = mps_matrix_data_type(dtype);
+        MPSMatrixDescriptor* desc_a =
+          [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(a_rows)
+                                                columns:static_cast<NSUInteger>(a_cols)
+                                               rowBytes:static_cast<NSUInteger>(lda * element_size)
+                                               dataType:matrix_type];
+        MPSMatrixDescriptor* desc_b =
+          [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(b_rows)
+                                                columns:static_cast<NSUInteger>(b_cols)
+                                               rowBytes:static_cast<NSUInteger>(ldb * element_size)
+                                               dataType:matrix_type];
+        MPSMatrixDescriptor* desc_c =
+          [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(m)
+                                                columns:static_cast<NSUInteger>(n)
+                                               rowBytes:static_cast<NSUInteger>(ldc * element_size)
+                                               dataType:matrix_type];
+        // MPS descriptor factories return autoreleased objects. Keep them
+        // alive until GPU completion while draining the worker-local pool now.
+        record_metal_object_use((__bridge void*)desc_a);
+        record_metal_object_use((__bridge void*)desc_b);
+        record_metal_object_use((__bridge void*)desc_c);
 
-      MPSMatrix* mat_a = [[MPSMatrix alloc] initWithBuffer:buf_a offset:offset_a descriptor:desc_a];
-      MPSMatrix* mat_b = [[MPSMatrix alloc] initWithBuffer:buf_b offset:offset_b descriptor:desc_b];
-      MPSMatrix* mat_c = [[MPSMatrix alloc] initWithBuffer:buf_c offset:offset_c descriptor:desc_c];
-      record_metal_object_use((__bridge void*)mat_a);
-      record_metal_object_use((__bridge void*)mat_b);
-      record_metal_object_use((__bridge void*)mat_c);
+        MPSMatrix* mat_a = [[MPSMatrix alloc] initWithBuffer:buf_a offset:offset_a descriptor:desc_a];
+        MPSMatrix* mat_b = [[MPSMatrix alloc] initWithBuffer:buf_b offset:offset_b descriptor:desc_b];
+        MPSMatrix* mat_c = [[MPSMatrix alloc] initWithBuffer:buf_c offset:offset_c descriptor:desc_c];
+        record_metal_object_use((__bridge void*)mat_a);
+        record_metal_object_use((__bridge void*)mat_b);
+        record_metal_object_use((__bridge void*)mat_c);
 
-      MPSMatrixMultiplication* matmul = gemm_kernel(device,
-                                                    dtype,
-                                                    transpose_a,
-                                                    transpose_b,
-                                                    m,
-                                                    n,
-                                                    k,
-                                                    1,
-                                                    alpha,
-                                                    beta);
+        MPSMatrixMultiplication* matmul = gemm_kernel(device,
+                                                      dtype,
+                                                      transpose_a,
+                                                      transpose_b,
+                                                      m,
+                                                      n,
+                                                      k,
+                                                      1,
+                                                      alpha,
+                                                      beta);
 
-      end_active_encoder();
-      id<MTLCommandBuffer> active_command_buffer =
-        (__bridge id<MTLCommandBuffer>)command_buffer();
-      [matmul encodeToCommandBuffer:active_command_buffer
-                         leftMatrix:mat_a
-                        rightMatrix:mat_b
-                        resultMatrix:mat_c];
-      record_compute_dispatch("mps_matrix_gemm");
-      record_profile_event(ProfileEvent::Gemm);
+        end_active_encoder();
+        id<MTLCommandBuffer> active_command_buffer =
+          (__bridge id<MTLCommandBuffer>)command_buffer();
+        [matmul encodeToCommandBuffer:active_command_buffer
+                           leftMatrix:mat_a
+                          rightMatrix:mat_b
+                          resultMatrix:mat_c];
+        record_compute_dispatch("mps_matrix_gemm");
+        record_profile_event(ProfileEvent::Gemm);
 
 #if !__has_feature(objc_arc)
-      [mat_a release];
-      [mat_b release];
-      [mat_c release];
+        [mat_a release];
+        [mat_b release];
+        [mat_c release];
 #endif
+      }
     }
 
     void gemm_batch_strided(DataType dtype,
@@ -3102,61 +3184,66 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       id<MTLBuffer> buf_c =
         mtl_buffer(c, strided_matrix_array_bytes(m, n, ldc, stridec, batch_size, element_size), offset_c);
 
-      const MPSDataType matrix_type = mps_matrix_data_type(dtype);
-      MPSMatrixDescriptor* desc_a =
-        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(a_rows)
-                                              columns:static_cast<NSUInteger>(a_cols)
-                                             matrices:static_cast<NSUInteger>(batch_size)
-                                             rowBytes:static_cast<NSUInteger>(lda * element_size)
-                                          matrixBytes:static_cast<NSUInteger>(stridea * element_size)
-                                             dataType:matrix_type];
-      MPSMatrixDescriptor* desc_b =
-        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(b_rows)
-                                              columns:static_cast<NSUInteger>(b_cols)
-                                             matrices:static_cast<NSUInteger>(batch_size)
-                                             rowBytes:static_cast<NSUInteger>(ldb * element_size)
-                                          matrixBytes:static_cast<NSUInteger>(strideb * element_size)
-                                             dataType:matrix_type];
-      MPSMatrixDescriptor* desc_c =
-        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(m)
-                                              columns:static_cast<NSUInteger>(n)
-                                             matrices:static_cast<NSUInteger>(batch_size)
-                                             rowBytes:static_cast<NSUInteger>(ldc * element_size)
-                                          matrixBytes:static_cast<NSUInteger>(stridec * element_size)
-                                             dataType:matrix_type];
+      @autoreleasepool {
+        const MPSDataType matrix_type = mps_matrix_data_type(dtype);
+        MPSMatrixDescriptor* desc_a =
+          [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(a_rows)
+                                                columns:static_cast<NSUInteger>(a_cols)
+                                               matrices:static_cast<NSUInteger>(batch_size)
+                                               rowBytes:static_cast<NSUInteger>(lda * element_size)
+                                            matrixBytes:static_cast<NSUInteger>(stridea * element_size)
+                                               dataType:matrix_type];
+        MPSMatrixDescriptor* desc_b =
+          [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(b_rows)
+                                                columns:static_cast<NSUInteger>(b_cols)
+                                               matrices:static_cast<NSUInteger>(batch_size)
+                                               rowBytes:static_cast<NSUInteger>(ldb * element_size)
+                                            matrixBytes:static_cast<NSUInteger>(strideb * element_size)
+                                               dataType:matrix_type];
+        MPSMatrixDescriptor* desc_c =
+          [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(m)
+                                                columns:static_cast<NSUInteger>(n)
+                                               matrices:static_cast<NSUInteger>(batch_size)
+                                               rowBytes:static_cast<NSUInteger>(ldc * element_size)
+                                            matrixBytes:static_cast<NSUInteger>(stridec * element_size)
+                                               dataType:matrix_type];
+        record_metal_object_use((__bridge void*)desc_a);
+        record_metal_object_use((__bridge void*)desc_b);
+        record_metal_object_use((__bridge void*)desc_c);
 
-      MPSMatrix* mat_a = [[MPSMatrix alloc] initWithBuffer:buf_a offset:offset_a descriptor:desc_a];
-      MPSMatrix* mat_b = [[MPSMatrix alloc] initWithBuffer:buf_b offset:offset_b descriptor:desc_b];
-      MPSMatrix* mat_c = [[MPSMatrix alloc] initWithBuffer:buf_c offset:offset_c descriptor:desc_c];
-      record_metal_object_use((__bridge void*)mat_a);
-      record_metal_object_use((__bridge void*)mat_b);
-      record_metal_object_use((__bridge void*)mat_c);
-      MPSMatrixMultiplication* matmul = gemm_kernel(device,
-                                                    dtype,
-                                                    transpose_a,
-                                                    transpose_b,
-                                                    m,
-                                                    n,
-                                                    k,
-                                                    batch_size,
-                                                    alpha,
-                                                    beta);
+        MPSMatrix* mat_a = [[MPSMatrix alloc] initWithBuffer:buf_a offset:offset_a descriptor:desc_a];
+        MPSMatrix* mat_b = [[MPSMatrix alloc] initWithBuffer:buf_b offset:offset_b descriptor:desc_b];
+        MPSMatrix* mat_c = [[MPSMatrix alloc] initWithBuffer:buf_c offset:offset_c descriptor:desc_c];
+        record_metal_object_use((__bridge void*)mat_a);
+        record_metal_object_use((__bridge void*)mat_b);
+        record_metal_object_use((__bridge void*)mat_c);
+        MPSMatrixMultiplication* matmul = gemm_kernel(device,
+                                                      dtype,
+                                                      transpose_a,
+                                                      transpose_b,
+                                                      m,
+                                                      n,
+                                                      k,
+                                                      batch_size,
+                                                      alpha,
+                                                      beta);
 
-      end_active_encoder();
-      id<MTLCommandBuffer> active_command_buffer =
-        (__bridge id<MTLCommandBuffer>)command_buffer();
-      [matmul encodeToCommandBuffer:active_command_buffer
-                         leftMatrix:mat_a
-                        rightMatrix:mat_b
-                        resultMatrix:mat_c];
-      record_compute_dispatch("mps_matrix_batched_gemm");
-      record_profile_event(ProfileEvent::Gemm);
+        end_active_encoder();
+        id<MTLCommandBuffer> active_command_buffer =
+          (__bridge id<MTLCommandBuffer>)command_buffer();
+        [matmul encodeToCommandBuffer:active_command_buffer
+                           leftMatrix:mat_a
+                          rightMatrix:mat_b
+                          resultMatrix:mat_c];
+        record_compute_dispatch("mps_matrix_batched_gemm");
+        record_profile_event(ProfileEvent::Gemm);
 
 #if !__has_feature(objc_arc)
-      [mat_a release];
-      [mat_b release];
-      [mat_c release];
+        [mat_a release];
+        [mat_b release];
+        [mat_c release];
 #endif
+      }
     }
 
     bool supports_topk(DataType dtype, dim_t k) {
@@ -3276,66 +3363,71 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       id<MTLBuffer> indices_buffer =
         mtl_buffer(indices, static_cast<size_t>(batch_size * k) * sizeof(uint32_t), indices_offset);
 
-      MPSMatrixDescriptor* input_desc =
-        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(batch_size)
-                                              columns:static_cast<NSUInteger>(depth)
-                                             rowBytes:static_cast<NSUInteger>(depth * element_size)
-                                             dataType:mps_matrix_data_type(dtype)];
-      MPSMatrixDescriptor* values_desc =
-        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(batch_size)
-                                              columns:static_cast<NSUInteger>(k)
-                                             rowBytes:static_cast<NSUInteger>(k * element_size)
-                                             dataType:mps_matrix_data_type(dtype)];
-      MPSMatrixDescriptor* indices_desc =
-        [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(batch_size)
-                                              columns:static_cast<NSUInteger>(k)
-                                             rowBytes:static_cast<NSUInteger>(k * sizeof(uint32_t))
-                                             dataType:MPSDataTypeUInt32];
+      @autoreleasepool {
+        MPSMatrixDescriptor* input_desc =
+          [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(batch_size)
+                                                columns:static_cast<NSUInteger>(depth)
+                                               rowBytes:static_cast<NSUInteger>(depth * element_size)
+                                               dataType:mps_matrix_data_type(dtype)];
+        MPSMatrixDescriptor* values_desc =
+          [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(batch_size)
+                                                columns:static_cast<NSUInteger>(k)
+                                               rowBytes:static_cast<NSUInteger>(k * element_size)
+                                               dataType:mps_matrix_data_type(dtype)];
+        MPSMatrixDescriptor* indices_desc =
+          [MPSMatrixDescriptor matrixDescriptorWithRows:static_cast<NSUInteger>(batch_size)
+                                                columns:static_cast<NSUInteger>(k)
+                                               rowBytes:static_cast<NSUInteger>(k * sizeof(uint32_t))
+                                               dataType:MPSDataTypeUInt32];
+        record_metal_object_use((__bridge void*)input_desc);
+        record_metal_object_use((__bridge void*)values_desc);
+        record_metal_object_use((__bridge void*)indices_desc);
 
-      MPSMatrix* input_matrix = [[MPSMatrix alloc] initWithBuffer:input_buffer
-                                                          offset:input_offset
-                                                      descriptor:input_desc];
-      MPSMatrix* values_matrix = [[MPSMatrix alloc] initWithBuffer:values_buffer
-                                                            offset:values_offset
-                                                        descriptor:values_desc];
-      MPSMatrix* indices_matrix = [[MPSMatrix alloc] initWithBuffer:indices_buffer
-                                                             offset:indices_offset
-                                                         descriptor:indices_desc];
-      record_metal_object_use((__bridge void*)input_matrix);
-      record_metal_object_use((__bridge void*)values_matrix);
-      record_metal_object_use((__bridge void*)indices_matrix);
+        MPSMatrix* input_matrix = [[MPSMatrix alloc] initWithBuffer:input_buffer
+                                                            offset:input_offset
+                                                        descriptor:input_desc];
+        MPSMatrix* values_matrix = [[MPSMatrix alloc] initWithBuffer:values_buffer
+                                                              offset:values_offset
+                                                          descriptor:values_desc];
+        MPSMatrix* indices_matrix = [[MPSMatrix alloc] initWithBuffer:indices_buffer
+                                                               offset:indices_offset
+                                                           descriptor:indices_desc];
+        record_metal_object_use((__bridge void*)input_matrix);
+        record_metal_object_use((__bridge void*)values_matrix);
+        record_metal_object_use((__bridge void*)indices_matrix);
 
-      static thread_local std::unordered_map<dim_t, MPSMatrixFindTopK*> topk_cache;
-      MPSMatrixFindTopK* topk_kernel = nil;
-      auto cache_it = topk_cache.find(k);
-      if (cache_it == topk_cache.end()) {
-        topk_kernel = [[MPSMatrixFindTopK alloc]
-          initWithDevice:device
-          numberOfTopKValues:static_cast<NSUInteger>(k)];
-        if (!topk_kernel)
-          throw std::runtime_error("failed to create MPS TopK kernel");
-        topk_cache.emplace(k, topk_kernel);
-      } else {
-        topk_kernel = cache_it->second;
-      }
-      topk_kernel.sourceRows = static_cast<NSUInteger>(batch_size);
-      topk_kernel.sourceColumns = static_cast<NSUInteger>(depth);
+        static thread_local std::unordered_map<dim_t, MPSMatrixFindTopK*> topk_cache;
+        MPSMatrixFindTopK* topk_kernel = nil;
+        auto cache_it = topk_cache.find(k);
+        if (cache_it == topk_cache.end()) {
+          topk_kernel = [[MPSMatrixFindTopK alloc]
+            initWithDevice:device
+            numberOfTopKValues:static_cast<NSUInteger>(k)];
+          if (!topk_kernel)
+            throw std::runtime_error("failed to create MPS TopK kernel");
+          topk_cache.emplace(k, topk_kernel);
+        } else {
+          topk_kernel = cache_it->second;
+        }
+        topk_kernel.sourceRows = static_cast<NSUInteger>(batch_size);
+        topk_kernel.sourceColumns = static_cast<NSUInteger>(depth);
 
-      end_active_encoder();
-      id<MTLCommandBuffer> active_command_buffer =
-        (__bridge id<MTLCommandBuffer>)command_buffer();
-      [topk_kernel encodeToCommandBuffer:active_command_buffer
-                             inputMatrix:input_matrix
-                       resultIndexMatrix:indices_matrix
-                       resultValueMatrix:values_matrix];
-      record_compute_dispatch("mps_matrix_topk");
-      record_profile_event(ProfileEvent::TopKGpu);
+        end_active_encoder();
+        id<MTLCommandBuffer> active_command_buffer =
+          (__bridge id<MTLCommandBuffer>)command_buffer();
+        [topk_kernel encodeToCommandBuffer:active_command_buffer
+                               inputMatrix:input_matrix
+                         resultIndexMatrix:indices_matrix
+                         resultValueMatrix:values_matrix];
+        record_compute_dispatch("mps_matrix_topk");
+        record_profile_event(ProfileEvent::TopKGpu);
 
 #if !__has_feature(objc_arc)
-      [input_matrix release];
-      [values_matrix release];
-      [indices_matrix release];
+        [input_matrix release];
+        [values_matrix release];
+        [indices_matrix release];
 #endif
+      }
     }
 
     void fill(DataType dtype, const void* value, void* y, dim_t size) {
@@ -3413,6 +3505,42 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
              &args,
              sizeof(args),
              2);
+    }
+
+    void penalize_previous_tokens(DataType dtype,
+                                  void* scores,
+                                  const void* previous_scores,
+                                  const int32_t* previous_ids,
+                                  float penalty,
+                                  dim_t batch_size,
+                                  dim_t length,
+                                  dim_t vocabulary_size) {
+      if (batch_size <= 0 || length <= 0 || vocabulary_size <= 0)
+        return;
+      const uint64_t total = static_cast<uint64_t>(batch_size)
+                             * static_cast<uint64_t>(length);
+      if (!fits_u32(batch_size) || !fits_u32(length) || !fits_u32(vocabulary_size)
+          || total > UINT32_MAX)
+        throw std::invalid_argument("MPS repetition penalty dimensions are too large");
+
+      const size_t element_size = dtype_size(dtype);
+      const size_t scores_bytes = static_cast<size_t>(batch_size)
+                                  * static_cast<size_t>(vocabulary_size)
+                                  * element_size;
+      const size_t previous_scores_bytes = static_cast<size_t>(total) * element_size;
+      const size_t previous_ids_bytes = static_cast<size_t>(total) * sizeof(int32_t);
+      const RepetitionPenaltyArgs args{static_cast<uint32_t>(total),
+                                       static_cast<uint32_t>(length),
+                                       static_cast<uint32_t>(vocabulary_size),
+                                       penalty};
+      run_1d(kernel_name("repetition_penalty", dtype),
+             total,
+             {{scores, scores_bytes},
+              {previous_scores, previous_scores_bytes},
+              {previous_ids, previous_ids_bytes}},
+             &args,
+             sizeof(args),
+             3);
     }
 
     void prepare_length_mask(const int32_t* lengths,
@@ -3562,6 +3690,31 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
              output_size,
              {{data, static_cast<size_t>(batch_size * batch_stride) * element_size},
               {indices, static_cast<size_t>(num_indices) * sizeof(int32_t)},
+              {output, static_cast<size_t>(output_size) * element_size}},
+             &args,
+             sizeof(args),
+             3);
+    }
+
+    void concat2(DataType dtype,
+                 const void* a,
+                 dim_t a_block_size,
+                 const void* b,
+                 dim_t b_block_size,
+                 void* output,
+                 dim_t outer_size) {
+      if (outer_size <= 0 || a_block_size <= 0 || b_block_size <= 0)
+        return;
+      const size_t element_size = dtype_size(dtype);
+      const uint64_t output_block = static_cast<uint64_t>(a_block_size + b_block_size);
+      const uint64_t output_size = static_cast<uint64_t>(outer_size) * output_block;
+      const Concat2Args args{static_cast<uint64_t>(outer_size),
+                             static_cast<uint64_t>(a_block_size),
+                             static_cast<uint64_t>(b_block_size)};
+      run_1d(storage_kernel_name("concat2", dtype),
+             output_size,
+             {{a, static_cast<size_t>(outer_size * a_block_size) * element_size},
+              {b, static_cast<size_t>(outer_size * b_block_size) * element_size},
               {output, static_cast<size_t>(output_size) * element_size}},
              &args,
              sizeof(args),

--- a/src/mps/kernels.mm
+++ b/src/mps/kernels.mm
@@ -6,6 +6,7 @@
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -19,6 +20,7 @@
 
 #include "mps/kernels.h"
 #include "mps/utils.h"
+#include "ctranslate2/random.h"
 
 namespace ctranslate2 {
   namespace mps {
@@ -202,6 +204,59 @@ struct BiasAddArgs {
   uint block_broadcast;
   uint has_residual;
   int activation;
+};
+
+struct QuantizeArgs {
+  ulong batch_size;
+  ulong depth;
+  uint round_before_cast;
+};
+
+struct DequantizeArgs {
+  ulong total;
+  ulong depth;
+};
+
+struct DequantizeGemmArgs {
+  ulong batch_size;
+  ulong depth;
+  ulong a_scale_size;
+  ulong b_scale_size;
+  uint transpose_a;
+  uint transpose_b;
+  uint has_bias;
+  int activation;
+};
+
+struct MedianFilterArgs {
+  ulong total;
+  ulong depth;
+  ulong width;
+};
+
+struct TopPMaskArgs {
+  uint batch_size;
+  uint depth;
+  uint padded_depth;
+  float probability;
+  float mask_value;
+};
+
+struct RandomArgs {
+  ulong total;
+  ulong depth;
+  ulong sample_size;
+  ulong seed;
+  ulong counter;
+};
+
+struct AlibiArgs {
+  ulong total;
+  ulong num_heads;
+  ulong query_length;
+  ulong key_length;
+  ulong cached_key_length;
+  ulong alibi_offset;
 };
 
 static inline ushort f32_to_bf16(float x) {
@@ -577,6 +632,7 @@ kernel void NAME(device const TYPE* a [[buffer(0)]],                            
 
 GENERIC_GEMM_KERNEL(generic_gemm_f32, float, load_value<float>, store_value<float>)
 GENERIC_GEMM_KERNEL(generic_gemm_f16, half, load_value<half>, store_value<half>)
+GENERIC_GEMM_KERNEL(generic_gemm_bf16, ushort, load_value_bf16, store_value_bf16)
 
 #define TILED_GEMM_KERNEL(NAME, TYPE, LOAD, STORE)                                   \
 kernel void NAME(device const TYPE* a [[buffer(0)]],                                 \
@@ -626,10 +682,138 @@ kernel void NAME(device const TYPE* a [[buffer(0)]],                            
 
 TILED_GEMM_KERNEL(tiled_gemm_f32, float, load_value<float>, store_value<float>)
 TILED_GEMM_KERNEL(tiled_gemm_f16, half, load_value<half>, store_value<half>)
+TILED_GEMM_KERNEL(tiled_gemm_bf16, ushort, load_value_bf16, store_value_bf16)
+
+kernel void generic_gemm_i8_i32(device const char* a [[buffer(0)]],
+                                device const char* b [[buffer(1)]],
+                                device int* c [[buffer(2)]],
+                                constant GenericGemmArgs& args [[buffer(3)]],
+                                uint gid [[thread_position_in_grid]]) {
+  const ulong index = (ulong)gid;
+  const ulong matrix_size = args.m * args.n;
+  const ulong total = args.batch_size * matrix_size;
+  if (index >= total) return;
+  const ulong batch = index / matrix_size;
+  const ulong matrix_index = index - batch * matrix_size;
+  const ulong row = matrix_index / args.n;
+  const ulong column = matrix_index - row * args.n;
+  const ulong a_base = args.stridea == 0 ? 0 : batch * args.stridea;
+  const ulong b_base = args.strideb == 0 ? 0 : batch * args.strideb;
+  const ulong c_base = args.stridec == 0 ? 0 : batch * args.stridec;
+  int sum = 0;
+  for (ulong p = 0; p < args.k; ++p) {
+    const ulong ai = args.transpose_a ? p * args.lda + row : row * args.lda + p;
+    const ulong bi = args.transpose_b ? column * args.ldb + p : p * args.ldb + column;
+    sum += int(a[a_base + ai]) * int(b[b_base + bi]);
+  }
+  const ulong ci = c_base + row * args.ldc + column;
+  const float previous = args.beta == 0.0f ? 0.0f : float(c[ci]);
+  c[ci] = int(rint(args.alpha * float(sum) + args.beta * previous));
+}
+
+kernel void tiled_gemm_i8_i32(device const char* a [[buffer(0)]],
+                              device const char* b [[buffer(1)]],
+                              device int* c [[buffer(2)]],
+                              constant TiledGemmArgs& args [[buffer(3)]],
+                              threadgroup int* tiles [[threadgroup(0)]],
+                              uint3 group [[threadgroup_position_in_grid]],
+                              uint3 tid [[thread_position_in_threadgroup]]) {
+  const uint row = group.y * 16u + tid.y;
+  const uint column = group.x * 16u + tid.x;
+  const uint batch = group.z;
+  const uint a_base = args.stridea == 0 ? 0 : batch * args.stridea;
+  const uint b_base = args.strideb == 0 ? 0 : batch * args.strideb;
+  const uint c_base = args.stridec == 0 ? 0 : batch * args.stridec;
+  threadgroup int* tile_a = tiles;
+  threadgroup int* tile_b = tiles + 256;
+  int sum = 0;
+  for (uint base_k = 0; base_k < args.k; base_k += 16u) {
+    const uint ak = base_k + tid.x;
+    const uint bk = base_k + tid.y;
+    int av = 0;
+    int bv = 0;
+    if (row < args.m && ak < args.k) {
+      const uint ai = args.transpose_a ? ak * args.lda + row : row * args.lda + ak;
+      av = int(a[a_base + ai]);
+    }
+    if (column < args.n && bk < args.k) {
+      const uint bi = args.transpose_b ? column * args.ldb + bk : bk * args.ldb + column;
+      bv = int(b[b_base + bi]);
+    }
+    tile_a[tid.y * 16u + tid.x] = av;
+    tile_b[tid.y * 16u + tid.x] = bv;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint p = 0; p < 16u; ++p)
+      sum += tile_a[tid.y * 16u + p] * tile_b[p * 16u + tid.x];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+  if (row < args.m && column < args.n) {
+    const uint ci = c_base + row * args.ldc + column;
+    const float previous = args.beta == 0.0f ? 0.0f : float(c[ci]);
+    c[ci] = int(rint(args.alpha * float(sum) + args.beta * previous));
+  }
+}
 
 static inline bool topk_better(float av, uint ai, float bv, uint bi) {
   return av > bv || (av == bv && ai < bi);
 }
+
+#define TOP_P_MASK_KERNEL(NAME, TYPE, LOAD, STORE)                                     \
+kernel void NAME(device const TYPE* input [[buffer(0)]],                               \
+                 device const TYPE* probabilities [[buffer(1)]],                       \
+                 device TYPE* output [[buffer(2)]],                                    \
+                 constant TopPMaskArgs& args [[buffer(3)]],                            \
+                 threadgroup float* values [[threadgroup(0)]],                         \
+                 threadgroup uint* indices [[threadgroup(1)]],                         \
+                 uint row [[threadgroup_position_in_grid]],                            \
+                 uint tid [[thread_index_in_threadgroup]],                             \
+                 uint nt [[threads_per_threadgroup]]) {                                \
+  if (row >= args.batch_size) return;                                                   \
+  const ulong offset = (ulong)row * args.depth;                                         \
+  for (uint i = tid; i < args.padded_depth; i += nt) {                                  \
+    values[i] = i < args.depth ? LOAD(probabilities, offset + i) : -INFINITY;           \
+    indices[i] = i;                                                                     \
+  }                                                                                     \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                      \
+  for (uint width = 2; width <= args.padded_depth; width <<= 1) {                       \
+    for (uint stride = width >> 1; stride > 0; stride >>= 1) {                          \
+      for (uint i = tid; i < args.padded_depth; i += nt) {                              \
+        const uint other = i ^ stride;                                                  \
+        if (other > i) {                                                                \
+          const bool descending = (i & width) == 0;                                     \
+          const bool left_better = topk_better(values[i], indices[i],                   \
+                                                values[other], indices[other]);          \
+          const bool right_better = topk_better(values[other], indices[other],          \
+                                                 values[i], indices[i]);                 \
+          if ((descending && right_better) || (!descending && left_better)) {           \
+            const float temp_value = values[i];                                         \
+            const uint temp_index = indices[i];                                         \
+            values[i] = values[other];                                                  \
+            indices[i] = indices[other];                                                \
+            values[other] = temp_value;                                                 \
+            indices[other] = temp_index;                                                \
+          }                                                                             \
+        }                                                                               \
+      }                                                                                 \
+      threadgroup_barrier(mem_flags::mem_threadgroup);                                  \
+    }                                                                                   \
+  }                                                                                     \
+  if (tid == 0) {                                                                       \
+    float cumulative = 0.0f;                                                           \
+    for (uint i = 0; i < args.depth; ++i) {                                            \
+      const uint original = indices[i];                                                 \
+      const float value = cumulative < args.probability                                \
+                          ? LOAD(input, offset + original)                              \
+                          : args.mask_value;                                            \
+      STORE(output, offset + original, value);                                          \
+      cumulative += values[i];                                                         \
+    }                                                                                   \
+  }                                                                                     \
+}
+
+TOP_P_MASK_KERNEL(top_p_mask_f32, float, load_value<float>, store_value<float>)
+TOP_P_MASK_KERNEL(top_p_mask_f16, half, load_value<half>, store_value<half>)
+TOP_P_MASK_KERNEL(top_p_mask_bf16, ushort, load_value_bf16, store_value_bf16)
 
 #define SMALL_TOPK_KERNEL(NAME, TYPE, LOAD, STORE)                                    \
 kernel void NAME(device const TYPE* input [[buffer(0)]],                              \
@@ -700,6 +884,7 @@ kernel void NAME(device const TYPE* input [[buffer(0)]],                        
 
 SMALL_TOPK_KERNEL(small_topk_f32, float, load_value<float>, store_value<float>)
 SMALL_TOPK_KERNEL(small_topk_f16, half, load_value<half>, store_value<half>)
+SMALL_TOPK_KERNEL(small_topk_bf16, ushort, load_value_bf16, store_value_bf16)
 
 #define GATHER_KERNEL(NAME, TYPE)                                                     \
 kernel void NAME(device const TYPE* input [[buffer(0)]],                              \
@@ -790,6 +975,191 @@ kernel void NAME(device const TYPE* a [[buffer(0)]],                            
 BROADCAST_KERNEL(broadcast_f32, float, load_value<float>, store_value<float>)
 BROADCAST_KERNEL(broadcast_f16, half, load_value<half>, store_value<half>)
 BROADCAST_KERNEL(broadcast_bf16, ushort, load_value_bf16, store_value_bf16)
+
+#define QUANTIZE_KERNEL(NAME, TYPE, LOAD)                                                \
+kernel void NAME(device const TYPE* input [[buffer(0)]],                                \
+                 device char* output [[buffer(1)]],                                     \
+                 device float* scales [[buffer(2)]],                                    \
+                 constant QuantizeArgs& args [[buffer(3)]],                             \
+                 threadgroup float* scratch [[threadgroup(0)]],                         \
+                 uint row [[threadgroup_position_in_grid]],                             \
+                 uint tid [[thread_index_in_threadgroup]],                              \
+                 uint nt [[threads_per_threadgroup]]) {                                 \
+  if ((ulong)row >= args.batch_size) return;                                            \
+  const ulong offset = (ulong)row * args.depth;                                         \
+  float maximum = 0.0f;                                                                 \
+  for (ulong i = (ulong)tid; i < args.depth; i += (ulong)nt)                            \
+    maximum = max(maximum, fabs(LOAD(input, offset + i)));                              \
+  scratch[tid] = maximum;                                                               \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                      \
+  for (uint stride = nt >> 1; stride > 0; stride >>= 1) {                               \
+    if (tid < stride) scratch[tid] = max(scratch[tid], scratch[tid + stride]);           \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                    \
+  }                                                                                     \
+  if (tid == 0) {                                                                       \
+    const float scale = scratch[0] == 0.0f ? 1.0f : 127.0f / scratch[0];                \
+    scratch[0] = scale;                                                                 \
+    scales[row] = scale;                                                                \
+  }                                                                                     \
+  threadgroup_barrier(mem_flags::mem_threadgroup);                                      \
+  const float scale = scratch[0];                                                       \
+  for (ulong i = (ulong)tid; i < args.depth; i += (ulong)nt) {                          \
+    float value = LOAD(input, offset + i) * scale;                                      \
+    if (args.round_before_cast) value = rint(value);                                    \
+    value = clamp(value, -127.0f, 127.0f);                                              \
+    output[offset + i] = char(value);                                                   \
+  }                                                                                     \
+}
+
+QUANTIZE_KERNEL(quantize_f32, float, load_value<float>)
+QUANTIZE_KERNEL(quantize_f16, half, load_value<half>)
+QUANTIZE_KERNEL(quantize_bf16, ushort, load_value_bf16)
+
+#define DEQUANTIZE_KERNEL(NAME, TYPE, STORE)                                            \
+kernel void NAME(device const char* input [[buffer(0)]],                               \
+                 device const float* scales [[buffer(1)]],                             \
+                 device TYPE* output [[buffer(2)]],                                    \
+                 constant DequantizeArgs& args [[buffer(3)]],                          \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  const ulong i = (ulong)gid;                                                          \
+  if (i >= args.total) return;                                                         \
+  const ulong row = i / args.depth;                                                    \
+  STORE(output, i, float(input[i]) / scales[row]);                                     \
+}
+
+DEQUANTIZE_KERNEL(dequantize_f32, float, store_value<float>)
+DEQUANTIZE_KERNEL(dequantize_f16, half, store_value<half>)
+DEQUANTIZE_KERNEL(dequantize_bf16, ushort, store_value_bf16)
+
+#define DEQUANTIZE_GEMM_KERNEL(NAME, TYPE, LOAD, STORE)                                 \
+kernel void NAME(device const int* input [[buffer(0)]],                                \
+                 device const float* a_scales [[buffer(1)]],                           \
+                 device const float* b_scales [[buffer(2)]],                           \
+                 device const TYPE* bias [[buffer(3)]],                                \
+                 device TYPE* output [[buffer(4)]],                                    \
+                 constant DequantizeGemmArgs& args [[buffer(5)]],                      \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  const ulong i = (ulong)gid;                                                          \
+  const ulong total = args.batch_size * args.depth;                                    \
+  if (i >= total) return;                                                              \
+  const ulong row = i / args.depth;                                                    \
+  const ulong column = i - row * args.depth;                                           \
+  const ulong ai = args.a_scale_size == 1 ? 0 : (args.transpose_a ? column : row);     \
+  const ulong bi = args.b_scale_size == 1 ? 0 : (args.transpose_b ? column : row);     \
+  float value = float(input[i]) / (a_scales[ai] * b_scales[bi]);                       \
+  if (args.has_bias) value += LOAD(bias, column);                                      \
+  if (args.activation >= 0) value = apply_unary(value, uint(args.activation));         \
+  STORE(output, i, value);                                                             \
+}
+
+DEQUANTIZE_GEMM_KERNEL(dequantize_gemm_f32, float, load_value<float>, store_value<float>)
+DEQUANTIZE_GEMM_KERNEL(dequantize_gemm_f16, half, load_value<half>, store_value<half>)
+DEQUANTIZE_GEMM_KERNEL(dequantize_gemm_bf16, ushort, load_value_bf16, store_value_bf16)
+
+#define MEDIAN_FILTER_KERNEL(NAME, TYPE, LOAD, STORE)                                  \
+kernel void NAME(device const TYPE* input [[buffer(0)]],                               \
+                 device TYPE* output [[buffer(1)]],                                    \
+                 constant MedianFilterArgs& args [[buffer(2)]],                        \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  const ulong index = (ulong)gid;                                                      \
+  if (index >= args.total) return;                                                     \
+  const long rank = long(args.width / 2);                                              \
+  const long column = long(index % args.depth);                                        \
+  const ulong row_offset = (index / args.depth) * args.depth;                          \
+  float window[129];                                                                   \
+  for (long k = -rank; k <= rank; ++k) {                                               \
+    long read = abs(column + k);                                                       \
+    if (read >= long(args.depth)) read = 2 * long(args.depth) - read - 2;              \
+    window[k + rank] = LOAD(input, row_offset + ulong(read));                          \
+  }                                                                                    \
+  for (ulong i = 1; i < args.width; ++i) {                                             \
+    const float key = window[i];                                                       \
+    long j = long(i) - 1;                                                             \
+    while (j >= 0 && window[j] > key) {                                                \
+      window[j + 1] = window[j];                                                       \
+      --j;                                                                            \
+    }                                                                                  \
+    window[j + 1] = key;                                                              \
+  }                                                                                    \
+  STORE(output, index, window[rank]);                                                  \
+}
+
+MEDIAN_FILTER_KERNEL(median_filter_f32, float, load_value<float>, store_value<float>)
+MEDIAN_FILTER_KERNEL(median_filter_f16, half, load_value<half>, store_value<half>)
+MEDIAN_FILTER_KERNEL(median_filter_bf16, ushort, load_value_bf16, store_value_bf16)
+
+#define ALIBI_ADD_KERNEL(NAME, TYPE, LOAD, STORE)                                      \
+kernel void NAME(device const TYPE* input [[buffer(0)]],                               \
+                 device const TYPE* alibi [[buffer(1)]],                               \
+                 device TYPE* output [[buffer(2)]],                                    \
+                 constant AlibiArgs& args [[buffer(3)]],                               \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  const ulong i = (ulong)gid;                                                          \
+  if (i >= args.total) return;                                                         \
+  const ulong key = i % args.key_length;                                               \
+  const ulong query_row = i / args.key_length;                                         \
+  const ulong head = (query_row / args.query_length) % args.num_heads;                 \
+  const ulong alibi_i = head * args.cached_key_length + args.alibi_offset + key;        \
+  STORE(output, i, LOAD(input, i) + LOAD(alibi, alibi_i));                             \
+}
+
+ALIBI_ADD_KERNEL(alibi_add_f32, float, load_value<float>, store_value<float>)
+ALIBI_ADD_KERNEL(alibi_add_f16, half, load_value<half>, store_value<half>)
+ALIBI_ADD_KERNEL(alibi_add_bf16, ushort, load_value_bf16, store_value_bf16)
+
+static inline uint random_hash(uint x) {
+  x ^= x >> 16;
+  x *= 0x7feb352du;
+  x ^= x >> 15;
+  x *= 0x846ca68bu;
+  return x ^ (x >> 16);
+}
+
+static inline float random_uniform(ulong seed, ulong counter, ulong index) {
+  const uint mixed = random_hash(uint(seed) ^ uint(seed >> 32) ^
+                                 uint(counter + index) ^ uint((counter + index) >> 32));
+  return (float(mixed >> 8) + 1.0f) * (1.0f / 16777217.0f);
+}
+
+#define MULTINOMIAL_KERNEL(NAME, TYPE, LOAD)                                           \
+kernel void NAME(device const TYPE* probabilities [[buffer(0)]],                      \
+                 device int* output [[buffer(1)]],                                     \
+                 constant RandomArgs& args [[buffer(2)]],                              \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  const ulong sample = (ulong)gid;                                                     \
+  if (sample >= args.total) return;                                                    \
+  const ulong row = sample / args.sample_size;                                         \
+  const ulong offset = row * args.depth;                                               \
+  float total = 0.0f;                                                                  \
+  for (ulong i = 0; i < args.depth; ++i) total += max(LOAD(probabilities, offset + i), 0.0f); \
+  const float target = random_uniform(args.seed, args.counter, sample) * total;         \
+  float cumulative = 0.0f;                                                             \
+  int selected = int(args.depth - 1);                                                  \
+  for (ulong i = 0; i < args.depth; ++i) {                                             \
+    cumulative += max(LOAD(probabilities, offset + i), 0.0f);                          \
+    if (cumulative >= target) { selected = int(i); break; }                            \
+  }                                                                                    \
+  output[sample] = selected;                                                           \
+}
+
+MULTINOMIAL_KERNEL(multinomial_f32, float, load_value<float>)
+MULTINOMIAL_KERNEL(multinomial_f16, half, load_value<half>)
+MULTINOMIAL_KERNEL(multinomial_bf16, ushort, load_value_bf16)
+
+#define GUMBEL_NOISE_KERNEL(NAME, TYPE, LOAD, STORE)                                   \
+kernel void NAME(device const TYPE* input [[buffer(0)]],                               \
+                 device TYPE* output [[buffer(1)]],                                    \
+                 constant RandomArgs& args [[buffer(2)]],                              \
+                 uint gid [[thread_position_in_grid]]) {                               \
+  const ulong i = (ulong)gid;                                                          \
+  if (i >= args.total) return;                                                         \
+  const float noise = -log(random_uniform(args.seed, args.counter, i));                \
+  STORE(output, i, LOAD(input, i) + noise);                                            \
+}
+
+GUMBEL_NOISE_KERNEL(gumbel_noise_f32, float, load_value<float>, store_value<float>)
+GUMBEL_NOISE_KERNEL(gumbel_noise_f16, half, load_value<half>, store_value<half>)
+GUMBEL_NOISE_KERNEL(gumbel_noise_bf16, ushort, load_value_bf16, store_value_bf16)
 
 #define TRANSPOSE_2D_KERNEL(NAME, TYPE)                                                \
 kernel void NAME(device const TYPE* a [[buffer(0)]],                                   \
@@ -1017,6 +1387,7 @@ kernel void NAME(device const TYPE* x [[buffer(0)]],                            
 
 ARGMAX_KERNEL(argmax_f32, float, load_value<float>, store_value<float>)
 ARGMAX_KERNEL(argmax_f16, half, load_value<half>, store_value<half>)
+ARGMAX_KERNEL(argmax_bf16, ushort, load_value_bf16, store_value_bf16)
 
 #define LAYER_NORM_KERNEL(NAME, TYPE, LOAD, STORE)                                     \
 kernel void NAME(device const TYPE* x [[buffer(0)]],                                   \
@@ -1346,6 +1717,59 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         uint32_t block_broadcast;
         uint32_t has_residual;
         int32_t activation;
+      };
+
+      struct QuantizeArgs {
+        uint64_t batch_size;
+        uint64_t depth;
+        uint32_t round_before_cast;
+      };
+
+      struct DequantizeArgs {
+        uint64_t total;
+        uint64_t depth;
+      };
+
+      struct DequantizeGemmArgs {
+        uint64_t batch_size;
+        uint64_t depth;
+        uint64_t a_scale_size;
+        uint64_t b_scale_size;
+        uint32_t transpose_a;
+        uint32_t transpose_b;
+        uint32_t has_bias;
+        int32_t activation;
+      };
+
+      struct MedianFilterArgs {
+        uint64_t total;
+        uint64_t depth;
+        uint64_t width;
+      };
+
+      struct TopPMaskArgs {
+        uint32_t batch_size;
+        uint32_t depth;
+        uint32_t padded_depth;
+        float probability;
+        float mask_value;
+      };
+
+      struct RandomArgs {
+        uint64_t total;
+        uint64_t depth;
+        uint64_t sample_size;
+        uint64_t seed;
+        uint64_t counter;
+      };
+
+      struct AlibiArgs {
+        uint64_t total;
+        uint64_t num_heads;
+        uint64_t query_length;
+        uint64_t key_length;
+        uint64_t cached_key_length;
+        uint64_t alibi_offset;
       };
 
       static size_t dtype_size(DataType dtype) {
@@ -1905,7 +2329,9 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
     }
 
     bool supports_gemm_type(DataType dtype) {
-      return dtype == DataType::FLOAT32 || dtype == DataType::FLOAT16;
+      return dtype == DataType::FLOAT32
+             || dtype == DataType::FLOAT16
+             || dtype == DataType::BFLOAT16;
     }
 
     static bool mps_matrix_layout_supported(dim_t rows,
@@ -2036,6 +2462,136 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
              sizeof(args),
              3);
       record_profile_event(ProfileEvent::Gemm);
+    }
+
+    static void int8_gemm_impl(bool transpose_a,
+                               bool transpose_b,
+                               dim_t m,
+                               dim_t n,
+                               dim_t k,
+                               float alpha,
+                               const int8_t* a,
+                               dim_t lda,
+                               dim_t stridea,
+                               const int8_t* b,
+                               dim_t ldb,
+                               dim_t strideb,
+                               float beta,
+                               int32_t* c,
+                               dim_t ldc,
+                               dim_t stridec,
+                               dim_t batch_size) {
+      if (batch_size <= 0 || m <= 0 || n <= 0)
+        return;
+      if (stridea < 0 || strideb < 0 || stridec < 0)
+        throw std::invalid_argument("MPS INT8 GEMM received a negative batch stride");
+
+      const dim_t a_rows = transpose_a ? k : m;
+      const dim_t a_cols = transpose_a ? m : k;
+      const dim_t b_rows = transpose_b ? n : k;
+      const dim_t b_cols = transpose_b ? k : n;
+      const size_t a_elements = dense_matrix_elements(a_rows, a_cols, lda);
+      const size_t b_elements = dense_matrix_elements(b_rows, b_cols, ldb);
+      const size_t c_elements = dense_matrix_elements(m, n, ldc);
+      const size_t a_bytes = strided_array_bytes(a_elements, stridea, batch_size, sizeof(int8_t));
+      const size_t b_bytes = strided_array_bytes(b_elements, strideb, batch_size, sizeof(int8_t));
+      const size_t c_bytes = strided_array_bytes(c_elements, stridec, batch_size, sizeof(int32_t));
+
+      if (fits_u32(m) && fits_u32(n) && fits_u32(k)
+          && fits_u32(lda) && fits_u32(ldb) && fits_u32(ldc)
+          && fits_u32(stridea) && fits_u32(strideb) && fits_u32(stridec)
+          && fits_u32(batch_size)) {
+        const TiledGemmArgs args{static_cast<uint32_t>(m),
+                                 static_cast<uint32_t>(n),
+                                 static_cast<uint32_t>(k),
+                                 static_cast<uint32_t>(lda),
+                                 static_cast<uint32_t>(ldb),
+                                 static_cast<uint32_t>(ldc),
+                                 static_cast<uint32_t>(stridea),
+                                 static_cast<uint32_t>(strideb),
+                                 static_cast<uint32_t>(stridec),
+                                 static_cast<uint32_t>(batch_size),
+                                 transpose_a ? 1u : 0u,
+                                 transpose_b ? 1u : 0u,
+                                 alpha,
+                                 beta};
+        id<MTLComputePipelineState> state = pipeline("tiled_gemm_i8_i32");
+        id<MTLComputeCommandEncoder> encoder =
+          (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+        [encoder setComputePipelineState:state];
+        set_buffer(encoder, a, a_bytes, 0);
+        set_buffer(encoder, b, b_bytes, 1);
+        set_buffer(encoder, c, c_bytes, 2);
+        [encoder setBytes:&args length:sizeof(args) atIndex:3];
+        [encoder setThreadgroupMemoryLength:512 * sizeof(int32_t) atIndex:0];
+        [encoder dispatchThreadgroups:MTLSizeMake((static_cast<NSUInteger>(n) + 15) / 16,
+                                                  (static_cast<NSUInteger>(m) + 15) / 16,
+                                                  static_cast<NSUInteger>(batch_size))
+                 threadsPerThreadgroup:MTLSizeMake(16, 16, 1)];
+        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+        record_compute_dispatch();
+      } else {
+        const GenericGemmArgs args{static_cast<uint64_t>(m),
+                                   static_cast<uint64_t>(n),
+                                   static_cast<uint64_t>(k),
+                                   static_cast<uint64_t>(lda),
+                                   static_cast<uint64_t>(ldb),
+                                   static_cast<uint64_t>(ldc),
+                                   static_cast<uint64_t>(stridea),
+                                   static_cast<uint64_t>(strideb),
+                                   static_cast<uint64_t>(stridec),
+                                   static_cast<uint64_t>(batch_size),
+                                   transpose_a ? 1u : 0u,
+                                   transpose_b ? 1u : 0u,
+                                   alpha,
+                                   beta};
+        run_1d("generic_gemm_i8_i32",
+               static_cast<uint64_t>(batch_size * m * n),
+               {{a, a_bytes}, {b, b_bytes}, {c, c_bytes}},
+               &args,
+               sizeof(args),
+               3);
+      }
+      record_profile_event(ProfileEvent::Gemm);
+    }
+
+    void gemm_int8(bool transpose_a,
+                   bool transpose_b,
+                   dim_t m,
+                   dim_t n,
+                   dim_t k,
+                   float alpha,
+                   const int8_t* a,
+                   dim_t lda,
+                   const int8_t* b,
+                   dim_t ldb,
+                   float beta,
+                   int32_t* c,
+                   dim_t ldc) {
+      int8_gemm_impl(transpose_a, transpose_b, m, n, k, alpha,
+                     a, lda, 0, b, ldb, 0, beta, c, ldc, 0, 1);
+    }
+
+    void gemm_int8_batch_strided(bool transpose_a,
+                                 bool transpose_b,
+                                 dim_t m,
+                                 dim_t n,
+                                 dim_t k,
+                                 float alpha,
+                                 const int8_t* a,
+                                 dim_t lda,
+                                 dim_t stridea,
+                                 const int8_t* b,
+                                 dim_t ldb,
+                                 dim_t strideb,
+                                 float beta,
+                                 int32_t* c,
+                                 dim_t ldc,
+                                 dim_t stridec,
+                                 dim_t batch_size) {
+      int8_gemm_impl(transpose_a, transpose_b, m, n, k, alpha,
+                     a, lda, stridea, b, ldb, strideb, beta,
+                     c, ldc, stridec, batch_size);
     }
 
     void gemv(DataType dtype,
@@ -2252,6 +2808,17 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         return;
       }
 
+      // MPSMatrix does not expose a portable BF16 matrix type on the minimum
+      // deployment target. The custom kernel stores BF16 as ushort and
+      // accumulates in FP32, so it works consistently on all supported Macs.
+      if (dtype == DataType::BFLOAT16) {
+        log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+                 1, 0, 0, 0, "bf16_tiled");
+        generic_gemm(dtype, transpose_a, transpose_b, m, n, k, alpha,
+                     a, lda, 0, b, ldb, 0, beta, c, ldc, 0, 1);
+        return;
+      }
+
       const size_t element_size = dtype_size(dtype);
       const dim_t a_rows = transpose_a ? k : m;
       const dim_t a_cols = transpose_a ? m : k;
@@ -2418,6 +2985,15 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       if (!supports_gemm_type(dtype))
         throw std::invalid_argument("unsupported MPS batched GEMM dtype");
 
+      if (dtype == DataType::BFLOAT16) {
+        log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+                 batch_size, stridea, strideb, stridec, "bf16_tiled_batched");
+        generic_gemm(dtype, transpose_a, transpose_b, m, n, k, alpha,
+                     a, lda, stridea, b, ldb, strideb, beta,
+                     c, ldc, stridec, batch_size);
+        return;
+      }
+
       const dim_t a_rows = transpose_a ? k : m;
       const dim_t a_cols = transpose_a ? m : k;
       const dim_t b_rows = transpose_b ? n : k;
@@ -2527,13 +3103,17 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
 
     bool supports_topk(DataType dtype, dim_t k) {
       if (!gpu_topk_enabled()
-          || (dtype != DataType::FLOAT32 && dtype != DataType::FLOAT16)
+          || (dtype != DataType::FLOAT32
+              && dtype != DataType::FLOAT16
+              && dtype != DataType::BFLOAT16)
           || k <= 0
           || k > 16)
         return false;
       // The custom reduction supports the search-critical k values without
       // MPSMatrix's 16-byte result-row restriction. Larger aligned results use
       // MPSMatrixFindTopK.
+      if (dtype == DataType::BFLOAT16)
+        return k <= 8;
       return k <= 8 || (static_cast<size_t>(k) * dtype_size(dtype)) % 16 == 0;
     }
 
@@ -2819,6 +3399,88 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       const size_t bytes = static_cast<size_t>(size) * dtype_size(dtype);
       const ElementwiseArgs args{static_cast<uint64_t>(size), op_code(op), a};
       run_1d(kernel_name("scalar", dtype), size, {{x, bytes}, {y, bytes}}, &args, sizeof(args), 2);
+    }
+
+    void quantize(DataType dtype,
+                  const void* input,
+                  int8_t* output,
+                  float* scales,
+                  dim_t batch_size,
+                  dim_t depth,
+                  bool round_before_cast) {
+      if (batch_size <= 0 || depth <= 0)
+        return;
+      const size_t input_bytes = static_cast<size_t>(batch_size * depth) * dtype_size(dtype);
+      const QuantizeArgs args{static_cast<uint64_t>(batch_size),
+                              static_cast<uint64_t>(depth),
+                              round_before_cast ? 1u : 0u};
+      run_rows(kernel_name("quantize", dtype),
+               batch_size,
+               reduction_threads(depth),
+               {{input, input_bytes},
+                {output, static_cast<size_t>(batch_size * depth)},
+                {scales, static_cast<size_t>(batch_size) * sizeof(float)}},
+               &args,
+               sizeof(args),
+               3);
+    }
+
+    void dequantize(DataType dtype,
+                    const int8_t* input,
+                    const float* scales,
+                    void* output,
+                    dim_t batch_size,
+                    dim_t depth) {
+      if (batch_size <= 0 || depth <= 0)
+        return;
+      const uint64_t total = static_cast<uint64_t>(batch_size * depth);
+      const DequantizeArgs args{total, static_cast<uint64_t>(depth)};
+      run_1d(kernel_name("dequantize", dtype),
+             total,
+             {{input, static_cast<size_t>(total)},
+              {scales, static_cast<size_t>(batch_size) * sizeof(float)},
+              {output, static_cast<size_t>(total) * dtype_size(dtype)}},
+             &args,
+             sizeof(args),
+             3);
+    }
+
+    void dequantize_gemm_output(DataType dtype,
+                                const int32_t* input,
+                                const float* a_scales,
+                                dim_t a_scale_size,
+                                const float* b_scales,
+                                dim_t b_scale_size,
+                                bool transpose_a,
+                                bool transpose_b,
+                                const void* bias,
+                                void* output,
+                                dim_t batch_size,
+                                dim_t depth,
+                                int activation) {
+      if (batch_size <= 0 || depth <= 0)
+        return;
+      const uint64_t total = static_cast<uint64_t>(batch_size * depth);
+      const size_t element_size = dtype_size(dtype);
+      const void* bias_or_dummy = bias ? bias : output;
+      const DequantizeGemmArgs args{static_cast<uint64_t>(batch_size),
+                                    static_cast<uint64_t>(depth),
+                                    static_cast<uint64_t>(a_scale_size),
+                                    static_cast<uint64_t>(b_scale_size),
+                                    transpose_a ? 1u : 0u,
+                                    transpose_b ? 1u : 0u,
+                                    bias ? 1u : 0u,
+                                    activation};
+      run_1d(kernel_name("dequantize_gemm", dtype),
+             total,
+             {{input, static_cast<size_t>(total) * sizeof(int32_t)},
+              {a_scales, static_cast<size_t>(a_scale_size) * sizeof(float)},
+              {b_scales, static_cast<size_t>(b_scale_size) * sizeof(float)},
+              {bias_or_dummy, bias ? static_cast<size_t>(depth) * element_size : element_size},
+              {output, static_cast<size_t>(total) * element_size}},
+             &args,
+             sizeof(args),
+             5);
     }
 
     void gather(DataType dtype,
@@ -3187,6 +3849,168 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
              &args,
              sizeof(args),
              2);
+    }
+
+    void median_filter(DataType dtype,
+                       const void* input,
+                       void* output,
+                       dim_t rows,
+                       dim_t depth,
+                       dim_t width) {
+      if (rows <= 0 || depth <= 0)
+        return;
+      if (width <= 0 || (width & 1) == 0 || width > 129)
+        throw std::invalid_argument("MPS MedianFilter requires an odd width no greater than 129");
+      const uint64_t total = static_cast<uint64_t>(rows * depth);
+      const size_t bytes = static_cast<size_t>(total) * dtype_size(dtype);
+      const MedianFilterArgs args{total,
+                                  static_cast<uint64_t>(depth),
+                                  static_cast<uint64_t>(width)};
+      run_1d(kernel_name("median_filter", dtype),
+             total,
+             {{input, bytes}, {output, bytes}},
+             &args,
+             sizeof(args),
+             2);
+    }
+
+    static uint32_t next_power_of_two(uint32_t value) {
+      if (value <= 1)
+        return 1;
+      --value;
+      value |= value >> 1;
+      value |= value >> 2;
+      value |= value >> 4;
+      value |= value >> 8;
+      value |= value >> 16;
+      return value + 1;
+    }
+
+    dim_t max_top_p_classes() {
+      return 1024;
+    }
+
+    void top_p_mask(DataType dtype,
+                    const void* input,
+                    const void* probabilities,
+                    void* output,
+                    dim_t batch_size,
+                    dim_t depth,
+                    float probability,
+                    float mask_value) {
+      if (batch_size <= 0 || depth <= 0)
+        return;
+      if (depth > max_top_p_classes())
+        throw std::invalid_argument("MPS TopPMask supports at most "
+                                    + std::to_string(max_top_p_classes())
+                                    + " classes");
+      const uint32_t padded_depth = next_power_of_two(static_cast<uint32_t>(depth));
+      const TopPMaskArgs args{static_cast<uint32_t>(batch_size),
+                              static_cast<uint32_t>(depth),
+                              padded_depth,
+                              probability,
+                              mask_value};
+      const size_t bytes = static_cast<size_t>(batch_size * depth) * dtype_size(dtype);
+      id<MTLComputePipelineState> state = pipeline(kernel_name("top_p_mask", dtype));
+      id<MTLComputeCommandEncoder> encoder =
+        (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+      [encoder setComputePipelineState:state];
+      set_buffer(encoder, input, bytes, 0);
+      set_buffer(encoder, probabilities, bytes, 1);
+      set_buffer(encoder, output, bytes, 2);
+      [encoder setBytes:&args length:sizeof(args) atIndex:3];
+      [encoder setThreadgroupMemoryLength:static_cast<NSUInteger>(padded_depth) * sizeof(float)
+                                  atIndex:0];
+      [encoder setThreadgroupMemoryLength:static_cast<NSUInteger>(padded_depth) * sizeof(uint32_t)
+                                  atIndex:1];
+      NSUInteger threads = std::min<NSUInteger>(256, padded_depth);
+      threads = std::min<NSUInteger>(threads, state.maxTotalThreadsPerThreadgroup);
+      [encoder dispatchThreadgroups:MTLSizeMake(static_cast<NSUInteger>(batch_size), 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
+      [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+      record_compute_dispatch();
+    }
+
+    static std::atomic<uint64_t> g_random_counter{0};
+
+    void multinomial(DataType dtype,
+                     const void* probabilities,
+                     int32_t* output,
+                     dim_t batch_size,
+                     dim_t depth,
+                     dim_t sample_size) {
+      if (batch_size <= 0 || depth <= 0 || sample_size <= 0)
+        return;
+      const uint64_t total = static_cast<uint64_t>(batch_size * sample_size);
+      const uint64_t counter = g_random_counter.fetch_add(total);
+      const RandomArgs args{total,
+                            static_cast<uint64_t>(depth),
+                            static_cast<uint64_t>(sample_size),
+                            static_cast<uint64_t>(get_random_seed()),
+                            counter};
+      run_1d(kernel_name("multinomial", dtype),
+             total,
+             {{probabilities,
+               static_cast<size_t>(batch_size * depth) * dtype_size(dtype)},
+              {output, static_cast<size_t>(total) * sizeof(int32_t)}},
+             &args,
+             sizeof(args),
+             2);
+    }
+
+    void gumbel_noise(DataType dtype,
+                      const void* input,
+                      void* output,
+                      dim_t size) {
+      if (size <= 0)
+        return;
+      const uint64_t total = static_cast<uint64_t>(size);
+      const uint64_t counter = g_random_counter.fetch_add(total);
+      const RandomArgs args{total,
+                            0,
+                            0,
+                            static_cast<uint64_t>(get_random_seed()),
+                            counter};
+      const size_t bytes = static_cast<size_t>(size) * dtype_size(dtype);
+      run_1d(kernel_name("gumbel_noise", dtype),
+             total,
+             {{input, bytes}, {output, bytes}},
+             &args,
+             sizeof(args),
+             2);
+    }
+
+    void alibi_add(DataType dtype,
+                   const void* input,
+                   const void* alibi,
+                   void* output,
+                   dim_t batch_size,
+                   dim_t num_heads,
+                   dim_t query_length,
+                   dim_t key_length,
+                   dim_t cached_key_length,
+                   dim_t alibi_offset) {
+      const uint64_t total = static_cast<uint64_t>(batch_size)
+                             * static_cast<uint64_t>(num_heads)
+                             * static_cast<uint64_t>(query_length)
+                             * static_cast<uint64_t>(key_length);
+      if (total == 0)
+        return;
+      const size_t element_size = dtype_size(dtype);
+      const AlibiArgs args{total,
+                           static_cast<uint64_t>(num_heads),
+                           static_cast<uint64_t>(query_length),
+                           static_cast<uint64_t>(key_length),
+                           static_cast<uint64_t>(cached_key_length),
+                           static_cast<uint64_t>(alibi_offset)};
+      run_1d(kernel_name("alibi_add", dtype),
+             total,
+             {{input, static_cast<size_t>(total) * element_size},
+              {alibi, static_cast<size_t>(num_heads * cached_key_length) * element_size},
+              {output, static_cast<size_t>(total) * element_size}},
+             &args,
+             sizeof(args),
+             3);
     }
 
   }

--- a/src/mps/kernels.mm
+++ b/src/mps/kernels.mm
@@ -45,6 +45,7 @@ struct BroadcastArgs {
   ulong b_size;
   ulong block;
   uint op;
+  uint mode;
 };
 
 struct Transpose2DArgs {
@@ -753,8 +754,9 @@ kernel void NAME(device const TYPE* bias [[buffer(0)]],                         
                  uint gid [[thread_position_in_grid]]) {                              \
   ulong i = (ulong)gid;                                                                \
   if (i >= args.value_size) return;                                                    \
-  /* The CPU block-broadcast mapping simplifies to i % bias_size. */                   \
-  ulong bias_index = i % args.bias_size;                                               \
+  ulong bias_index = args.block_broadcast                                              \
+    ? (i / args.block) % args.bias_size                                                 \
+    : i % args.bias_size;                                                               \
   float result = LOAD(value, i) + LOAD(bias, bias_index);                              \
   if (args.has_residual) result += LOAD(residual, i);                                  \
   if (args.activation >= 0) result = apply_unary(result, uint(args.activation));       \
@@ -774,14 +776,13 @@ kernel void NAME(device const TYPE* a [[buffer(0)]],                            
   ulong i = (ulong)gid;                                                                 \
   if (i >= args.b_size) return;                                                         \
   ulong ai = 0;                                                                         \
-  if (args.block == 0) {                                                                \
+  if (args.mode == 0) {                                                                 \
     ai = i % args.a_size;                                                               \
-  } else if (args.block == 1) {                                                         \
+  } else if (args.mode == 1) {                                                          \
     ulong depth = args.a_size == 0 ? 0 : args.b_size / args.a_size;                     \
     ai = depth == 0 ? 0 : i / depth;                                                    \
   } else {                                                                              \
-    /* Preserve the offset within each block; this is equivalent to i % a_size. */      \
-    ai = i % args.a_size;                                                               \
+    ai = (i / args.block) % args.a_size;                                                 \
   }                                                                                     \
   STORE(c, i, apply_binary(LOAD(a, ai), LOAD(b, i), args.op));                          \
 }
@@ -1188,6 +1189,7 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         uint64_t b_size;
         uint64_t block;
         uint32_t op;
+        uint32_t mode;
       };
 
       struct Transpose2DArgs {
@@ -2911,7 +2913,8 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       const BroadcastArgs args{static_cast<uint64_t>(a_size),
                                static_cast<uint64_t>(b_size),
                                0,
-                               op_code(op)};
+                               op_code(op),
+                               0};
       run_1d(kernel_name("broadcast", dtype),
              b_size,
              {{a, static_cast<size_t>(a_size) * element_size},
@@ -2932,8 +2935,9 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       const size_t element_size = dtype_size(dtype);
       const BroadcastArgs args{static_cast<uint64_t>(a_size),
                                static_cast<uint64_t>(b_size),
-                               1,
-                               op_code(op)};
+                               0,
+                               op_code(op),
+                               1};
       run_1d(kernel_name("broadcast", dtype),
              b_size,
              {{a, static_cast<size_t>(a_size) * element_size},
@@ -2956,7 +2960,8 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       const BroadcastArgs args{static_cast<uint64_t>(a_size),
                                static_cast<uint64_t>(b_size),
                                static_cast<uint64_t>(block),
-                               op_code(op)};
+                               op_code(op),
+                               2};
       run_1d(kernel_name("broadcast", dtype),
              b_size,
              {{a, static_cast<size_t>(a_size) * element_size},

--- a/src/mps/kernels.mm
+++ b/src/mps/kernels.mm
@@ -28,6 +28,7 @@ namespace ctranslate2 {
 
       static constexpr const char* kMetalSource = R"METAL(
 #include <metal_stdlib>
+#include <metal_simdgroup_matrix>
 using namespace metal;
 
 struct ElementwiseArgs {
@@ -66,11 +67,27 @@ struct TransposeNDArgs {
   ulong p3;
 };
 
+struct Transpose0213Args {
+  uint d1;
+  uint d2;
+  uint d3_vectors;
+};
+
 struct SoftmaxArgs {
   ulong batch_size;
   ulong depth;
   uint has_lengths;
   uint log_output;
+};
+
+struct FusedAttentionArgs {
+  uint batch_size;
+  uint query_length;
+  uint key_length;
+  uint depth_vectors;
+  uint has_lengths;
+  uint interleaved_num_heads;
+  float scale;
 };
 
 struct MeanArgs {
@@ -167,9 +184,30 @@ struct TiledGemmArgs {
   float beta;
 };
 
+struct SimdgroupGemmArgs {
+  uint m;
+  uint n;
+  uint k;
+  uint lda;
+  uint ldb;
+  uint ldc;
+  float alpha;
+  float beta;
+  uint has_bias;
+  uint has_residual;
+  int activation;
+};
+
 struct SmallTopKArgs {
   uint batch_size;
   uint depth;
+  uint k;
+};
+
+struct BeamSearchTopKArgs {
+  uint batch_size;
+  uint beam_size;
+  uint vocabulary_size;
   uint k;
 };
 
@@ -201,10 +239,30 @@ struct GatherArgs {
   ulong num_indices_per_batch;
 };
 
+struct GatherBlockArgs {
+  uint copy_vectors;
+  uint batch_stride_vectors;
+  uint num_indices;
+  uint num_indices_per_batch;
+};
+
 struct Concat2Args {
   ulong outer_size;
   ulong a_block_size;
   ulong b_block_size;
+};
+
+struct Split2Args {
+  ulong outer_size;
+  ulong a_block_size;
+  ulong b_block_size;
+};
+
+struct Split3Args {
+  ulong outer_size;
+  ulong a_block_size;
+  ulong b_block_size;
+  ulong c_block_size;
 };
 
 struct TileArgs {
@@ -241,6 +299,17 @@ struct DequantizeGemmArgs {
   uint transpose_a;
   uint transpose_b;
   uint has_bias;
+  int activation;
+};
+
+struct Int8DenseArgs {
+  uint m;
+  uint n;
+  uint k;
+  uint a_scale_size;
+  uint b_scale_size;
+  uint has_bias;
+  uint has_residual;
   int activation;
 };
 
@@ -747,6 +816,364 @@ TILED_GEMM_KERNEL(tiled_gemm_f32, float, load_value<float>, store_value<float>)
 TILED_GEMM_KERNEL(tiled_gemm_f16, half, load_value<half>, store_value<half>)
 TILED_GEMM_KERNEL(tiled_gemm_bf16, ushort, load_value_bf16, store_value_bf16)
 
+// The SIMD-group matrix layout and 64x64x16 tile are adapted from Apple
+// MLX's Steel GEMM implementation. Copyright (c) 2024 Apple Inc., licensed
+// under Apache-2.0. This specialized kernel covers CTranslate2 Dense weights,
+// which are stored output-major as B[N, K] and multiplied as A[M, K] * B^T.
+// Four SIMD groups cooperatively load one A/B tile, then each group computes
+// one 32x32 output quadrant using 8x8 SIMD-group matrix instructions.
+kernel void simdgroup_gemm_nt_f16_64x64(
+    device const half* a [[buffer(0)]],
+    device const half* b [[buffer(1)]],
+    device half* c [[buffer(2)]],
+    constant SimdgroupGemmArgs& args [[buffer(3)]],
+    device const half* bias [[buffer(4)]],
+    device const half* residual [[buffer(5)]],
+    uint3 group [[threadgroup_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]],
+    uint simd_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr uint BM = 64;
+  constexpr uint BN = 64;
+  constexpr uint BK = 16;
+  // Eight-half padding prevents the SIMD matrix loads from repeatedly
+  // colliding on the same threadgroup-memory banks.
+  constexpr uint TG_LD = 24;
+  threadgroup half as[BM * TG_LD];
+  // B stays output-major in threadgroup memory. This makes both device loads
+  // and the physical CTranslate2 [N,K] weight layout contiguous.
+  threadgroup half bs[BN * TG_LD];
+  struct alignas(16) Half8Bytes { uchar bytes[16]; };
+
+  simdgroup_matrix<float, 8, 8> accum[4][4];
+  #pragma clang loop unroll(full)
+  for (uint mi = 0; mi < 4; ++mi) {
+    #pragma clang loop unroll(full)
+    for (uint nj = 0; nj < 4; ++nj) {
+      accum[mi][nj].thread_elements()[0] = 0.0f;
+      accum[mi][nj].thread_elements()[1] = 0.0f;
+    }
+  }
+
+  const uint linear_tid = simd_id * 32u + lane;
+  const uint tile_row = group.y * BM;
+  const uint tile_col = group.x * BN;
+  const uint simd_row = (simd_id >> 1) * 32u;
+  const uint simd_col = (simd_id & 1u) * 32u;
+
+  const uint quad = lane >> 2;
+  const uint frag_row = (quad & 4u) + ((lane >> 1) & 3u);
+  const uint frag_col = (quad & 2u) * 2u + (lane & 1u) * 2u;
+
+  for (uint base_k = 0; base_k < args.k; base_k += BK) {
+    for (uint index = linear_tid; index < BM * 2u; index += 128u) {
+      const uint row = index >> 1;
+      const uint kk = (index & 1u) * 8u;
+      const uint global_row = tile_row + row;
+      const uint global_k = base_k + kk;
+      threadgroup half* dst = as + row * TG_LD + kk;
+      if (global_row < args.m && global_k + 8u <= args.k) {
+        *(threadgroup Half8Bytes*)dst =
+            *(device const Half8Bytes*)(a + global_row * args.lda + global_k);
+      } else {
+        #pragma clang loop unroll(full)
+        for (uint element = 0; element < 8; ++element)
+          dst[element] = global_row < args.m && global_k + element < args.k
+                           ? a[global_row * args.lda + global_k + element]
+                           : half(0.0h);
+      }
+    }
+    for (uint index = linear_tid; index < BN * 2u; index += 128u) {
+      const uint column = index >> 1;
+      const uint kk = (index & 1u) * 8u;
+      const uint global_k = base_k + kk;
+      const uint global_column = tile_col + column;
+      threadgroup half* dst = bs + column * TG_LD + kk;
+      if (global_column < args.n && global_k + 8u <= args.k) {
+        *(threadgroup Half8Bytes*)dst =
+            *(device const Half8Bytes*)(b + global_column * args.ldb + global_k);
+      } else {
+        #pragma clang loop unroll(full)
+        for (uint element = 0; element < 8; ++element)
+          dst[element] = global_column < args.n && global_k + element < args.k
+                           ? b[global_column * args.ldb + global_k + element]
+                           : half(0.0h);
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    #pragma clang loop unroll(full)
+    for (uint ki = 0; ki < 2; ++ki) {
+      simdgroup_matrix<float, 8, 8> a_frag[4];
+      simdgroup_matrix<float, 8, 8> b_frag[4];
+      #pragma clang loop unroll(full)
+      for (uint mi = 0; mi < 4; ++mi) {
+        const uint a_row = simd_row + mi * 8u + frag_row;
+        const uint a_col = ki * 8u + frag_col;
+        a_frag[mi].thread_elements()[0] = float(as[a_row * TG_LD + a_col]);
+        a_frag[mi].thread_elements()[1] = float(as[a_row * TG_LD + a_col + 1u]);
+      }
+      #pragma clang loop unroll(full)
+      for (uint nj = 0; nj < 4; ++nj) {
+        const uint b_row = ki * 8u + frag_row;
+        const uint b_col = simd_col + nj * 8u + frag_col;
+        b_frag[nj].thread_elements()[0] = float(bs[b_col * TG_LD + b_row]);
+        b_frag[nj].thread_elements()[1] = float(bs[(b_col + 1u) * TG_LD + b_row]);
+      }
+      #pragma clang loop unroll(full)
+      for (uint mi = 0; mi < 4; ++mi) {
+        #pragma clang loop unroll(full)
+        for (uint nj = 0; nj < 4; ++nj) {
+          simdgroup_multiply_accumulate(
+              accum[mi][nj], a_frag[mi], b_frag[nj], accum[mi][nj]);
+        }
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  #pragma clang loop unroll(full)
+  for (uint mi = 0; mi < 4; ++mi) {
+    const uint row = tile_row + simd_row + mi * 8u + frag_row;
+    if (row >= args.m)
+      continue;
+    #pragma clang loop unroll(full)
+    for (uint nj = 0; nj < 4; ++nj) {
+      const uint column0 = tile_col + simd_col + nj * 8u + frag_col;
+      #pragma clang loop unroll(full)
+      for (uint element = 0; element < 2; ++element) {
+        const uint column = column0 + element;
+        if (column >= args.n)
+          continue;
+        const uint output_index = row * args.ldc + column;
+        const float previous = args.beta == 0.0f ? 0.0f : float(c[output_index]);
+        // Preserve the established Dense numerical boundary: round the GEMM
+        // result to FP16 before applying the separately-defined epilogue.
+        float value = float(half(args.alpha * accum[mi][nj].thread_elements()[element]
+                                 + args.beta * previous));
+        if (args.has_bias)
+          value += float(bias[column]);
+        if (args.has_residual)
+          value += float(residual[output_index]);
+        if (args.activation >= 0)
+          value = apply_unary(value, uint(args.activation));
+        c[output_index] = half(value);
+      }
+    }
+  }
+}
+
+// Small-M weight-only INT8 GEMM. The 16x64x16 tile is shaped for beam and
+// small request batches: all four SIMD groups cover different output columns,
+// while SIMD-group matrix instructions provide the floating-point throughput.
+// INT8 weights are expanded only for the current K tile in threadgroup memory,
+// so the persistent model allocation remains compressed.
+kernel void simdgroup_gemm_nt_i8_f16_16x64(
+    device const half* a [[buffer(0)]],
+    device const char* b [[buffer(1)]],
+    device const float* b_scales [[buffer(2)]],
+    device const half* bias [[buffer(3)]],
+    device const half* residual [[buffer(4)]],
+    device half* output [[buffer(5)]],
+    constant Int8DenseArgs& args [[buffer(6)]],
+    uint3 group [[threadgroup_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]],
+    uint simd_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr uint BM = 16;
+  constexpr uint BN = 64;
+  constexpr uint BK = 16;
+  constexpr uint TG_LD = 24;
+  threadgroup half as[BM * TG_LD];
+  threadgroup half bs[BN * TG_LD];
+
+  simdgroup_matrix<float, 8, 8> accum[2][2];
+  #pragma clang loop unroll(full)
+  for (uint mi = 0; mi < 2; ++mi) {
+    #pragma clang loop unroll(full)
+    for (uint nj = 0; nj < 2; ++nj) {
+      accum[mi][nj].thread_elements()[0] = 0.0f;
+      accum[mi][nj].thread_elements()[1] = 0.0f;
+    }
+  }
+
+  const uint linear_tid = simd_id * 32u + lane;
+  const uint tile_row = group.y * BM;
+  const uint tile_col = group.x * BN;
+  const uint simd_col = simd_id * 16u;
+  const uint quad = lane >> 2;
+  const uint frag_row = (quad & 4u) + ((lane >> 1) & 3u);
+  const uint frag_col = (quad & 2u) * 2u + (lane & 1u) * 2u;
+
+  for (uint base_k = 0; base_k < args.k; base_k += BK) {
+    for (uint index = linear_tid; index < BM * BK; index += 128u) {
+      const uint row = index / BK;
+      const uint kk = index - row * BK;
+      const uint global_row = tile_row + row;
+      const uint global_k = base_k + kk;
+      as[row * TG_LD + kk] = global_row < args.m && global_k < args.k
+                                ? a[global_row * args.k + global_k]
+                                : half(0.0h);
+    }
+    for (uint index = linear_tid; index < BN * BK; index += 128u) {
+      const uint column = index / BK;
+      const uint kk = index - column * BK;
+      const uint global_column = tile_col + column;
+      const uint global_k = base_k + kk;
+      bs[column * TG_LD + kk] = global_column < args.n && global_k < args.k
+                                  ? half(b[global_column * args.k + global_k])
+                                  : half(0.0h);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    #pragma clang loop unroll(full)
+    for (uint ki = 0; ki < 2; ++ki) {
+      simdgroup_matrix<half, 8, 8> a_frag[2];
+      simdgroup_matrix<half, 8, 8> b_frag[2];
+      #pragma clang loop unroll(full)
+      for (uint mi = 0; mi < 2; ++mi) {
+        const uint a_row = mi * 8u + frag_row;
+        const uint a_col = ki * 8u + frag_col;
+        a_frag[mi].thread_elements()[0] = as[a_row * TG_LD + a_col];
+        a_frag[mi].thread_elements()[1] = as[a_row * TG_LD + a_col + 1u];
+      }
+      #pragma clang loop unroll(full)
+      for (uint nj = 0; nj < 2; ++nj) {
+        const uint b_row = ki * 8u + frag_row;
+        const uint b_col = simd_col + nj * 8u + frag_col;
+        b_frag[nj].thread_elements()[0] = bs[b_col * TG_LD + b_row];
+        b_frag[nj].thread_elements()[1] = bs[(b_col + 1u) * TG_LD + b_row];
+      }
+      #pragma clang loop unroll(full)
+      for (uint mi = 0; mi < 2; ++mi) {
+        #pragma clang loop unroll(full)
+        for (uint nj = 0; nj < 2; ++nj)
+          simdgroup_multiply_accumulate(
+            accum[mi][nj], a_frag[mi], b_frag[nj], accum[mi][nj]);
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  #pragma clang loop unroll(full)
+  for (uint mi = 0; mi < 2; ++mi) {
+    const uint row = tile_row + mi * 8u + frag_row;
+    if (row >= args.m)
+      continue;
+    #pragma clang loop unroll(full)
+    for (uint nj = 0; nj < 2; ++nj) {
+      const uint column0 = tile_col + simd_col + nj * 8u + frag_col;
+      #pragma clang loop unroll(full)
+      for (uint element = 0; element < 2; ++element) {
+        const uint column = column0 + element;
+        if (column >= args.n)
+          continue;
+        const uint bi = args.b_scale_size == 1u ? 0u : column;
+        float value = accum[mi][nj].thread_elements()[element] / b_scales[bi];
+        if (args.has_bias)
+          value += float(bias[column]);
+        if (args.activation >= 0)
+          value = apply_unary(value, uint(args.activation));
+        value = float(half(value));
+        const uint index = row * args.n + column;
+        if (args.has_residual)
+          value += float(residual[index]);
+        output[index] = half(value);
+      }
+    }
+  }
+}
+
+// Whisper beam 5 executes most decoder projections as [5,K] x [N,K]^T.
+// MPSMatrix has a large efficiency cliff at this odd row count. Each SIMD
+// group below computes two output columns for all five rows, reusing every
+// weight vector across the beam and keeping the established FP16 epilogue
+// boundary. This also keeps consecutive projections on the compute encoder.
+kernel void small_m5_gemm_nt_f16(
+    device const half* a [[buffer(0)]],
+    device const half* b [[buffer(1)]],
+    device half* c [[buffer(2)]],
+    constant SimdgroupGemmArgs& args [[buffer(3)]],
+    device const half* bias [[buffer(4)]],
+    device const half* residual [[buffer(5)]],
+    uint3 group [[threadgroup_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]],
+    uint simd_id [[simdgroup_index_in_threadgroup]],
+    uint simd_groups [[simdgroups_per_threadgroup]]) {
+  constexpr uint MaxM = 5;
+  constexpr uint OutputsPerSimdgroup = 2;
+  const uint first_output = (group.x * simd_groups + simd_id)
+                            * OutputsPerSimdgroup;
+  float sums[MaxM][OutputsPerSimdgroup];
+  #pragma clang loop unroll(full)
+  for (uint row = 0; row < MaxM; ++row) {
+    #pragma clang loop unroll(full)
+    for (uint output_delta = 0; output_delta < OutputsPerSimdgroup; ++output_delta)
+      sums[row][output_delta] = 0.0f;
+  }
+
+  if ((args.k & 3u) == 0u && (args.lda & 3u) == 0u && (args.ldb & 3u) == 0u) {
+    const uint vectors = args.k >> 2;
+    for (uint p = lane; p < vectors; p += 32u) {
+      float4 weights[OutputsPerSimdgroup];
+      #pragma clang loop unroll(full)
+      for (uint output_delta = 0; output_delta < OutputsPerSimdgroup; ++output_delta) {
+        const uint output = first_output + output_delta;
+        weights[output_delta] = output < args.n
+          ? float4(reinterpret_cast<device const half4*>(
+              b + output * args.ldb)[p])
+          : float4(0.0f);
+      }
+      #pragma clang loop unroll(full)
+      for (uint row = 0; row < MaxM; ++row) {
+        const float4 input = row < args.m
+          ? float4(reinterpret_cast<device const half4*>(
+              a + row * args.lda)[p])
+          : float4(0.0f);
+        #pragma clang loop unroll(full)
+        for (uint output_delta = 0; output_delta < OutputsPerSimdgroup; ++output_delta)
+          sums[row][output_delta] += dot(input, weights[output_delta]);
+      }
+    }
+  } else {
+    for (uint p = lane; p < args.k; p += 32u) {
+      #pragma clang loop unroll(full)
+      for (uint row = 0; row < MaxM; ++row) {
+        const float input = row < args.m ? float(a[row * args.lda + p]) : 0.0f;
+        #pragma clang loop unroll(full)
+        for (uint output_delta = 0; output_delta < OutputsPerSimdgroup; ++output_delta) {
+          const uint output = first_output + output_delta;
+          if (output < args.n)
+            sums[row][output_delta] += input * float(b[output * args.ldb + p]);
+        }
+      }
+    }
+  }
+
+  #pragma clang loop unroll(full)
+  for (uint row = 0; row < MaxM; ++row) {
+    if (row >= args.m)
+      continue;
+    #pragma clang loop unroll(full)
+    for (uint output_delta = 0; output_delta < OutputsPerSimdgroup; ++output_delta) {
+      const uint output = first_output + output_delta;
+      if (output >= args.n)
+        continue;
+      const float sum = simd_sum(sums[row][output_delta]);
+      if (lane == 0u) {
+        const uint output_index = row * args.ldc + output;
+        const float previous = args.beta == 0.0f ? 0.0f : float(c[output_index]);
+        float value = float(half(args.alpha * sum + args.beta * previous));
+        if (args.has_bias)
+          value += float(bias[output]);
+        if (args.has_residual)
+          value += float(residual[output_index]);
+        if (args.activation >= 0)
+          value = apply_unary(value, uint(args.activation));
+        c[output_index] = half(value);
+      }
+    }
+  }
+}
+
 kernel void generic_gemm_i8_i32(device const char* a [[buffer(0)]],
                                 device const char* b [[buffer(1)]],
                                 device int* c [[buffer(2)]],
@@ -949,6 +1376,368 @@ SMALL_TOPK_KERNEL(small_topk_f32, float, load_value<float>, store_value<float>)
 SMALL_TOPK_KERNEL(small_topk_f16, half, load_value<half>, store_value<half>)
 SMALL_TOPK_KERNEL(small_topk_bf16, ushort, load_value_bf16, store_value_bf16)
 
+// Fused deterministic beam-search selection. One threadgroup owns a model
+// batch row and processes all beams. The FP16 rounding after log-softmax and
+// score addition intentionally matches the materialized operator sequence.
+// Keep separate 8- and 16-candidate entry points so the common beam-4 path
+// does not pay the register cost required by beam 5 (which requests k=10).
+template <uint MaxK>
+static inline void fused_beam_search_topk_impl(
+                 device const half* logits,
+                 device const half* beam_scores,
+                 device half* values,
+                 device int* indices,
+                 constant BeamSearchTopKArgs& args,
+                 threadgroup float* shared_values,
+                 threadgroup uint* shared_indices,
+                 threadgroup float* beam_candidates,
+                 threadgroup uint* beam_candidate_indices,
+                 uint batch,
+                 uint tid,
+                 uint nt) {
+  if (batch >= args.batch_size) return;
+  for (uint beam = 0; beam < args.beam_size; ++beam) {
+    const uint row = batch * args.beam_size + beam;
+    const uint row_offset = row * args.vocabulary_size;
+    float local_maximum = -INFINITY;
+    for (uint column = tid; column < args.vocabulary_size; column += nt)
+      local_maximum = max(local_maximum, float(logits[row_offset + column]));
+    shared_values[tid] = local_maximum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint stride = nt >> 1; stride > 0; stride >>= 1) {
+      if (tid < stride)
+        shared_values[tid] = max(shared_values[tid], shared_values[tid + stride]);
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const float maximum = shared_values[0];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float local_values[MaxK];
+    uint local_indices[MaxK];
+    for (uint rank = 0; rank < MaxK; ++rank) {
+      local_values[rank] = -INFINITY;
+      local_indices[rank] = UINT_MAX;
+    }
+    float local_sum = 0.0f;
+    for (uint column = tid; column < args.vocabulary_size; column += nt) {
+      const float candidate = float(logits[row_offset + column]);
+      local_sum += exp(candidate - maximum);
+      uint insert = args.k;
+      for (uint rank = 0; rank < args.k; ++rank) {
+        if (topk_better(candidate, column, local_values[rank], local_indices[rank])) {
+          insert = rank;
+          break;
+        }
+      }
+      if (insert < args.k) {
+        for (uint rank = args.k - 1; rank > insert; --rank) {
+          local_values[rank] = local_values[rank - 1];
+          local_indices[rank] = local_indices[rank - 1];
+        }
+        local_values[insert] = candidate;
+        local_indices[insert] = column;
+      }
+    }
+    shared_values[tid] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint stride = nt >> 1; stride > 0; stride >>= 1) {
+      if (tid < stride) shared_values[tid] += shared_values[tid + stride];
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const float log_sum = log(shared_values[0]);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint rank = 0; rank < args.k; ++rank) {
+      const half normalized = half(local_values[0] - maximum - log_sum);
+      const half scored = half(float(normalized) + float(beam_scores[row]));
+      shared_values[tid] = float(scored);
+      shared_indices[tid] = beam * args.vocabulary_size + local_indices[0];
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      for (uint stride = nt >> 1; stride > 0; stride >>= 1) {
+        if (tid < stride
+            && topk_better(shared_values[tid + stride], shared_indices[tid + stride],
+                           shared_values[tid], shared_indices[tid])) {
+          shared_values[tid] = shared_values[tid + stride];
+          shared_indices[tid] = shared_indices[tid + stride];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+      }
+      if (tid == 0) {
+        beam_candidates[beam * args.k + rank] = shared_values[0];
+        beam_candidate_indices[beam * args.k + rank] = shared_indices[0];
+      }
+      const uint selected_column = shared_indices[0] - beam * args.vocabulary_size;
+      if (local_indices[0] == selected_column) {
+        for (uint next = 1; next < args.k; ++next) {
+          local_values[next - 1] = local_values[next];
+          local_indices[next - 1] = local_indices[next];
+        }
+        local_values[args.k - 1] = -INFINITY;
+        local_indices[args.k - 1] = UINT_MAX;
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  }
+
+  if (tid == 0) {
+    float best_values[MaxK];
+    uint best_indices[MaxK];
+    for (uint rank = 0; rank < MaxK; ++rank) {
+      best_values[rank] = -INFINITY;
+      best_indices[rank] = UINT_MAX;
+    }
+    const uint candidate_count = args.beam_size * args.k;
+    for (uint candidate_id = 0; candidate_id < candidate_count; ++candidate_id) {
+      const float candidate = beam_candidates[candidate_id];
+      const uint candidate_index = beam_candidate_indices[candidate_id];
+      uint insert = args.k;
+      for (uint rank = 0; rank < args.k; ++rank) {
+        if (topk_better(candidate, candidate_index,
+                        best_values[rank], best_indices[rank])) {
+          insert = rank;
+          break;
+        }
+      }
+      if (insert < args.k) {
+        for (uint rank = args.k - 1; rank > insert; --rank) {
+          best_values[rank] = best_values[rank - 1];
+          best_indices[rank] = best_indices[rank - 1];
+        }
+        best_values[insert] = candidate;
+        best_indices[insert] = candidate_index;
+      }
+    }
+    for (uint rank = 0; rank < args.k; ++rank) {
+      values[batch * args.k + rank] = half(best_values[rank]);
+      indices[batch * args.k + rank] = int(best_indices[rank]);
+    }
+  }
+}
+
+// The wider candidate path avoids one full threadgroup reduction per rank.
+// Each SIMD group selects its local TopK with shuffle reductions, then thread
+// zero merges the small list of SIMD-group candidates. This is substantially
+// cheaper for beam 5 (5 beams x 10 candidates) than 50 barrier-heavy
+// threadgroup reductions per decoding step.
+template <uint MaxK>
+static inline void fused_beam_search_topk_simd_impl(
+                 device const half* logits,
+                 device const half* beam_scores,
+                 device half* values,
+                 device int* indices,
+                 constant BeamSearchTopKArgs& args,
+                 threadgroup float* shared_values,
+                 threadgroup uint* shared_indices,
+                 threadgroup float* beam_candidates,
+                 threadgroup uint* beam_candidate_indices,
+                 uint batch,
+                 uint tid,
+                 uint nt,
+                 uint lane,
+                 uint simd_id) {
+  if (batch >= args.batch_size) return;
+  const uint simd_width = 32;
+  const uint num_simdgroups = nt / simd_width;
+
+  for (uint beam = 0; beam < args.beam_size; ++beam) {
+    const uint row = batch * args.beam_size + beam;
+    const uint row_offset = row * args.vocabulary_size;
+    float local_maximum = -INFINITY;
+    for (uint column = tid; column < args.vocabulary_size; column += nt)
+      local_maximum = max(local_maximum, float(logits[row_offset + column]));
+    shared_values[tid] = local_maximum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint stride = nt >> 1; stride > 0; stride >>= 1) {
+      if (tid < stride)
+        shared_values[tid] = max(shared_values[tid], shared_values[tid + stride]);
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const float maximum = shared_values[0];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float local_values[MaxK];
+    uint local_indices[MaxK];
+    for (uint rank = 0; rank < MaxK; ++rank) {
+      local_values[rank] = -INFINITY;
+      local_indices[rank] = UINT_MAX;
+    }
+    float local_sum = 0.0f;
+    for (uint column = tid; column < args.vocabulary_size; column += nt) {
+      const float candidate = float(logits[row_offset + column]);
+      local_sum += exp(candidate - maximum);
+      uint insert = args.k;
+      for (uint rank = 0; rank < args.k; ++rank) {
+        if (topk_better(candidate, column, local_values[rank], local_indices[rank])) {
+          insert = rank;
+          break;
+        }
+      }
+      if (insert < args.k) {
+        for (uint rank = args.k - 1; rank > insert; --rank) {
+          local_values[rank] = local_values[rank - 1];
+          local_indices[rank] = local_indices[rank - 1];
+        }
+        local_values[insert] = candidate;
+        local_indices[insert] = column;
+      }
+    }
+    shared_values[tid] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint stride = nt >> 1; stride > 0; stride >>= 1) {
+      if (tid < stride) shared_values[tid] += shared_values[tid + stride];
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const float log_sum = log(shared_values[0]);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint rank = 0; rank < args.k; ++rank) {
+      const half normalized = half(local_values[0] - maximum - log_sum);
+      const half scored = half(float(normalized) + float(beam_scores[row]));
+      float candidate_value = float(scored);
+      uint candidate_index = local_indices[0];
+      for (uint offset = simd_width >> 1; offset > 0; offset >>= 1) {
+        const float other_value = simd_shuffle_down(candidate_value, offset);
+        const uint other_index = simd_shuffle_down(candidate_index, offset);
+        if (lane + offset < simd_width
+            && topk_better(other_value, other_index,
+                           candidate_value, candidate_index)) {
+          candidate_value = other_value;
+          candidate_index = other_index;
+        }
+      }
+      candidate_value = simd_broadcast_first(candidate_value);
+      candidate_index = simd_broadcast_first(candidate_index);
+      if (lane == 0) {
+        const uint candidate_offset = simd_id * args.k + rank;
+        shared_values[candidate_offset] = candidate_value;
+        shared_indices[candidate_offset] = candidate_index;
+      }
+      if (local_indices[0] == candidate_index) {
+        for (uint next = 1; next < args.k; ++next) {
+          local_values[next - 1] = local_values[next];
+          local_indices[next - 1] = local_indices[next];
+        }
+        local_values[args.k - 1] = -INFINITY;
+        local_indices[args.k - 1] = UINT_MAX;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (tid == 0) {
+      float best_values[MaxK];
+      uint best_indices[MaxK];
+      for (uint rank = 0; rank < MaxK; ++rank) {
+        best_values[rank] = -INFINITY;
+        best_indices[rank] = UINT_MAX;
+      }
+      const uint candidate_count = num_simdgroups * args.k;
+      for (uint candidate_id = 0; candidate_id < candidate_count; ++candidate_id) {
+        const float candidate = shared_values[candidate_id];
+        const uint candidate_index = shared_indices[candidate_id];
+        uint insert = args.k;
+        for (uint rank = 0; rank < args.k; ++rank) {
+          if (topk_better(candidate, candidate_index,
+                          best_values[rank], best_indices[rank])) {
+            insert = rank;
+            break;
+          }
+        }
+        if (insert < args.k) {
+          for (uint rank = args.k - 1; rank > insert; --rank) {
+            best_values[rank] = best_values[rank - 1];
+            best_indices[rank] = best_indices[rank - 1];
+          }
+          best_values[insert] = candidate;
+          best_indices[insert] = candidate_index;
+        }
+      }
+      for (uint rank = 0; rank < args.k; ++rank) {
+        beam_candidates[beam * args.k + rank] = best_values[rank];
+        beam_candidate_indices[beam * args.k + rank]
+          = beam * args.vocabulary_size + best_indices[rank];
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (tid == 0) {
+    float best_values[MaxK];
+    uint best_indices[MaxK];
+    for (uint rank = 0; rank < MaxK; ++rank) {
+      best_values[rank] = -INFINITY;
+      best_indices[rank] = UINT_MAX;
+    }
+    const uint candidate_count = args.beam_size * args.k;
+    for (uint candidate_id = 0; candidate_id < candidate_count; ++candidate_id) {
+      const float candidate = beam_candidates[candidate_id];
+      const uint candidate_index = beam_candidate_indices[candidate_id];
+      uint insert = args.k;
+      for (uint rank = 0; rank < args.k; ++rank) {
+        if (topk_better(candidate, candidate_index,
+                        best_values[rank], best_indices[rank])) {
+          insert = rank;
+          break;
+        }
+      }
+      if (insert < args.k) {
+        for (uint rank = args.k - 1; rank > insert; --rank) {
+          best_values[rank] = best_values[rank - 1];
+          best_indices[rank] = best_indices[rank - 1];
+        }
+        best_values[insert] = candidate;
+        best_indices[insert] = candidate_index;
+      }
+    }
+    for (uint rank = 0; rank < args.k; ++rank) {
+      values[batch * args.k + rank] = half(best_values[rank]);
+      indices[batch * args.k + rank] = int(best_indices[rank]);
+    }
+  }
+}
+
+#define FUSED_BEAM_SEARCH_TOPK_KERNEL(NAME, MAX_K)                                    \
+kernel void NAME(device const half* logits [[buffer(0)]],                             \
+                 device const half* beam_scores [[buffer(1)]],                       \
+                 device half* values [[buffer(2)]],                                  \
+                 device int* indices [[buffer(3)]],                                  \
+                 constant BeamSearchTopKArgs& args [[buffer(4)]],                    \
+                 threadgroup float* shared_values [[threadgroup(0)]],                \
+                 threadgroup uint* shared_indices [[threadgroup(1)]],                \
+                 threadgroup float* beam_candidates [[threadgroup(2)]],              \
+                 threadgroup uint* beam_candidate_indices [[threadgroup(3)]],        \
+                 uint batch [[threadgroup_position_in_grid]],                        \
+                 uint tid [[thread_index_in_threadgroup]],                           \
+                 uint nt [[threads_per_threadgroup]]) {                              \
+  fused_beam_search_topk_impl<MAX_K>(logits, beam_scores, values, indices, args,      \
+                                      shared_values, shared_indices, beam_candidates, \
+                                      beam_candidate_indices, batch, tid, nt);        \
+}
+
+FUSED_BEAM_SEARCH_TOPK_KERNEL(fused_beam_search_topk_f16, 8)
+
+#define FUSED_BEAM_SEARCH_TOPK_SIMD_KERNEL(NAME, MAX_K)                               \
+kernel void NAME(device const half* logits [[buffer(0)]],                             \
+                 device const half* beam_scores [[buffer(1)]],                       \
+                 device half* values [[buffer(2)]],                                  \
+                 device int* indices [[buffer(3)]],                                  \
+                 constant BeamSearchTopKArgs& args [[buffer(4)]],                    \
+                 threadgroup float* shared_values [[threadgroup(0)]],                \
+                 threadgroup uint* shared_indices [[threadgroup(1)]],                \
+                 threadgroup float* beam_candidates [[threadgroup(2)]],              \
+                 threadgroup uint* beam_candidate_indices [[threadgroup(3)]],        \
+                 uint batch [[threadgroup_position_in_grid]],                        \
+                 uint tid [[thread_index_in_threadgroup]],                           \
+                 uint nt [[threads_per_threadgroup]],                                \
+                 uint lane [[thread_index_in_simdgroup]],                            \
+                 uint simd_id [[simdgroup_index_in_threadgroup]]) {                  \
+  fused_beam_search_topk_simd_impl<MAX_K>(                                            \
+    logits, beam_scores, values, indices, args, shared_values, shared_indices,        \
+    beam_candidates, beam_candidate_indices, batch, tid, nt, lane, simd_id);          \
+}
+
+FUSED_BEAM_SEARCH_TOPK_SIMD_KERNEL(fused_beam_search_topk_10_f16, 10)
+FUSED_BEAM_SEARCH_TOPK_SIMD_KERNEL(fused_beam_search_topk_16_f16, 16)
+
 #define GATHER_KERNEL(NAME, TYPE)                                                     \
 kernel void NAME(device const TYPE* input [[buffer(0)]],                              \
                  device const int* indices [[buffer(1)]],                             \
@@ -971,6 +1760,28 @@ GATHER_KERNEL(gather_bf16, ushort)
 GATHER_KERNEL(gather_i8, char)
 GATHER_KERNEL(gather_i16, short)
 GATHER_KERNEL(gather_i32, int)
+
+// Gather rows as contiguous vector blocks. The generic one-thread-per-element
+// kernel divides by copy_size for every value, which is particularly costly
+// when beam cache rows contain tens of thousands of FP16 elements.
+#define GATHER_BLOCK_VEC4_KERNEL(NAME, TYPE4)                                        \
+kernel void NAME(device const TYPE4* input [[buffer(0)]],                            \
+                 device const int* indices [[buffer(1)]],                            \
+                 device TYPE4* output [[buffer(2)]],                                 \
+                 constant GatherBlockArgs& args [[buffer(3)]],                       \
+                 uint index_id [[threadgroup_position_in_grid]],                     \
+                 uint tid [[thread_index_in_threadgroup]],                           \
+                 uint nt [[threads_per_threadgroup]]) {                              \
+  if (index_id >= args.num_indices) return;                                          \
+  const uint batch = index_id / args.num_indices_per_batch;                          \
+  const uint source = batch * args.batch_stride_vectors                             \
+                      + uint(indices[index_id]) * args.copy_vectors;                 \
+  const uint destination = index_id * args.copy_vectors;                             \
+  for (uint v = tid; v < args.copy_vectors; v += nt)                                \
+    output[destination + v] = input[source + v];                                     \
+}
+
+GATHER_BLOCK_VEC4_KERNEL(gather_block_vec4_f16, half4)
 
 #define CONCAT2_KERNEL(NAME, TYPE)                                                    \
 kernel void NAME(device const TYPE* a [[buffer(0)]],                                 \
@@ -995,6 +1806,61 @@ CONCAT2_KERNEL(concat2_bf16, ushort)
 CONCAT2_KERNEL(concat2_i8, char)
 CONCAT2_KERNEL(concat2_i16, short)
 CONCAT2_KERNEL(concat2_i32, int)
+
+#define SPLIT2_KERNEL(NAME, TYPE)                                                    \
+kernel void NAME(device const TYPE* input [[buffer(0)]],                             \
+                 device TYPE* a [[buffer(1)]],                                       \
+                 device TYPE* b [[buffer(2)]],                                       \
+                 constant Split2Args& args [[buffer(3)]],                            \
+                 uint gid [[thread_position_in_grid]]) {                             \
+  const ulong input_block = args.a_block_size + args.b_block_size;                   \
+  const ulong total = args.outer_size * input_block;                                 \
+  const ulong index = ulong(gid);                                                    \
+  if (index >= total) return;                                                        \
+  const ulong outer = index / input_block;                                           \
+  const ulong within = index - outer * input_block;                                  \
+  if (within < args.a_block_size)                                                    \
+    a[outer * args.a_block_size + within] = input[index];                            \
+  else                                                                               \
+    b[outer * args.b_block_size + within - args.a_block_size] = input[index];        \
+}
+
+SPLIT2_KERNEL(split2_f32, float)
+SPLIT2_KERNEL(split2_f16, half)
+SPLIT2_KERNEL(split2_bf16, ushort)
+SPLIT2_KERNEL(split2_i8, char)
+SPLIT2_KERNEL(split2_i16, short)
+SPLIT2_KERNEL(split2_i32, int)
+
+#define SPLIT3_KERNEL(NAME, TYPE)                                                    \
+kernel void NAME(device const TYPE* input [[buffer(0)]],                             \
+                 device TYPE* a [[buffer(1)]],                                       \
+                 device TYPE* b [[buffer(2)]],                                       \
+                 device TYPE* c [[buffer(3)]],                                       \
+                 constant Split3Args& args [[buffer(4)]],                            \
+                 uint gid [[thread_position_in_grid]]) {                             \
+  const ulong ab_block = args.a_block_size + args.b_block_size;                      \
+  const ulong input_block = ab_block + args.c_block_size;                            \
+  const ulong total = args.outer_size * input_block;                                 \
+  const ulong index = ulong(gid);                                                    \
+  if (index >= total) return;                                                        \
+  const ulong outer = index / input_block;                                           \
+  const ulong within = index - outer * input_block;                                  \
+  if (within < args.a_block_size) {                                                  \
+    a[outer * args.a_block_size + within] = input[index];                            \
+  } else if (within < ab_block) {                                                    \
+    b[outer * args.b_block_size + within - args.a_block_size] = input[index];        \
+  } else {                                                                           \
+    c[outer * args.c_block_size + within - ab_block] = input[index];                 \
+  }                                                                                  \
+}
+
+SPLIT3_KERNEL(split3_f32, float)
+SPLIT3_KERNEL(split3_f16, half)
+SPLIT3_KERNEL(split3_bf16, ushort)
+SPLIT3_KERNEL(split3_i8, char)
+SPLIT3_KERNEL(split3_i16, short)
+SPLIT3_KERNEL(split3_i32, int)
 
 #define TILE_KERNEL(NAME, TYPE)                                                       \
 kernel void NAME(device const TYPE* input [[buffer(0)]],                              \
@@ -1142,6 +2008,133 @@ kernel void NAME(device const int* input [[buffer(0)]],                         
 DEQUANTIZE_GEMM_KERNEL(dequantize_gemm_f32, float, load_value<float>, store_value<float>)
 DEQUANTIZE_GEMM_KERNEL(dequantize_gemm_f16, half, load_value<half>, store_value<half>)
 DEQUANTIZE_GEMM_KERNEL(dequantize_gemm_bf16, ushort, load_value_bf16, store_value_bf16)
+
+// Apple GPU arithmetic throughput is optimized for FP16/FP32 rather than
+// scalar integer dot products. For explicit int8_float16 execution, keep the
+// model weights compressed but multiply them directly by FP16 activations.
+// Weight loads are reused across all rows in the beam/request batch. Separate
+// 4/8/16-row variants avoid carrying inactive accumulators when the active
+// batch shrinks near the end of beam search.
+template <uint RowsPerBlock, uint OutputsPerSimdgroup>
+static inline void weight_only_int8_dense_f16_impl(
+    device const half* a,
+    device const char* b,
+    device const float* b_scales,
+    device const half* bias,
+    device const half* residual,
+    device half* output,
+    constant Int8DenseArgs& args,
+    uint3 group,
+    uint lane,
+    uint simd_id,
+    uint simd_groups) {
+  const uint first_row = group.y * RowsPerBlock;
+  const uint first_column = (group.x * simd_groups + simd_id)
+                            * OutputsPerSimdgroup;
+
+  float sums[RowsPerBlock][OutputsPerSimdgroup];
+  #pragma clang loop unroll(full)
+  for (uint row_delta = 0; row_delta < RowsPerBlock; ++row_delta) {
+    #pragma clang loop unroll(full)
+    for (uint output_delta = 0; output_delta < OutputsPerSimdgroup; ++output_delta)
+      sums[row_delta][output_delta] = 0.0f;
+  }
+
+  if ((args.k & 3u) == 0u) {
+    const uint vectors = args.k >> 2;
+    for (uint p = lane; p < vectors; p += 32u) {
+      float4 weights[OutputsPerSimdgroup];
+      #pragma clang loop unroll(full)
+      for (uint output_delta = 0; output_delta < OutputsPerSimdgroup; ++output_delta) {
+        const uint column = first_column + output_delta;
+        weights[output_delta] = column < args.n
+          ? float4(int4(reinterpret_cast<device const char4*>(
+              b + column * args.k)[p]))
+          : float4(0.0f);
+      }
+      #pragma clang loop unroll(full)
+      for (uint row_delta = 0; row_delta < RowsPerBlock; ++row_delta) {
+        const uint row = first_row + row_delta;
+        if (row < args.m) {
+          device const half4* input = reinterpret_cast<device const half4*>(
+            a + row * args.k);
+          const float4 input_value = float4(input[p]);
+          #pragma clang loop unroll(full)
+          for (uint output_delta = 0; output_delta < OutputsPerSimdgroup; ++output_delta)
+            sums[row_delta][output_delta] += dot(input_value, weights[output_delta]);
+        }
+      }
+    }
+  } else {
+    for (uint p = lane; p < args.k; p += 32u) {
+      float weights[OutputsPerSimdgroup];
+      #pragma clang loop unroll(full)
+      for (uint output_delta = 0; output_delta < OutputsPerSimdgroup; ++output_delta) {
+        const uint column = first_column + output_delta;
+        weights[output_delta] = column < args.n
+          ? float(b[column * args.k + p])
+          : 0.0f;
+      }
+      #pragma clang loop unroll(full)
+      for (uint row_delta = 0; row_delta < RowsPerBlock; ++row_delta) {
+        const uint row = first_row + row_delta;
+        if (row < args.m) {
+          const float input_value = float(a[row * args.k + p]);
+          #pragma clang loop unroll(full)
+          for (uint output_delta = 0; output_delta < OutputsPerSimdgroup; ++output_delta)
+            sums[row_delta][output_delta] += input_value * weights[output_delta];
+        }
+      }
+    }
+  }
+
+  #pragma clang loop unroll(full)
+  for (uint row_delta = 0; row_delta < RowsPerBlock; ++row_delta) {
+    const uint row = first_row + row_delta;
+    if (row >= args.m)
+      continue;
+    #pragma clang loop unroll(full)
+    for (uint output_delta = 0; output_delta < OutputsPerSimdgroup; ++output_delta) {
+      const uint column = first_column + output_delta;
+      if (column >= args.n)
+        continue;
+      const float sum = simd_sum(sums[row_delta][output_delta]);
+      if (lane == 0u) {
+        const uint bi = args.b_scale_size == 1u ? 0u : column;
+        float value = sum / b_scales[bi];
+        if (args.has_bias)
+          value += float(bias[column]);
+        if (args.activation >= 0)
+          value = apply_unary(value, uint(args.activation));
+        value = float(half(value));
+        const uint index = row * args.n + column;
+        if (args.has_residual)
+          value += float(residual[index]);
+        output[index] = half(value);
+      }
+    }
+  }
+}
+
+#define WEIGHT_ONLY_INT8_DENSE_KERNEL(NAME, ROWS, OUTPUTS)                            \
+kernel void NAME(device const half* a [[buffer(0)]],                                  \
+                 device const char* b [[buffer(1)]],                                  \
+                 device const float* b_scales [[buffer(2)]],                          \
+                 device const half* bias [[buffer(3)]],                               \
+                 device const half* residual [[buffer(4)]],                           \
+                 device half* output [[buffer(5)]],                                   \
+                 constant Int8DenseArgs& args [[buffer(6)]],                          \
+                 uint3 group [[threadgroup_position_in_grid]],                        \
+                 uint lane [[thread_index_in_simdgroup]],                             \
+                 uint simd_id [[simdgroup_index_in_threadgroup]],                     \
+                 uint simd_groups [[simdgroups_per_threadgroup]]) {                   \
+  weight_only_int8_dense_f16_impl<ROWS, OUTPUTS>(                                     \
+    a, b, b_scales, bias, residual, output, args, group, lane, simd_id, simd_groups); \
+}
+
+WEIGHT_ONLY_INT8_DENSE_KERNEL(weight_only_int8_dense_m4_f16, 4, 2)
+WEIGHT_ONLY_INT8_DENSE_KERNEL(weight_only_int8_dense_m8_f16, 8, 2)
+WEIGHT_ONLY_INT8_DENSE_KERNEL(weight_only_int8_dense_m16_f16, 16, 1)
 
 #define MEDIAN_FILTER_KERNEL(NAME, TYPE, LOAD, STORE)                                  \
 kernel void NAME(device const TYPE* input [[buffer(0)]],                               \
@@ -1326,6 +2319,28 @@ TRANSPOSE_4D_KERNEL(transpose_4d_f32, float)
 TRANSPOSE_4D_KERNEL(transpose_4d_f16, half)
 TRANSPOSE_4D_KERNEL(transpose_4d_bf16, ushort)
 
+// Transformer attention overwhelmingly uses [B, T, H, D] <-> [B, H, T, D].
+// Dispatch one threadgroup per contiguous D block so group coordinates replace
+// the generic kernel's multiple 64-bit divisions for every scalar value.
+#define TRANSPOSE_0213_VEC4_KERNEL(NAME, TYPE4)                                      \
+kernel void NAME(device const TYPE4* a [[buffer(0)]],                                \
+                 device TYPE4* b [[buffer(1)]],                                      \
+                 constant Transpose0213Args& args [[buffer(2)]],                     \
+                 uint block [[threadgroup_position_in_grid]],                        \
+                 uint tid [[thread_index_in_threadgroup]],                           \
+                 uint nt [[threads_per_threadgroup]]) {                              \
+  const uint blocks_per_batch = args.d2 * args.d1;                                   \
+  const uint batch = block / blocks_per_batch;                                       \
+  const uint local = block - batch * blocks_per_batch;                               \
+  const uint i2 = local / args.d1;                                                   \
+  const uint i1 = local - i2 * args.d1;                                              \
+  const uint source_block = (batch * args.d1 + i1) * args.d2 + i2;                   \
+  for (uint v = tid; v < args.d3_vectors; v += nt)                                  \
+    b[block * args.d3_vectors + v] = a[source_block * args.d3_vectors + v];          \
+}
+
+TRANSPOSE_0213_VEC4_KERNEL(transpose_0213_vec4_f16, half4)
+
 #define SOFTMAX_KERNEL(NAME, TYPE, LOAD, STORE)                                        \
 kernel void NAME(device const TYPE* x [[buffer(0)]],                                   \
                  device const int* lengths [[buffer(1)]],                              \
@@ -1380,6 +2395,101 @@ kernel void NAME(device const TYPE* x [[buffer(0)]],                            
 SOFTMAX_KERNEL(softmax_f32, float, load_value<float>, store_value<float>)
 SOFTMAX_KERNEL(softmax_f16, half, load_value<half>, store_value<half>)
 SOFTMAX_KERNEL(softmax_bf16, ushort, load_value_bf16, store_value_bf16)
+
+// Fuses the two decoder attention GEMMs and the intervening softmax. The
+// input layout is [matrix_batch, query/key_length, depth], where
+// matrix_batch is the product of the model batch and attention heads. One
+// threadgroup computes one query row. Scores and probabilities are rounded
+// to FP16 at the same boundaries as the generic GEMM -> softmax -> GEMM path.
+kernel void fused_attention_f16(
+    device const half4* queries [[buffer(0)]],
+    device const half4* keys [[buffer(1)]],
+    device const half4* values [[buffer(2)]],
+    device const int* lengths [[buffer(3)]],
+    device half4* output [[buffer(4)]],
+    constant FusedAttentionArgs& args [[buffer(5)]],
+    threadgroup float* scores [[threadgroup(0)]],
+    threadgroup float* scratch [[threadgroup(1)]],
+    uint row [[threadgroup_position_in_grid]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint nt [[threads_per_threadgroup]]) {
+  const uint total_rows = args.batch_size * args.query_length;
+  if (row >= total_rows)
+    return;
+
+  const uint matrix = row / args.query_length;
+  const uint query_row = row - matrix * args.query_length;
+  uint q_offset;
+  if (args.interleaved_num_heads != 0u) {
+    const uint model_batch = matrix / args.interleaved_num_heads;
+    const uint head = matrix - model_batch * args.interleaved_num_heads;
+    q_offset = ((model_batch * args.query_length + query_row)
+                * args.interleaved_num_heads + head) * args.depth_vectors;
+  } else {
+    q_offset = (matrix * args.query_length + query_row) * args.depth_vectors;
+  }
+  const uint kv_offset = matrix * args.key_length * args.depth_vectors;
+  uint valid = args.key_length;
+  if (args.has_lengths) {
+    const int requested = lengths[row];
+    valid = requested <= 0 ? 0u : min(uint(requested), args.key_length);
+  }
+
+  if (valid == 0u) {
+    for (uint d = tid; d < args.depth_vectors; d += nt)
+      output[q_offset + d] = half4(0.0h);
+    return;
+  }
+
+  float local_maximum = -INFINITY;
+  for (uint key_row = tid; key_row < valid; key_row += nt) {
+    const uint key_offset = kv_offset + key_row * args.depth_vectors;
+    float dot_product = 0.0f;
+    for (uint d = 0; d < args.depth_vectors; ++d)
+      dot_product += dot(float4(queries[q_offset + d]),
+                         float4(keys[key_offset + d]));
+    // Preserve the materialized first GEMM's FP16 rounding.
+    const float score = float(half(dot_product * args.scale));
+    scores[key_row] = score;
+    local_maximum = max(local_maximum, score);
+  }
+
+  scratch[tid] = local_maximum;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for (uint stride = nt >> 1; stride > 0; stride >>= 1) {
+    if (tid < stride)
+      scratch[tid] = max(scratch[tid], scratch[tid + stride]);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+  const float maximum = scratch[0];
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  float local_sum = 0.0f;
+  for (uint key_row = tid; key_row < valid; key_row += nt)
+    local_sum += exp(scores[key_row] - maximum);
+  scratch[tid] = local_sum;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for (uint stride = nt >> 1; stride > 0; stride >>= 1) {
+    if (tid < stride)
+      scratch[tid] += scratch[tid + stride];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+  const float log_sum = log(scratch[0]);
+  for (uint key_row = tid; key_row < valid; key_row += nt) {
+    // Preserve the materialized softmax's FP16 rounding.
+    scores[key_row] = float(half(exp(scores[key_row] - maximum - log_sum)));
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint d = tid; d < args.depth_vectors; d += nt) {
+    float4 result(0.0f);
+    for (uint key_row = 0; key_row < valid; ++key_row) {
+      const uint value_offset = kv_offset + key_row * args.depth_vectors + d;
+      result += scores[key_row] * float4(values[value_offset]);
+    }
+    output[q_offset + d] = half4(result);
+  }
+}
 
 #define MEAN_KERNEL(NAME, TYPE, LOAD, STORE)                                           \
 kernel void NAME(device const TYPE* x [[buffer(0)]],                                   \
@@ -1529,6 +2639,57 @@ LAYER_NORM_KERNEL(layer_norm_f32, float, load_value<float>, store_value<float>)
 LAYER_NORM_KERNEL(layer_norm_f16, half, load_value<half>, store_value<half>)
 LAYER_NORM_KERNEL(layer_norm_bf16, ushort, load_value_bf16, store_value_bf16)
 
+// The post-norm Transformer path normally dispatches BiasAdd and LayerNorm
+// separately. Preserve the intermediate FP16 rounding performed by BiasAdd so
+// this fusion changes submission and memory traffic, not model numerics.
+kernel void fused_bias_residual_layer_norm_f16(
+                 device const half* x [[buffer(0)]],
+                 device const half* bias [[buffer(1)]],
+                 device const half* residual [[buffer(2)]],
+                 device const half* gamma [[buffer(3)]],
+                 device const half* beta [[buffer(4)]],
+                 device half* y [[buffer(5)]],
+                 constant NormArgs& args [[buffer(6)]],
+                 threadgroup float* scratch [[threadgroup(0)]],
+                 uint row [[threadgroup_position_in_grid]],
+                 uint tid [[thread_index_in_threadgroup]],
+                 uint nt [[threads_per_threadgroup]]) {
+  if ((ulong)row >= args.outer_size) return;
+  const ulong base = (ulong)row * args.axis_size;
+  float sum = 0.0f;
+  float sumsq = 0.0f;
+  for (ulong k = (ulong)tid; k < args.axis_size; k += (ulong)nt) {
+    const ulong index = base + k;
+    const half rounded = half(float(x[index]) + float(bias[k]) + float(residual[index]));
+    const float value = float(rounded);
+    sum += value;
+    sumsq += value * value;
+  }
+  scratch[tid] = sum;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for (uint stride = nt >> 1; stride > 0; stride >>= 1) {
+    if (tid < stride) scratch[tid] += scratch[tid + stride];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+  const float total_sum = scratch[0];
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  scratch[tid] = sumsq;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for (uint stride = nt >> 1; stride > 0; stride >>= 1) {
+    if (tid < stride) scratch[tid] += scratch[tid + stride];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+  const float mean = total_sum / float(args.axis_size);
+  const float variance = max(scratch[0] / float(args.axis_size) - mean * mean, 0.0f);
+  const float rstd = rsqrt(variance + args.epsilon);
+  for (ulong k = (ulong)tid; k < args.axis_size; k += (ulong)nt) {
+    const ulong index = base + k;
+    const half rounded = half(float(x[index]) + float(bias[k]) + float(residual[index]));
+    const float value = (float(rounded) - mean) * rstd;
+    y[index] = half(value * float(gamma[k]) + float(beta[k]));
+  }
+}
+
 #define RMS_NORM_KERNEL(NAME, TYPE, LOAD, STORE)                                       \
 kernel void NAME(device const TYPE* x [[buffer(0)]],                                   \
                  device const TYPE* gamma [[buffer(1)]],                               \
@@ -1666,11 +2827,27 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         uint64_t p3;
       };
 
+      struct Transpose0213Args {
+        uint32_t d1;
+        uint32_t d2;
+        uint32_t d3_vectors;
+      };
+
       struct SoftmaxArgs {
         uint64_t batch_size;
         uint64_t depth;
         uint32_t has_lengths;
         uint32_t log_output;
+      };
+
+      struct FusedAttentionArgs {
+        uint32_t batch_size;
+        uint32_t query_length;
+        uint32_t key_length;
+        uint32_t depth_vectors;
+        uint32_t has_lengths;
+        uint32_t interleaved_num_heads;
+        float scale;
       };
 
       struct MeanArgs {
@@ -1767,9 +2944,30 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         float beta;
       };
 
+      struct SimdgroupGemmArgs {
+        uint32_t m;
+        uint32_t n;
+        uint32_t k;
+        uint32_t lda;
+        uint32_t ldb;
+        uint32_t ldc;
+        float alpha;
+        float beta;
+        uint32_t has_bias;
+        uint32_t has_residual;
+        int32_t activation;
+      };
+
       struct SmallTopKArgs {
         uint32_t batch_size;
         uint32_t depth;
+        uint32_t k;
+      };
+
+      struct BeamSearchTopKArgs {
+        uint32_t batch_size;
+        uint32_t beam_size;
+        uint32_t vocabulary_size;
         uint32_t k;
       };
 
@@ -1801,10 +2999,30 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         uint64_t num_indices_per_batch;
       };
 
+      struct GatherBlockArgs {
+        uint32_t copy_vectors;
+        uint32_t batch_stride_vectors;
+        uint32_t num_indices;
+        uint32_t num_indices_per_batch;
+      };
+
       struct Concat2Args {
         uint64_t outer_size;
         uint64_t a_block_size;
         uint64_t b_block_size;
+      };
+
+      struct Split2Args {
+        uint64_t outer_size;
+        uint64_t a_block_size;
+        uint64_t b_block_size;
+      };
+
+      struct Split3Args {
+        uint64_t outer_size;
+        uint64_t a_block_size;
+        uint64_t b_block_size;
+        uint64_t c_block_size;
       };
 
       struct TileArgs {
@@ -1841,6 +3059,17 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         uint32_t transpose_a;
         uint32_t transpose_b;
         uint32_t has_bias;
+        int32_t activation;
+      };
+
+      struct Int8DenseArgs {
+        uint32_t m;
+        uint32_t n;
+        uint32_t k;
+        uint32_t a_scale_size;
+        uint32_t b_scale_size;
+        uint32_t has_bias;
+        uint32_t has_residual;
         int32_t activation;
       };
 
@@ -2455,6 +3684,137 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       return value >= 0 && static_cast<uint64_t>(value) <= UINT32_MAX;
     }
 
+    static bool small_m5_gemm_layout_supported(const void* a,
+                                                dim_t lda,
+                                                const void* b,
+                                                dim_t ldb,
+                                                dim_t k) {
+      const bool uses_vector_loads = k % 4 == 0 && lda % 4 == 0 && ldb % 4 == 0;
+      return !uses_vector_loads
+             || ((reinterpret_cast<uintptr_t>(a) & 7u) == 0
+                 && (reinterpret_cast<uintptr_t>(b) & 7u) == 0);
+    }
+
+    static bool simdgroup_gemm_enabled() {
+      static const bool enabled = []() {
+        const char* value = std::getenv("CT2_MPS_USE_SIMDGROUP_GEMM");
+        return value && value[0] != '\0' && value[0] != '0';
+      }();
+      return enabled;
+    }
+
+    static void simdgroup_gemm_nt_f16(dim_t m,
+                                      dim_t n,
+                                      dim_t k,
+                                      float alpha,
+                                      const void* a,
+                                      dim_t lda,
+                                      const void* b,
+                                      dim_t ldb,
+                                      float beta,
+                                      void* c,
+                                      dim_t ldc,
+                                      const void* bias = nullptr,
+                                      const void* residual = nullptr,
+                                      int activation = -1) {
+      const char* kernel = "simdgroup_gemm_nt_f16_64x64";
+      const NSUInteger tile_m = 64;
+      const NSUInteger threads = 128;
+      const SimdgroupGemmArgs args{static_cast<uint32_t>(m),
+                                   static_cast<uint32_t>(n),
+                                   static_cast<uint32_t>(k),
+                                   static_cast<uint32_t>(lda),
+                                   static_cast<uint32_t>(ldb),
+                                   static_cast<uint32_t>(ldc),
+                                   alpha,
+                                   beta,
+                                   bias ? 1u : 0u,
+                                   residual ? 1u : 0u,
+                                   activation};
+      id<MTLComputePipelineState> state = pipeline(kernel);
+      id<MTLComputeCommandEncoder> encoder =
+        (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+      [encoder setComputePipelineState:state];
+      set_buffer(encoder, a, dense_matrix_bytes(m, k, lda, sizeof(uint16_t)), 0);
+      set_buffer(encoder, b, dense_matrix_bytes(n, k, ldb, sizeof(uint16_t)), 1);
+      set_buffer(encoder, c, dense_matrix_bytes(m, n, ldc, sizeof(uint16_t)), 2);
+      [encoder setBytes:&args length:sizeof(args) atIndex:3];
+      set_buffer(encoder,
+                 bias ? bias : c,
+                 bias ? static_cast<size_t>(n) * sizeof(uint16_t) : sizeof(uint16_t),
+                 4);
+      set_buffer(encoder,
+                 residual ? residual : c,
+                 residual ? dense_matrix_bytes(m, n, ldc, sizeof(uint16_t))
+                          : sizeof(uint16_t),
+                 5);
+      [encoder dispatchThreadgroups:MTLSizeMake((static_cast<NSUInteger>(n) + 63) / 64,
+                                                (static_cast<NSUInteger>(m) + tile_m - 1) / tile_m,
+                                                1)
+               threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
+      [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+      record_compute_dispatch(kernel);
+      record_profile_event(ProfileEvent::Gemm);
+    }
+
+    static void small_m5_gemm_nt_f16(dim_t m,
+                                     dim_t n,
+                                     dim_t k,
+                                     float alpha,
+                                     const void* a,
+                                     dim_t lda,
+                                     const void* b,
+                                     dim_t ldb,
+                                     float beta,
+                                     void* c,
+                                     dim_t ldc,
+                                     const void* bias = nullptr,
+                                     const void* residual = nullptr,
+                                     int activation = -1) {
+      const char* kernel = "small_m5_gemm_nt_f16";
+      const SimdgroupGemmArgs args{static_cast<uint32_t>(m),
+                                   static_cast<uint32_t>(n),
+                                   static_cast<uint32_t>(k),
+                                   static_cast<uint32_t>(lda),
+                                   static_cast<uint32_t>(ldb),
+                                   static_cast<uint32_t>(ldc),
+                                   alpha,
+                                   beta,
+                                   bias ? 1u : 0u,
+                                   residual ? 1u : 0u,
+                                   activation};
+      id<MTLComputePipelineState> state = pipeline(kernel);
+      id<MTLComputeCommandEncoder> encoder =
+        (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+      [encoder setComputePipelineState:state];
+      set_buffer(encoder, a, dense_matrix_bytes(m, k, lda, sizeof(uint16_t)), 0);
+      set_buffer(encoder, b, dense_matrix_bytes(n, k, ldb, sizeof(uint16_t)), 1);
+      set_buffer(encoder, c, dense_matrix_bytes(m, n, ldc, sizeof(uint16_t)), 2);
+      [encoder setBytes:&args length:sizeof(args) atIndex:3];
+      set_buffer(encoder,
+                 bias ? bias : c,
+                 bias ? static_cast<size_t>(n) * sizeof(uint16_t) : sizeof(uint16_t),
+                 4);
+      set_buffer(encoder,
+                 residual ? residual : c,
+                 residual ? dense_matrix_bytes(m, n, ldc, sizeof(uint16_t))
+                          : sizeof(uint16_t),
+                 5);
+      NSUInteger simd_groups = n >= 4096 ? 8 : 4;
+      while (simd_groups * 32 > state.maxTotalThreadsPerThreadgroup)
+        simd_groups >>= 1;
+      const NSUInteger outputs_per_group = simd_groups * 2;
+      [encoder dispatchThreadgroups:MTLSizeMake(
+                 (static_cast<NSUInteger>(n) + outputs_per_group - 1)
+                   / outputs_per_group,
+                 1,
+                 1)
+               threadsPerThreadgroup:MTLSizeMake(simd_groups * 32, 1, 1)];
+      [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+      record_compute_dispatch(kernel);
+      record_profile_event(ProfileEvent::Gemm);
+    }
+
     static void tiled_gemm(DataType dtype,
                            bool transpose_a,
                            bool transpose_b,
@@ -2679,6 +4039,121 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                      a, lda, 0, b, ldb, 0, beta, c, ldc, 0, 1);
     }
 
+    bool gemm_weight_only_int8_with_epilogue(const void* a,
+                                             const int8_t* b,
+                                             const float* b_scales,
+                                             dim_t b_scale_size,
+                                             const void* bias,
+                                             const void* residual,
+                                             void* output,
+                                             dim_t m,
+                                             dim_t n,
+                                             dim_t k,
+                                             int activation) {
+      static const bool enabled = []() {
+        const char* value = std::getenv("CT2_MPS_USE_WEIGHT_ONLY_INT8");
+        return !value || value[0] == '\0' || std::string(value) != "0";
+      }();
+      if (!enabled
+          || m <= 0 || m > 32 || n <= 0 || k <= 0
+          || !fits_u32(m) || !fits_u32(n) || !fits_u32(k)
+          || (b_scale_size != 1 && b_scale_size != n))
+        return false;
+      if ((k & 3) == 0
+          && ((reinterpret_cast<uintptr_t>(a) & 7u) != 0
+              || (reinterpret_cast<uintptr_t>(b) & 3u) != 0))
+        return false;
+
+      const Int8DenseArgs args{static_cast<uint32_t>(m),
+                               static_cast<uint32_t>(n),
+                               static_cast<uint32_t>(k),
+                               0,
+                               static_cast<uint32_t>(b_scale_size),
+                               bias ? 1u : 0u,
+                               residual ? 1u : 0u,
+                               activation};
+      constexpr NSUInteger threads = 128;
+      constexpr NSUInteger simdgroups = threads / 32;
+      const char* kernel = nullptr;
+      NSUInteger rows_per_block = 0;
+      NSUInteger outputs_per_simdgroup = 0;
+      static const bool use_simdgroup = []() {
+        const char* value = std::getenv("CT2_MPS_USE_INT8_SIMDGROUP");
+        return !value || value[0] == '\0' || std::string(value) != "0";
+      }();
+      if (use_simdgroup) {
+        kernel = "simdgroup_gemm_nt_i8_f16_16x64";
+        rows_per_block = 16;
+        // The four SIMD groups jointly cover one 64-column tile.
+        outputs_per_simdgroup = 16;
+      } else if (m <= 4) {
+        kernel = "weight_only_int8_dense_m4_f16";
+        rows_per_block = 4;
+        outputs_per_simdgroup = 2;
+      } else if (m <= 8) {
+        kernel = "weight_only_int8_dense_m8_f16";
+        rows_per_block = 8;
+        outputs_per_simdgroup = 2;
+      } else {
+        kernel = "weight_only_int8_dense_m16_f16";
+        rows_per_block = 16;
+        outputs_per_simdgroup = 1;
+      }
+      id<MTLComputePipelineState> state = pipeline(kernel);
+      id<MTLComputeCommandEncoder> encoder =
+        (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+      [encoder setComputePipelineState:state];
+      set_buffer(encoder, a, static_cast<size_t>(m * k) * sizeof(uint16_t), 0);
+      set_buffer(encoder, b, static_cast<size_t>(n * k), 1);
+      set_buffer(encoder,
+                 b_scales,
+                 static_cast<size_t>(b_scale_size) * sizeof(float),
+                 2);
+      set_buffer(encoder,
+                 bias ? bias : output,
+                 bias ? static_cast<size_t>(n) * sizeof(uint16_t) : sizeof(uint16_t),
+                 3);
+      set_buffer(encoder,
+                 residual ? residual : output,
+                 residual ? static_cast<size_t>(m * n) * sizeof(uint16_t)
+                          : sizeof(uint16_t),
+                 4);
+      set_buffer(encoder,
+                 output,
+                 static_cast<size_t>(m * n) * sizeof(uint16_t),
+                 5);
+      [encoder setBytes:&args length:sizeof(args) atIndex:6];
+      [encoder dispatchThreadgroups:MTLSizeMake(
+          (static_cast<NSUInteger>(n) + simdgroups * outputs_per_simdgroup - 1)
+            / (simdgroups * outputs_per_simdgroup),
+          (static_cast<NSUInteger>(m) + rows_per_block - 1) / rows_per_block,
+          1)
+               threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
+      record_compute_dispatch(kernel);
+      record_profile_event(ProfileEvent::Gemm);
+      log_gemm(DataType::INT8,
+               false,
+               true,
+               m,
+               n,
+               k,
+               k,
+               k,
+               n,
+               1,
+               0,
+               0,
+               0,
+               "weight_only_f16");
+      if (profile_enabled()) {
+        const std::string detail = "int8_weight_only m=" + std::to_string(m)
+                                   + " n=" + std::to_string(n)
+                                   + " k=" + std::to_string(k);
+        record_profile_detail(detail.c_str());
+      }
+      return true;
+    }
+
     void gemm_int8_batch_strided(bool transpose_a,
                                  bool transpose_b,
                                  dim_t m,
@@ -2878,6 +4353,54 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       record_profile_event(ProfileEvent::Gemv);
     }
 
+    bool gemm_with_epilogue(DataType dtype,
+                            bool transpose_a,
+                            bool transpose_b,
+                            dim_t m,
+                            dim_t n,
+                            dim_t k,
+                            float alpha,
+                            const void* a,
+                            dim_t lda,
+                            const void* b,
+                            dim_t ldb,
+                            float beta,
+                            void* c,
+                            dim_t ldc,
+                            const void* bias,
+                            const void* residual,
+                            int activation) {
+      if (dtype == DataType::FLOAT16
+          && !transpose_a
+          && transpose_b
+          && m == 5
+          && small_m5_gemm_layout_supported(a, lda, b, ldb, k)
+          && fits_u32(n) && fits_u32(k)
+          && fits_u32(lda) && fits_u32(ldb) && fits_u32(ldc)) {
+        log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+                 1, 0, 0, 0, "small_m5_nt_f16_epilogue");
+        small_m5_gemm_nt_f16(m, n, k, alpha,
+                             a, lda, b, ldb, beta, c, ldc,
+                             bias, residual, activation);
+        return true;
+      }
+      if (!simdgroup_gemm_enabled()
+          || dtype != DataType::FLOAT16
+          || transpose_a
+          || !transpose_b
+          || m < 64
+          || !fits_u32(m) || !fits_u32(n) || !fits_u32(k)
+          || !fits_u32(lda) || !fits_u32(ldb) || !fits_u32(ldc))
+        return false;
+
+      log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+               1, 0, 0, 0, "simdgroup_nt_f16_epilogue");
+      simdgroup_gemm_nt_f16(m, n, k, alpha,
+                            a, lda, b, ldb, beta, c, ldc,
+                            bias, residual, activation);
+      return true;
+    }
+
     void gemm(DataType dtype,
               bool transpose_a,
               bool transpose_b,
@@ -2938,6 +4461,39 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
              ldc,
              0,
              1);
+        return;
+      }
+
+      if (dtype == DataType::FLOAT16
+          && !transpose_a
+          && transpose_b
+          && m == 5
+          && small_m5_gemm_layout_supported(a, lda, b, ldb, k)
+          && fits_u32(n) && fits_u32(k)
+          && fits_u32(lda) && fits_u32(ldb) && fits_u32(ldc)) {
+        log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+                 1, 0, 0, 0, "small_m5_nt_f16");
+        small_m5_gemm_nt_f16(m, n, k, alpha,
+                             a, lda, b, ldb, beta, c, ldc);
+        return;
+      }
+
+      // CTranslate2 Dense weights use the output-major [N, K] layout. On
+      // Apple Silicon, MPSMatrixMultiplication leaves substantial throughput
+      // on the table for these medium-M FP16 projections (especially the
+      // vocabulary projection). Keep this opt-in while its shape thresholds
+      // are benchmarked across supported GPU generations.
+      if (simdgroup_gemm_enabled()
+          && dtype == DataType::FLOAT16
+          && !transpose_a
+          && transpose_b
+          && m >= 64
+          && fits_u32(m) && fits_u32(n) && fits_u32(k)
+          && fits_u32(lda) && fits_u32(ldb) && fits_u32(ldc)) {
+        log_gemm(dtype, transpose_a, transpose_b, m, n, k, lda, ldb, ldc,
+                 1, 0, 0, 0, "simdgroup_nt_f16");
+        simdgroup_gemm_nt_f16(m, n, k, alpha,
+                              a, lda, b, ldb, beta, c, ldc);
         return;
       }
 
@@ -3430,6 +4986,67 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
       }
     }
 
+    bool fused_beam_search_topk(DataType dtype,
+                                const void* logits,
+                                const void* beam_scores,
+                                void* values,
+                                int32_t* indices,
+                                dim_t batch_size,
+                                dim_t beam_size,
+                                dim_t vocabulary_size,
+                                dim_t k) {
+      if (dtype != DataType::FLOAT16
+          || !logits || !beam_scores || !values || !indices
+          || batch_size <= 0 || batch_size > UINT32_MAX
+          || beam_size <= 1 || beam_size > 8
+          || vocabulary_size <= 0 || vocabulary_size > UINT32_MAX
+          || k <= 0 || k > 16)
+        return false;
+
+      const BeamSearchTopKArgs args{static_cast<uint32_t>(batch_size),
+                                    static_cast<uint32_t>(beam_size),
+                                    static_cast<uint32_t>(vocabulary_size),
+                                    static_cast<uint32_t>(k)};
+      const size_t logits_elements = static_cast<size_t>(batch_size)
+                                     * static_cast<size_t>(beam_size)
+                                     * static_cast<size_t>(vocabulary_size);
+      const size_t score_elements = static_cast<size_t>(batch_size)
+                                    * static_cast<size_t>(beam_size);
+      const size_t output_elements = static_cast<size_t>(batch_size)
+                                     * static_cast<size_t>(k);
+      const char* kernel = k <= 8
+                             ? "fused_beam_search_topk_f16"
+                             : (k <= 10
+                                  ? "fused_beam_search_topk_10_f16"
+                                  : "fused_beam_search_topk_16_f16");
+      id<MTLComputePipelineState> state = pipeline(kernel);
+      id<MTLComputeCommandEncoder> encoder =
+        (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+      [encoder setComputePipelineState:state];
+      set_buffer(encoder, logits, logits_elements * sizeof(float16_t), 0);
+      set_buffer(encoder, beam_scores, score_elements * sizeof(float16_t), 1);
+      set_buffer(encoder, values, output_elements * sizeof(float16_t), 2);
+      set_buffer(encoder, indices, output_elements * sizeof(int32_t), 3);
+      [encoder setBytes:&args length:sizeof(args) atIndex:4];
+      NSUInteger threads = 256;
+      while (threads > state.maxTotalThreadsPerThreadgroup)
+        threads >>= 1;
+      const NSUInteger float_scratch = ((threads * sizeof(float) + 15) / 16) * 16;
+      const NSUInteger index_scratch = ((threads * sizeof(uint32_t) + 15) / 16) * 16;
+      const NSUInteger candidate_count = static_cast<NSUInteger>(beam_size * k);
+      [encoder setThreadgroupMemoryLength:float_scratch atIndex:0];
+      [encoder setThreadgroupMemoryLength:index_scratch atIndex:1];
+      [encoder setThreadgroupMemoryLength:candidate_count * sizeof(float) atIndex:2];
+      [encoder setThreadgroupMemoryLength:candidate_count * sizeof(uint32_t) atIndex:3];
+      [encoder dispatchThreadgroups:MTLSizeMake(static_cast<NSUInteger>(batch_size), 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
+      [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+      record_compute_dispatch(kernel);
+      record_profile_event(ProfileEvent::TopKGpu);
+      record_profile_detail(kernel);
+      return true;
+    }
+
     void fill(DataType dtype, const void* value, void* y, dim_t size) {
       if (size == 0)
         return;
@@ -3679,9 +5296,68 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                 dim_t num_indices_per_batch) {
       if (num_indices == 0 || copy_size == 0)
         return;
+      if (num_indices_per_batch <= 0 || num_indices % num_indices_per_batch != 0)
+        throw std::invalid_argument("MPS gather received invalid per-batch indices");
       const dim_t batch_size = num_indices / num_indices_per_batch;
       const size_t element_size = dtype_size(dtype);
       const uint64_t output_size = static_cast<uint64_t>(num_indices * copy_size);
+      if (profile_enabled()) {
+        const std::string detail =
+          "gather dtype=" + dtype_name(dtype)
+          + " copy=" + std::to_string(copy_size)
+          + " batch_stride=" + std::to_string(batch_stride)
+          + " indices=" + std::to_string(num_indices)
+          + " per_batch=" + std::to_string(num_indices_per_batch);
+        record_profile_detail(detail.c_str());
+      }
+      const size_t vector_bytes = 4 * element_size;
+      const bool vector_aligned = copy_size % 4 == 0
+                                  && batch_stride % 4 == 0
+                                  && reinterpret_cast<uintptr_t>(data) % vector_bytes == 0
+                                  && reinterpret_cast<uintptr_t>(output) % vector_bytes == 0;
+      const dim_t copy_vectors = copy_size / 4;
+      const dim_t batch_stride_vectors = batch_stride / 4;
+      if (dtype == DataType::FLOAT16
+          && vector_aligned
+          && fits_u32(copy_vectors)
+          && fits_u32(batch_stride_vectors)
+          && fits_u32(num_indices)
+          && fits_u32(num_indices_per_batch)) {
+        const GatherBlockArgs block_args{
+          static_cast<uint32_t>(copy_vectors),
+          static_cast<uint32_t>(batch_stride_vectors),
+          static_cast<uint32_t>(num_indices),
+          static_cast<uint32_t>(num_indices_per_batch)};
+        const std::string name = storage_kernel_name("gather_block_vec4", dtype);
+        id<MTLComputePipelineState> state = pipeline(name);
+        id<MTLComputeCommandEncoder> encoder =
+          (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+        [encoder setComputePipelineState:state];
+        set_buffer(encoder,
+                   data,
+                   static_cast<size_t>(batch_size * batch_stride) * element_size,
+                   0);
+        set_buffer(encoder,
+                   indices,
+                   static_cast<size_t>(num_indices) * sizeof(int32_t),
+                   1);
+        set_buffer(encoder,
+                   output,
+                   static_cast<size_t>(output_size) * element_size,
+                   2);
+        [encoder setBytes:&block_args length:sizeof(block_args) atIndex:3];
+        const NSUInteger simd_width = std::max<NSUInteger>(1, state.threadExecutionWidth);
+        NSUInteger threads = std::min<NSUInteger>(256, state.maxTotalThreadsPerThreadgroup);
+        threads = std::min<NSUInteger>(threads,
+                                       std::max<NSUInteger>(simd_width,
+                                         ((static_cast<NSUInteger>(copy_vectors)
+                                           + simd_width - 1) / simd_width) * simd_width));
+        [encoder dispatchThreadgroups:MTLSizeMake(static_cast<NSUInteger>(num_indices), 1, 1)
+                 threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
+        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+        record_compute_dispatch(name.c_str());
+        return;
+      }
       const GatherArgs args{static_cast<uint64_t>(copy_size),
                             static_cast<uint64_t>(batch_stride),
                             static_cast<uint64_t>(num_indices),
@@ -3721,6 +5397,61 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
              3);
     }
 
+    void split2(DataType dtype,
+                const void* input,
+                void* a,
+                dim_t a_block_size,
+                void* b,
+                dim_t b_block_size,
+                dim_t outer_size) {
+      if (outer_size <= 0 || a_block_size <= 0 || b_block_size <= 0)
+        return;
+      const size_t element_size = dtype_size(dtype);
+      const uint64_t input_block = static_cast<uint64_t>(a_block_size + b_block_size);
+      const uint64_t input_size = static_cast<uint64_t>(outer_size) * input_block;
+      const Split2Args args{static_cast<uint64_t>(outer_size),
+                            static_cast<uint64_t>(a_block_size),
+                            static_cast<uint64_t>(b_block_size)};
+      run_1d(storage_kernel_name("split2", dtype),
+             input_size,
+             {{input, static_cast<size_t>(input_size) * element_size},
+              {a, static_cast<size_t>(outer_size * a_block_size) * element_size},
+              {b, static_cast<size_t>(outer_size * b_block_size) * element_size}},
+             &args,
+             sizeof(args),
+             3);
+    }
+
+    void split3(DataType dtype,
+                const void* input,
+                void* a,
+                dim_t a_block_size,
+                void* b,
+                dim_t b_block_size,
+                void* c,
+                dim_t c_block_size,
+                dim_t outer_size) {
+      if (outer_size <= 0 || a_block_size <= 0 || b_block_size <= 0 || c_block_size <= 0)
+        return;
+      const size_t element_size = dtype_size(dtype);
+      const uint64_t input_block =
+        static_cast<uint64_t>(a_block_size + b_block_size + c_block_size);
+      const uint64_t input_size = static_cast<uint64_t>(outer_size) * input_block;
+      const Split3Args args{static_cast<uint64_t>(outer_size),
+                            static_cast<uint64_t>(a_block_size),
+                            static_cast<uint64_t>(b_block_size),
+                            static_cast<uint64_t>(c_block_size)};
+      run_1d(storage_kernel_name("split3", dtype),
+             input_size,
+             {{input, static_cast<size_t>(input_size) * element_size},
+              {a, static_cast<size_t>(outer_size * a_block_size) * element_size},
+              {b, static_cast<size_t>(outer_size * b_block_size) * element_size},
+              {c, static_cast<size_t>(outer_size * c_block_size) * element_size}},
+             &args,
+             sizeof(args),
+             4);
+    }
+
     void tile(DataType dtype,
               const void* input,
               void* output,
@@ -3731,6 +5462,14 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
         static_cast<uint64_t>(outer_size * inner_size * num_tiles);
       if (output_size == 0)
         return;
+      if (profile_enabled()) {
+        const std::string detail =
+          "tile dtype=" + dtype_name(dtype)
+          + " outer=" + std::to_string(outer_size)
+          + " inner=" + std::to_string(inner_size)
+          + " repeats=" + std::to_string(num_tiles);
+        record_profile_detail(detail.c_str());
+      }
       const size_t element_size = dtype_size(dtype);
       const TileArgs args{static_cast<uint64_t>(outer_size),
                           static_cast<uint64_t>(inner_size),
@@ -3869,6 +5608,49 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
     void transpose_4d(DataType dtype, const void* a, const dim_t* dims, const dim_t* perm, void* b) {
       const uint64_t size = static_cast<uint64_t>(dims[0] * dims[1] * dims[2] * dims[3]);
       const size_t bytes = static_cast<size_t>(size) * dtype_size(dtype);
+      if (profile_enabled()) {
+        const std::string detail =
+          "transpose4 dtype=" + dtype_name(dtype)
+          + " dims=" + std::to_string(dims[0]) + "x" + std::to_string(dims[1])
+          + "x" + std::to_string(dims[2]) + "x" + std::to_string(dims[3])
+          + " perm=" + std::to_string(perm[0]) + std::to_string(perm[1])
+          + std::to_string(perm[2]) + std::to_string(perm[3]);
+        record_profile_detail(detail.c_str());
+      }
+      const size_t vector_bytes = 4 * dtype_size(dtype);
+      const uint64_t block_count = static_cast<uint64_t>(dims[0])
+                                   * static_cast<uint64_t>(dims[1])
+                                   * static_cast<uint64_t>(dims[2]);
+      const bool swap_middle_dimensions = perm[0] == 0 && perm[1] == 2
+                                          && perm[2] == 1 && perm[3] == 3;
+      if (dtype == DataType::FLOAT16
+          && swap_middle_dimensions
+          && dims[0] > 0 && dims[1] > 0 && dims[2] > 0 && dims[3] > 0
+          && dims[3] % 4 == 0
+          && block_count <= UINT32_MAX
+          && fits_u32(dims[1]) && fits_u32(dims[2]) && fits_u32(dims[3] / 4)
+          && reinterpret_cast<uintptr_t>(a) % vector_bytes == 0
+          && reinterpret_cast<uintptr_t>(b) % vector_bytes == 0) {
+        const Transpose0213Args fast_args{static_cast<uint32_t>(dims[1]),
+                                          static_cast<uint32_t>(dims[2]),
+                                          static_cast<uint32_t>(dims[3] / 4)};
+        const std::string name = storage_kernel_name("transpose_0213_vec4", dtype);
+        id<MTLComputePipelineState> state = pipeline(name);
+        id<MTLComputeCommandEncoder> encoder =
+          (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+        [encoder setComputePipelineState:state];
+        set_buffer(encoder, a, bytes, 0);
+        set_buffer(encoder, b, bytes, 1);
+        [encoder setBytes:&fast_args length:sizeof(fast_args) atIndex:2];
+        const NSUInteger simd_width = std::max<NSUInteger>(1, state.threadExecutionWidth);
+        NSUInteger threads = std::min<NSUInteger>(state.maxTotalThreadsPerThreadgroup,
+                                                   simd_width);
+        [encoder dispatchThreadgroups:MTLSizeMake(static_cast<NSUInteger>(block_count), 1, 1)
+                 threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
+        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+        record_compute_dispatch(name.c_str());
+        return;
+      }
       const TransposeNDArgs args{static_cast<uint64_t>(dims[0]),
                                  static_cast<uint64_t>(dims[1]),
                                  static_cast<uint64_t>(dims[2]),
@@ -3902,6 +5684,93 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                &args,
                sizeof(args),
                3);
+    }
+
+    bool fused_attention(DataType dtype,
+                         const void* queries,
+                         const void* keys,
+                         const void* values,
+                         const int32_t* lengths,
+                         void* output,
+                         dim_t batch_size,
+                         dim_t query_length,
+                         dim_t key_length,
+                         dim_t depth,
+                         float scale,
+                         dim_t interleaved_num_heads) {
+      if (dtype != DataType::FLOAT16
+          || batch_size <= 0
+          || query_length <= 0
+          || query_length > 8
+          || key_length <= 0
+          || key_length > 4096
+          || depth <= 0
+          || depth > 256
+          || depth % 4 != 0
+          || batch_size > UINT32_MAX
+          || query_length > UINT32_MAX
+          || key_length > UINT32_MAX
+          || depth / 4 > UINT32_MAX)
+        return false;
+      if (interleaved_num_heads < 0
+          || interleaved_num_heads > UINT32_MAX
+          || (interleaved_num_heads != 0
+              && batch_size % interleaved_num_heads != 0))
+        return false;
+
+      // The half4 kernel requires 8-byte alignment at every matrix row.
+      if ((reinterpret_cast<uintptr_t>(queries) & 7u) != 0
+          || (reinterpret_cast<uintptr_t>(keys) & 7u) != 0
+          || (reinterpret_cast<uintptr_t>(values) & 7u) != 0
+          || (reinterpret_cast<uintptr_t>(output) & 7u) != 0)
+        return false;
+
+      const FusedAttentionArgs args{
+        static_cast<uint32_t>(batch_size),
+        static_cast<uint32_t>(query_length),
+        static_cast<uint32_t>(key_length),
+        static_cast<uint32_t>(depth / 4),
+        lengths ? 1u : 0u,
+        static_cast<uint32_t>(interleaved_num_heads),
+        scale,
+      };
+      const size_t element_size = sizeof(float16_t);
+      const size_t queries_bytes = static_cast<size_t>(batch_size * query_length * depth) * element_size;
+      const size_t keys_bytes = static_cast<size_t>(batch_size * key_length * depth) * element_size;
+      const size_t output_bytes = queries_bytes;
+      const void* lengths_or_dummy = lengths ? static_cast<const void*>(lengths) : queries;
+      const size_t lengths_bytes = lengths
+                                     ? static_cast<size_t>(batch_size * query_length) * sizeof(int32_t)
+                                     : element_size;
+
+      id<MTLComputePipelineState> state = pipeline("fused_attention_f16");
+      id<MTLComputeCommandEncoder> encoder =
+        (__bridge id<MTLComputeCommandEncoder>)compute_encoder();
+      [encoder setComputePipelineState:state];
+      set_buffer(encoder, queries, queries_bytes, 0);
+      set_buffer(encoder, keys, keys_bytes, 1);
+      set_buffer(encoder, values, keys_bytes, 2);
+      set_buffer(encoder, lengths_or_dummy, lengths_bytes, 3);
+      set_buffer(encoder, output, output_bytes, 4);
+      [encoder setBytes:&args length:sizeof(args) atIndex:5];
+
+      NSUInteger threads = 32;
+      const NSUInteger parallel_work = std::max<NSUInteger>(
+        static_cast<NSUInteger>(key_length),
+        static_cast<NSUInteger>(depth / 4));
+      while (threads < parallel_work && threads < 256)
+        threads <<= 1;
+      while (threads > state.maxTotalThreadsPerThreadgroup)
+        threads >>= 1;
+      [encoder setThreadgroupMemoryLength:static_cast<NSUInteger>(key_length) * sizeof(float)
+                                  atIndex:0];
+      [encoder setThreadgroupMemoryLength:threads * sizeof(float) atIndex:1];
+      [encoder dispatchThreadgroups:MTLSizeMake(static_cast<NSUInteger>(batch_size * query_length), 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
+      [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+      record_compute_dispatch("fused_attention_f16");
+      record_profile_detail("fused_attention_f16");
+      return true;
     }
 
     void mean(DataType dtype,
@@ -3968,6 +5837,47 @@ IM2COL_KERNEL(im2col_conv1d_bf16, ushort)
                &args,
                sizeof(args),
                4);
+    }
+
+    bool fused_bias_residual_layer_norm(DataType dtype,
+                                        const void* input,
+                                        const void* bias,
+                                        const void* residual,
+                                        const void* gamma,
+                                        const void* beta,
+                                        void* output,
+                                        dim_t rows,
+                                        dim_t depth,
+                                        float epsilon) {
+      if (dtype != DataType::FLOAT16
+          || !input || !bias || !residual || !gamma || !beta || !output
+          || rows <= 0 || depth <= 0)
+        return false;
+
+      const size_t element_size = sizeof(float16_t);
+      const size_t tensor_bytes = static_cast<size_t>(rows * depth) * element_size;
+      const size_t parameter_bytes = static_cast<size_t>(depth) * element_size;
+      const NormArgs args{static_cast<uint64_t>(rows),
+                          static_cast<uint64_t>(depth),
+                          1,
+                          epsilon,
+                          1u,
+                          1u,
+                          1u};
+      run_rows("fused_bias_residual_layer_norm_f16",
+               rows,
+               reduction_threads(depth),
+               {{input, tensor_bytes},
+                {bias, parameter_bytes},
+                {residual, tensor_bytes},
+                {gamma, parameter_bytes},
+                {beta, parameter_bytes},
+                {output, tensor_bytes}},
+               &args,
+               sizeof(args),
+               6);
+      record_profile_detail("fused_bias_residual_layer_norm_f16");
+      return true;
     }
 
     void rms_norm(DataType dtype,

--- a/src/mps/ops_impl.mm
+++ b/src/mps/ops_impl.mm
@@ -6,6 +6,9 @@
 #ifdef CT2_WITH_MPS
 
 #include <algorithm>
+#include <cstdlib>
+#include <cstdint>
+#include <limits>
 #include <numeric>
 #include <vector>
 
@@ -101,6 +104,28 @@ namespace {
     for (dim_t i = 0; i < axis; ++i) s *= x.dim(i);
     return s;
   }
+  static bool _css_ranges_overlap(const void* first,
+                                  size_t first_size,
+                                  const void* second,
+                                  size_t second_size) {
+    if (first_size == 0 || second_size == 0)
+      return false;
+    const auto first_begin = reinterpret_cast<uintptr_t>(first);
+    const auto second_begin = reinterpret_cast<uintptr_t>(second);
+    if (first_begin > std::numeric_limits<uintptr_t>::max() - first_size
+        || second_begin > std::numeric_limits<uintptr_t>::max() - second_size)
+      return true;
+    const auto first_end = first_begin + first_size;
+    const auto second_end = second_begin + second_size;
+    return first_begin < second_end && second_begin < first_end;
+  }
+  static bool _css_concat2_enabled() {
+    static const bool enabled = []() {
+      const char* value = std::getenv("CT2_MPS_USE_CONCAT2");
+      return !value || value[0] == '\0' || value[0] != '0';
+    }();
+    return enabled;
+  }
 }
 
 template <Device D, typename T>
@@ -109,6 +134,33 @@ void Concat::compute(const std::vector<const StorageView*>& inputs,
   const dim_t axis = _axis < 0 ? output.rank() + _axis : _axis;
   const dim_t step_size = output.dim(axis) * output.stride(axis);
   T* out = output.data<T>();
+
+  // Whisper appends decoder K/V cache tensors shaped [B, H, T, D]. The old
+  // implementation issued one copy dispatch per head and per input, which
+  // accounted for most decoder dispatches. Concatenate the two non-aliasing
+  // inputs with one kernel while preserving the generic path for unusual
+  // arity, empty tensors, and in-place views.
+  if (_css_concat2_enabled() && inputs.size() == 2) {
+    const dim_t a_block_size = _css_copy_size(*inputs[0], axis);
+    const dim_t b_block_size = _css_copy_size(*inputs[1], axis);
+    const dim_t outer_size = _css_iter_size(output, axis);
+    const size_t element_size = sizeof(T);
+    const size_t output_bytes = static_cast<size_t>(output.size()) * element_size;
+    const size_t a_bytes = static_cast<size_t>(inputs[0]->size()) * element_size;
+    const size_t b_bytes = static_cast<size_t>(inputs[1]->size()) * element_size;
+    if (a_block_size > 0 && b_block_size > 0 && outer_size > 0
+        && !_css_ranges_overlap(inputs[0]->data<T>(), a_bytes, out, output_bytes)
+        && !_css_ranges_overlap(inputs[1]->data<T>(), b_bytes, out, output_bytes)) {
+      mps::concat2(DataTypeToEnum<T>::value,
+                   inputs[0]->data<T>(),
+                   a_block_size,
+                   inputs[1]->data<T>(),
+                   b_block_size,
+                   out,
+                   outer_size);
+      return;
+    }
+  }
 
   for (const StorageView* inp : inputs) {
     const dim_t copy_size = _css_copy_size(*inp, axis);

--- a/src/mps/ops_impl.mm
+++ b/src/mps/ops_impl.mm
@@ -1,0 +1,277 @@
+// MPS direct implementations for ops that only use primitives<D>::copy / add.
+// Apple Silicon uses MTLResourceStorageModeShared, so all MPS buffers are
+// CPU-accessible via unified memory.  No device-to-host copies are needed.
+
+#ifdef __APPLE__
+#ifdef CT2_WITH_MPS
+
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+#include "ctranslate2/ops/gather.h"
+#include "ctranslate2/ops/concat.h"
+#include "ctranslate2/ops/split.h"
+#include "ctranslate2/ops/slide.h"
+#include "ctranslate2/ops/tile.h"
+#include "ctranslate2/ops/bias_add.h"
+#include "ctranslate2/ops/topk.h"
+#include "ctranslate2/ops/activation.h"
+#include "ctranslate2/ops/add.h"
+
+#include "ctranslate2/primitives.h"
+#include "mps/kernels.h"
+#include "mps/utils.h"
+#include "type_dispatch.h"
+
+namespace ctranslate2 {
+namespace ops {
+
+// ============================================================
+// Gather
+// ============================================================
+
+template <Device D, typename T>
+void Gather::compute(const StorageView& data,
+                     const StorageView& input,
+                     const dim_t axis,
+                     const dim_t batch_dims,
+                     StorageView& output) const {
+  if (axis == batch_dims) {
+    const dim_t copy_size = data.stride(axis);
+    const dim_t batch_stride = axis > 0 ? data.stride(axis - 1) : data.size();
+    const dim_t batch_size = data.size() / batch_stride;
+    const dim_t num_indices = input.size();
+    const dim_t num_indices_per_batch = num_indices / batch_size;
+    mps::gather(DataTypeToEnum<T>::value,
+                data.data<T>(),
+                input.data<int32_t>(),
+                output.data<T>(),
+                copy_size,
+                batch_stride,
+                num_indices,
+                num_indices_per_batch);
+  } else {
+    throw std::invalid_argument("Gather only supports indexing the first non batch dimension");
+  }
+}
+
+#define DECLARE_GATHER(T) \
+  template void Gather::compute<Device::MPS, T>( \
+      const StorageView&, const StorageView&, dim_t, dim_t, StorageView&) const;
+DECLARE_ALL_TYPES(DECLARE_GATHER)
+#undef DECLARE_GATHER
+
+// ============================================================
+// Concat / Split / Slide  (shared helpers)
+// ============================================================
+
+namespace {
+  static dim_t _css_copy_size(const StorageView& x, dim_t axis) {
+    dim_t s = 1;
+    for (dim_t i = axis; i < x.rank(); ++i) s *= x.dim(i);
+    return s;
+  }
+  static dim_t _css_iter_size(const StorageView& x, dim_t axis) {
+    dim_t s = 1;
+    for (dim_t i = 0; i < axis; ++i) s *= x.dim(i);
+    return s;
+  }
+}
+
+template <Device D, typename T>
+void Concat::compute(const std::vector<const StorageView*>& inputs,
+                     StorageView& output) const {
+  const dim_t axis = _axis < 0 ? output.rank() + _axis : _axis;
+  const dim_t step_size = output.dim(axis) * output.stride(axis);
+  T* out = output.data<T>();
+
+  for (const StorageView* inp : inputs) {
+    const dim_t copy_size = _css_copy_size(*inp, axis);
+    if (copy_size == 0) continue;
+    const dim_t iter_size = _css_iter_size(*inp, axis);
+    const T* x = inp->data<T>();
+    for (dim_t i = 0; i < iter_size; ++i)
+      primitives<Device::MPS>::copy(x + i * copy_size, out + i * step_size, copy_size);
+    out += copy_size;
+  }
+}
+
+template <Device D, typename T>
+void Split::compute(const StorageView& input,
+                    std::vector<StorageView*>& outputs) const {
+  const dim_t axis = _axis < 0 ? input.rank() + _axis : _axis;
+  const dim_t step_size = input.dim(axis) * input.stride(axis);
+  const T* in = input.data<T>();
+
+  for (StorageView* out : outputs) {
+    const dim_t copy_size = _css_copy_size(*out, axis);
+    if (copy_size == 0) continue;
+    const dim_t iter_size = _css_iter_size(*out, axis);
+    T* x = out->data<T>();
+    for (dim_t i = 0; i < iter_size; ++i)
+      primitives<Device::MPS>::copy(in + i * step_size, x + i * copy_size, copy_size);
+    in += copy_size;
+  }
+}
+
+template <Device D, typename T>
+void Slide::compute(const StorageView& input,
+                    StorageView& output,
+                    const dim_t& index) const {
+  const dim_t axis = _axis < 0 ? input.rank() + _axis : _axis;
+  const dim_t stride_axis = input.stride(axis) == 0 ? 1 : input.stride(axis);
+  const dim_t step_size = input.dim(axis) * stride_axis;
+  const T* in = input.data<T>() + index * stride_axis;
+  T* out = output.data<T>();
+
+  const dim_t copy_size = _css_copy_size(output, axis);
+  if (copy_size == 0) return;
+  const dim_t iter_size = _css_iter_size(output, axis);
+  for (dim_t i = 0; i < iter_size; ++i)
+    primitives<Device::MPS>::copy(in + i * step_size, out + i * copy_size, copy_size);
+}
+
+#define DECLARE_CSS(T) \
+  template void Concat::compute<Device::MPS, T>( \
+      const std::vector<const StorageView*>&, StorageView&) const; \
+  template void Split::compute<Device::MPS, T>( \
+      const StorageView&, std::vector<StorageView*>&) const; \
+  template void Slide::compute<Device::MPS, T>( \
+      const StorageView&, StorageView&, const dim_t&) const;
+DECLARE_ALL_TYPES(DECLARE_CSS)
+#undef DECLARE_CSS
+
+// ============================================================
+// Tile
+// ============================================================
+
+template <Device D, typename T>
+void Tile::compute(const StorageView& input,
+                   const dim_t outer_size,
+                   const dim_t inner_size,
+                   StorageView& output) const {
+  mps::tile(DataTypeToEnum<T>::value,
+            input.data<T>(),
+            output.data<T>(),
+            outer_size,
+            inner_size,
+            _num_tiles);
+}
+
+#define DECLARE_TILE(T) \
+  template void Tile::compute<Device::MPS, T>( \
+      const StorageView&, dim_t, dim_t, StorageView&) const;
+DECLARE_ALL_TYPES(DECLARE_TILE)
+#undef DECLARE_TILE
+
+// ============================================================
+// BiasAdd  (primitives<MPS>::add_batch_broadcast/add_block_broadcast are
+//           implemented in primitives.mm; Add::compute is header-inline)
+// ============================================================
+
+template <Device D, typename T>
+void BiasAdd::compute(const StorageView& value,
+                      const StorageView& bias,
+                      StorageView& output,
+                      const StorageView* residual) const {
+  if (_axis == -1 || _axis == value.rank() - 1) {
+    primitives<Device::MPS>::add_batch_broadcast(bias.data<T>(),
+                                                 value.data<T>(),
+                                                 output.data<T>(),
+                                                 bias.size(),
+                                                 value.size());
+  } else {
+    const dim_t axis = _axis < 0 ? value.rank() + _axis : _axis;
+    dim_t width = 1;
+    for (dim_t i = axis + 1; i < value.rank(); ++i)
+      width *= value.dim(i);
+    primitives<Device::MPS>::add_block_broadcast(bias.data<T>(),
+                                                 value.data<T>(),
+                                                 output.data<T>(),
+                                                 width,
+                                                 bias.size(),
+                                                 value.size());
+  }
+  if (residual)
+    Add()(*residual, output, output);
+  if (_activation_type)
+    get_activation_op(*_activation_type)(output, output);
+}
+
+template void BiasAdd::compute<Device::MPS, float>(
+    const StorageView&, const StorageView&, StorageView&, const StorageView*) const;
+template void BiasAdd::compute<Device::MPS, float16_t>(
+    const StorageView&, const StorageView&, StorageView&, const StorageView*) const;
+template void BiasAdd::compute<Device::MPS, bfloat16_t>(
+    const StorageView&, const StorageView&, StorageView&, const StorageView*) const;
+
+// ============================================================
+// TopK  (direct – MPS buffers are CPU-accessible on Apple Silicon)
+// ============================================================
+
+template <Device D, typename DataType, typename IndexType>
+void TopK::compute(const StorageView& x,
+                   StorageView& values,
+                   StorageView& indices) const {
+  const dim_t depth = x.dim(-1);
+  const dim_t batch_size = x.size() / depth;
+
+  if (mps::supports_topk(x.dtype(), _k)) {
+    mps::topk(x.dtype(),
+              x.data<DataType>(),
+              values.data<DataType>(),
+              indices.data<int32_t>(),
+              batch_size,
+              depth,
+              _k);
+    return;
+  }
+
+  mps::record_profile_event(mps::ProfileEvent::TopKCpu);
+  mps::record_profile_event(mps::ProfileEvent::CpuFallback);
+  mps::synchronize();
+
+  const DataType* x_data   = x.data<DataType>();
+  DataType*       v_data   = values.data<DataType>();
+  IndexType*      i_data   = indices.data<IndexType>();
+
+  if (_k == 1) {
+    for (dim_t i = 0; i < batch_size; ++i) {
+      const DataType* row = x_data + i * depth;
+      const DataType* best = std::max_element(row, row + depth);
+      v_data[i] = *best;
+      i_data[i] = static_cast<IndexType>(std::distance(row, best));
+    }
+  } else {
+    std::vector<IndexType> ids(depth);
+    for (dim_t i = 0; i < batch_size; ++i) {
+      const DataType* row = x_data + i * depth;
+      DataType*       val = v_data  + i * _k;
+      IndexType*      ind = i_data  + i * _k;
+
+      std::iota(ids.begin(), ids.end(), IndexType(0));
+      std::partial_sort(ids.begin(), ids.begin() + _k, ids.end(),
+                        [&row](IndexType a, IndexType b) {
+                          return row[a] > row[b];
+                        });
+      for (dim_t j = 0; j < _k; ++j) {
+        ind[j] = ids[j];
+        val[j] = row[ind[j]];
+      }
+    }
+  }
+}
+
+template void TopK::compute<Device::MPS, float, int32_t>(
+    const StorageView&, StorageView&, StorageView&) const;
+template void TopK::compute<Device::MPS, float16_t, int32_t>(
+    const StorageView&, StorageView&, StorageView&) const;
+template void TopK::compute<Device::MPS, bfloat16_t, int32_t>(
+    const StorageView&, StorageView&, StorageView&) const;
+
+}  // namespace ops
+}  // namespace ctranslate2
+
+#endif  // CT2_WITH_MPS
+#endif  // __APPLE__

--- a/src/mps/ops_impl.mm
+++ b/src/mps/ops_impl.mm
@@ -27,6 +27,30 @@
 namespace ctranslate2 {
 namespace ops {
 
+namespace {
+int mps_activation_code(const ActivationType* activation) {
+  if (!activation)
+    return -1;
+  switch (*activation) {
+  case ActivationType::ReLU:
+    return static_cast<int>(mps::UnaryOp::RELU);
+  case ActivationType::GELUTanh:
+    return static_cast<int>(mps::UnaryOp::GELU_TANH);
+  case ActivationType::Swish:
+    return static_cast<int>(mps::UnaryOp::SWISH);
+  case ActivationType::GELU:
+    return static_cast<int>(mps::UnaryOp::GELU);
+  case ActivationType::GELUSigmoid:
+    return static_cast<int>(mps::UnaryOp::GELU_SIGMOID);
+  case ActivationType::Tanh:
+    return static_cast<int>(mps::UnaryOp::TANH);
+  case ActivationType::Sigmoid:
+    return static_cast<int>(mps::UnaryOp::SIGMOID);
+  }
+  return -1;
+}
+}
+
 // ============================================================
 // Gather
 // ============================================================
@@ -175,28 +199,23 @@ void BiasAdd::compute(const StorageView& value,
                       const StorageView& bias,
                       StorageView& output,
                       const StorageView* residual) const {
+  dim_t block = 0;
   if (_axis == -1 || _axis == value.rank() - 1) {
-    primitives<Device::MPS>::add_batch_broadcast(bias.data<T>(),
-                                                 value.data<T>(),
-                                                 output.data<T>(),
-                                                 bias.size(),
-                                                 value.size());
+    block = 0;
   } else {
     const dim_t axis = _axis < 0 ? value.rank() + _axis : _axis;
-    dim_t width = 1;
     for (dim_t i = axis + 1; i < value.rank(); ++i)
-      width *= value.dim(i);
-    primitives<Device::MPS>::add_block_broadcast(bias.data<T>(),
-                                                 value.data<T>(),
-                                                 output.data<T>(),
-                                                 width,
-                                                 bias.size(),
-                                                 value.size());
+      block = (block == 0 ? 1 : block) * value.dim(i);
   }
-  if (residual)
-    Add()(*residual, output, output);
-  if (_activation_type)
-    get_activation_op(*_activation_type)(output, output);
+  mps::bias_add(DataTypeToEnum<T>::value,
+                bias.data<T>(),
+                value.data<T>(),
+                residual ? residual->data<T>() : nullptr,
+                output.data<T>(),
+                bias.size(),
+                value.size(),
+                block,
+                mps_activation_code(_activation_type));
 }
 
 template void BiasAdd::compute<Device::MPS, float>(

--- a/src/mps/ops_impl.mm
+++ b/src/mps/ops_impl.mm
@@ -126,6 +126,13 @@ namespace {
     }();
     return enabled;
   }
+  static bool _css_split_enabled() {
+    static const bool enabled = []() {
+      const char* value = std::getenv("CT2_MPS_USE_FUSED_SPLIT");
+      return !value || value[0] == '\0' || value[0] != '0';
+    }();
+    return enabled;
+  }
 }
 
 template <Device D, typename T>
@@ -179,6 +186,50 @@ void Split::compute(const StorageView& input,
   const dim_t axis = _axis < 0 ? input.rank() + _axis : _axis;
   const dim_t step_size = input.dim(axis) * input.stride(axis);
   const T* in = input.data<T>();
+
+  if (_css_split_enabled() && (outputs.size() == 2 || outputs.size() == 3)) {
+    const dim_t outer_size = _css_iter_size(input, axis);
+    std::vector<dim_t> block_sizes;
+    block_sizes.reserve(outputs.size());
+    bool supported = outer_size > 0;
+    const size_t element_size = sizeof(T);
+    const size_t input_bytes = static_cast<size_t>(input.size()) * element_size;
+    for (size_t i = 0; i < outputs.size(); ++i) {
+      const dim_t block_size = _css_copy_size(*outputs[i], axis);
+      block_sizes.emplace_back(block_size);
+      const size_t output_bytes = static_cast<size_t>(outputs[i]->size()) * element_size;
+      supported = supported
+                  && block_size > 0
+                  && !_css_ranges_overlap(in, input_bytes,
+                                          outputs[i]->data<T>(), output_bytes);
+      for (size_t j = 0; supported && j < i; ++j) {
+        const size_t other_bytes =
+          static_cast<size_t>(outputs[j]->size()) * element_size;
+        supported = !_css_ranges_overlap(outputs[j]->data<T>(), other_bytes,
+                                         outputs[i]->data<T>(), output_bytes);
+      }
+    }
+    supported = supported
+                && std::accumulate(block_sizes.begin(), block_sizes.end(), dim_t(0))
+                     == step_size;
+    if (supported && outputs.size() == 2) {
+      mps::split2(DataTypeToEnum<T>::value,
+                  in,
+                  outputs[0]->data<T>(), block_sizes[0],
+                  outputs[1]->data<T>(), block_sizes[1],
+                  outer_size);
+      return;
+    }
+    if (supported && outputs.size() == 3) {
+      mps::split3(DataTypeToEnum<T>::value,
+                  in,
+                  outputs[0]->data<T>(), block_sizes[0],
+                  outputs[1]->data<T>(), block_sizes[1],
+                  outputs[2]->data<T>(), block_sizes[2],
+                  outer_size);
+      return;
+    }
+  }
 
   for (StorageView* out : outputs) {
     const dim_t copy_size = _css_copy_size(*out, axis);

--- a/src/mps/ops_stubs.mm
+++ b/src/mps/ops_stubs.mm
@@ -3,6 +3,8 @@
 #include <vector>
 #include "ctranslate2/types.h"
 #include "ctranslate2/storage_view.h"
+#include "mps/kernels.h"
+#include "type_dispatch.h"
 
 // --- Standard Ops ---
 #include "ctranslate2/ops/dequantize.h"
@@ -39,9 +41,44 @@ namespace ops {
 
 #define THROW_MPS(NAME) throw std::runtime_error("MPS " #NAME " not implemented");
 
+namespace {
+int activation_code(const ActivationType* activation) {
+  if (!activation)
+    return -1;
+  switch (*activation) {
+  case ActivationType::ReLU:
+    return static_cast<int>(mps::UnaryOp::RELU);
+  case ActivationType::GELUTanh:
+    return static_cast<int>(mps::UnaryOp::GELU_TANH);
+  case ActivationType::Swish:
+    return static_cast<int>(mps::UnaryOp::SWISH);
+  case ActivationType::GELU:
+    return static_cast<int>(mps::UnaryOp::GELU);
+  case ActivationType::GELUSigmoid:
+    return static_cast<int>(mps::UnaryOp::GELU_SIGMOID);
+  case ActivationType::Tanh:
+    return static_cast<int>(mps::UnaryOp::TANH);
+  case ActivationType::Sigmoid:
+    return static_cast<int>(mps::UnaryOp::SIGMOID);
+  }
+  return -1;
+}
+}
+
 // --- Quantization ---
-template <Device D, typename T, typename Q>
-void Dequantize::dequantize(const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(Dequantize) }
+template <Device D, typename InT, typename OutT>
+void Dequantize::dequantize(const StorageView& input,
+                            const StorageView& scale,
+                            StorageView& output) const {
+  const dim_t depth = input.dim(-1);
+  const dim_t batch_size = input.size() / depth;
+  mps::dequantize(DataTypeToEnum<OutT>::value,
+                  input.data<InT>(),
+                  scale.data<float>(),
+                  output.data<OutT>(),
+                  batch_size,
+                  depth);
+}
 #define INST_DEQUANTIZE(T) \
 template void Dequantize::dequantize<Device::MPS, int8_t, T>(const StorageView&, const StorageView&, StorageView&) const;
 INST_DEQUANTIZE(float)
@@ -49,7 +86,29 @@ INST_DEQUANTIZE(float16_t)
 INST_DEQUANTIZE(bfloat16_t)
 
 template <Device D, typename T>
-void Dequantize::dequantize_gemm_output(const StorageView&, const StorageView&, const StorageView&, bool, bool, const StorageView*, StorageView&) const { THROW_MPS(DequantizeGemm) }
+void Dequantize::dequantize_gemm_output(const StorageView& input,
+                                        const StorageView& a_scale,
+                                        const StorageView& b_scale,
+                                        bool transpose_a,
+                                        bool transpose_b,
+                                        const StorageView* bias,
+                                        StorageView& output) const {
+  const dim_t depth = input.dim(-1);
+  const dim_t batch_size = input.size() / depth;
+  mps::dequantize_gemm_output(DataTypeToEnum<T>::value,
+                              input.data<int32_t>(),
+                              a_scale.data<float>(),
+                              a_scale.size(),
+                              b_scale.data<float>(),
+                              b_scale.size(),
+                              transpose_a,
+                              transpose_b,
+                              bias ? bias->data<T>() : nullptr,
+                              output.data<T>(),
+                              batch_size,
+                              depth,
+                              activation_code(_activation_type));
+}
 #define INST_DEQ_GEMM(T) \
 template void Dequantize::dequantize_gemm_output<Device::MPS, T>(const StorageView&, const StorageView&, const StorageView&, bool, bool, const StorageView*, StorageView&) const;
 INST_DEQ_GEMM(float)
@@ -57,7 +116,21 @@ INST_DEQ_GEMM(float16_t)
 INST_DEQ_GEMM(bfloat16_t)
 
 template <Device D, typename T, typename Q>
-void Quantize::quantize(const StorageView&, StorageView&, StorageView&) const { THROW_MPS(Quantize) }
+void Quantize::quantize(const StorageView& input,
+                        StorageView& output,
+                        StorageView& scale) const {
+  if (_shift_to_uint8)
+    throw std::invalid_argument("Shift to uint8_t is not defined on MPS");
+  const dim_t depth = input.dim(-1);
+  const dim_t batch_size = input.size() / depth;
+  mps::quantize(DataTypeToEnum<T>::value,
+                input.data<T>(),
+                output.data<int8_t>(),
+                scale.data<float>(),
+                batch_size,
+                depth,
+                _round_before_cast);
+}
 #define INST_QUANTIZE(T) \
 template void Quantize::quantize<Device::MPS, T, int8_t>(const StorageView&, StorageView&, StorageView&) const;
 INST_QUANTIZE(float)
@@ -85,7 +158,16 @@ void BiasAdd::compute(const StorageView&, const StorageView&, StorageView&, cons
 
 // --- Advanced ---
 template <Device D, typename T>
-void Multinomial::compute(const StorageView&, StorageView&) const { THROW_MPS(Multinomial) }
+void Multinomial::compute(const StorageView& input, StorageView& output) const {
+  const dim_t depth = input.dim(-1);
+  const dim_t batch_size = input.size() / depth;
+  mps::multinomial(DataTypeToEnum<T>::value,
+                   input.data<T>(),
+                   output.data<int32_t>(),
+                   batch_size,
+                   depth,
+                   _sample_size);
+}
 #define INST_MULTINOMIAL(T) template void Multinomial::compute<Device::MPS, T>(const StorageView&, StorageView&) const;
 INST_MULTINOMIAL(float)
 INST_MULTINOMIAL(float16_t)
@@ -99,21 +181,59 @@ void TopK::compute(const StorageView&, StorageView&, StorageView&) const { THROW
 // Conv1D: handled in conv1d_mps.mm - stub removed to avoid ODR conflict
 
 template <Device D, typename T>
-void AlibiAdd::compute(const StorageView&, const StorageView&, dim_t, StorageView&) const { THROW_MPS(AlibiAdd) }
+void AlibiAdd::compute(const StorageView& input,
+                       const StorageView& alibi,
+                       dim_t alibi_offset,
+                       StorageView& output) const {
+  mps::alibi_add(DataTypeToEnum<T>::value,
+                 input.data<T>(),
+                 alibi.data<T>(),
+                 output.data<T>(),
+                 input.dim(0),
+                 input.dim(1),
+                 input.dim(2),
+                 input.dim(3),
+                 alibi.dim(-1),
+                 alibi_offset);
+}
 #define INST_ALIBI(T) template void AlibiAdd::compute<Device::MPS, T>(const StorageView&, const StorageView&, dim_t, StorageView&) const;
 INST_ALIBI(float)
 INST_ALIBI(float16_t)
 INST_ALIBI(bfloat16_t)
 
 template <Device D, typename T>
-void MedianFilter::compute(const StorageView&, dim_t, StorageView&) const { THROW_MPS(MedianFilter) }
+void MedianFilter::compute(const StorageView& input,
+                           dim_t axis_size,
+                           StorageView& output) const {
+  const dim_t rank = _width / 2;
+  if (_width <= 1 || axis_size <= rank) {
+    if (&input != &output)
+      output.copy_from(input);
+    return;
+  }
+  if ((_width & 1) == 0)
+    throw std::invalid_argument("MedianFilter width must be odd");
+  if (_width > 129)
+    throw std::invalid_argument("MPS MedianFilter width exceeds 129");
+  mps::median_filter(DataTypeToEnum<T>::value,
+                     input.data<T>(),
+                     output.data<T>(),
+                     input.size() / axis_size,
+                     axis_size,
+                     _width);
+}
 #define INST_MEDIAN(T) template void MedianFilter::compute<Device::MPS, T>(const StorageView&, dim_t, StorageView&) const;
 INST_MEDIAN(float)
 INST_MEDIAN(float16_t)
 INST_MEDIAN(bfloat16_t)
 
 template <Device D, typename T>
-void GumbelMax::add_gumbel_noise(const StorageView&, StorageView&) const { THROW_MPS(GumbelMax) }
+void GumbelMax::add_gumbel_noise(const StorageView& input, StorageView& output) const {
+  mps::gumbel_noise(DataTypeToEnum<T>::value,
+                    input.data<T>(),
+                    output.data<T>(),
+                    input.size());
+}
 #define INST_GUMBEL(T) template void GumbelMax::add_gumbel_noise<Device::MPS, T>(const StorageView&, StorageView&) const;
 INST_GUMBEL(float)
 INST_GUMBEL(float16_t)
@@ -153,14 +273,28 @@ INST_REDUCEALL(int8_t)
 INST_REDUCEALL(int32_t)
 INST_REDUCEALL(int16_t)
 
-template<>
-void TopPMask::compute<Device::MPS, float>(const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(TopPMask) }
-template<>
-void TopPMask::compute<Device::MPS, float16_t>(const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(TopPMask) }
-template<>
-void TopPMask::compute<Device::MPS, bfloat16_t>(const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(TopPMask) }
+template <Device D, typename T>
+void TopPMask::compute(const StorageView& input,
+                       const StorageView& probabilities,
+                       StorageView& output) const {
+  const dim_t depth = input.dim(-1);
+  const dim_t batch_size = input.size() / depth;
+  mps::top_p_mask(DataTypeToEnum<T>::value,
+                  input.data<T>(),
+                  probabilities.data<T>(),
+                  output.data<T>(),
+                  batch_size,
+                  depth,
+                  _p,
+                  _mask_value);
+}
 
-template<> dim_t TopPMask::max_num_classes<Device::MPS>() { return 0; }
+#define INST_TOPP(T) template void TopPMask::compute<Device::MPS, T>(const StorageView&, const StorageView&, StorageView&) const;
+INST_TOPP(float)
+INST_TOPP(float16_t)
+INST_TOPP(bfloat16_t)
+
+template<> dim_t TopPMask::max_num_classes<Device::MPS>() { return mps::max_top_p_classes(); }
 
 } // namespace ops
 } // namespace ctranslate2

--- a/src/mps/ops_stubs.mm
+++ b/src/mps/ops_stubs.mm
@@ -1,0 +1,167 @@
+#ifdef __APPLE__
+#include <stdexcept>
+#include <vector>
+#include "ctranslate2/types.h"
+#include "ctranslate2/storage_view.h"
+
+// --- Standard Ops ---
+#include "ctranslate2/ops/dequantize.h"
+#include "ctranslate2/ops/quantize.h"
+#include "ctranslate2/ops/softmax.h"
+#include "ctranslate2/ops/rms_norm.h"
+#include "ctranslate2/ops/layer_norm.h"
+#include "ctranslate2/ops/bias_add.h"
+#include "ctranslate2/ops/tile.h"
+#include "ctranslate2/ops/split.h"
+#include "ctranslate2/ops/concat.h"
+#include "ctranslate2/ops/gather.h"
+#include "ctranslate2/ops/slide.h"
+#include "ctranslate2/ops/multinomial.h"
+#include "ctranslate2/ops/topk.h"
+#include "ctranslate2/ops/rotary.h"
+#include "ctranslate2/ops/conv1d.h"
+#include "ctranslate2/ops/alibi_add.h"
+#include "ctranslate2/ops/median_filter.h"
+#include "ctranslate2/ops/gumbel_max.h"
+#include "ctranslate2/ops/mean.h"
+#include "ctranslate2/ops/flash_attention.h"
+#include "ctranslate2/ops/gemm.h"
+#include "ctranslate2/ops/nccl_ops.h"
+#include "ctranslate2/ops/topp_mask.h"
+
+// --- AWQ Ops (Corrected Paths) ---
+#include "ctranslate2/ops/awq/gemm.h"
+#include "ctranslate2/ops/awq/gemv.h"
+#include "ctranslate2/ops/awq/dequantize_awq.h"
+
+namespace ctranslate2 {
+namespace ops {
+
+#define THROW_MPS(NAME) throw std::runtime_error("MPS " #NAME " not implemented");
+
+// --- Quantization ---
+template <Device D, typename T, typename Q>
+void Dequantize::dequantize(const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(Dequantize) }
+#define INST_DEQUANTIZE(T) \
+template void Dequantize::dequantize<Device::MPS, int8_t, T>(const StorageView&, const StorageView&, StorageView&) const;
+INST_DEQUANTIZE(float)
+INST_DEQUANTIZE(float16_t)
+INST_DEQUANTIZE(bfloat16_t)
+
+template <Device D, typename T>
+void Dequantize::dequantize_gemm_output(const StorageView&, const StorageView&, const StorageView&, bool, bool, const StorageView*, StorageView&) const { THROW_MPS(DequantizeGemm) }
+#define INST_DEQ_GEMM(T) \
+template void Dequantize::dequantize_gemm_output<Device::MPS, T>(const StorageView&, const StorageView&, const StorageView&, bool, bool, const StorageView*, StorageView&) const;
+INST_DEQ_GEMM(float)
+INST_DEQ_GEMM(float16_t)
+INST_DEQ_GEMM(bfloat16_t)
+
+template <Device D, typename T, typename Q>
+void Quantize::quantize(const StorageView&, StorageView&, StorageView&) const { THROW_MPS(Quantize) }
+#define INST_QUANTIZE(T) \
+template void Quantize::quantize<Device::MPS, T, int8_t>(const StorageView&, StorageView&, StorageView&) const;
+INST_QUANTIZE(float)
+INST_QUANTIZE(float16_t)
+INST_QUANTIZE(bfloat16_t)
+
+// --- Math & Activation ---
+// SoftMax: handled in softmax_mps.cc
+template <Device D, typename T>
+void SoftMax::compute(const StorageView&, const StorageView*, StorageView&) const { THROW_MPS(SoftMax) }
+
+// RMSNorm: handled in rms_norm_mps.mm
+template <Device D, typename T>
+void RMSNorm::compute(const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(RMSNorm) }
+
+// LayerNorm: handled in layer_norm_mps.mm
+template <Device D, typename T>
+void LayerNorm::compute(const StorageView*, const StorageView*, const StorageView&, dim_t, dim_t, dim_t, dim_t, StorageView&) const { THROW_MPS(LayerNorm) }
+
+// BiasAdd: handled in mps/ops_impl.mm
+template <Device D, typename T>
+void BiasAdd::compute(const StorageView&, const StorageView&, StorageView&, const StorageView*) const { THROW_MPS(BiasAdd) }
+
+// Tile, Split, Concat, Gather, Slide: handled in mps/ops_impl.mm
+
+// --- Advanced ---
+template <Device D, typename T>
+void Multinomial::compute(const StorageView&, StorageView&) const { THROW_MPS(Multinomial) }
+#define INST_MULTINOMIAL(T) template void Multinomial::compute<Device::MPS, T>(const StorageView&, StorageView&) const;
+INST_MULTINOMIAL(float)
+INST_MULTINOMIAL(float16_t)
+INST_MULTINOMIAL(bfloat16_t)
+
+// TopK: handled in mps/ops_impl.mm
+template <Device D, typename DataType, typename IndexType>
+void TopK::compute(const StorageView&, StorageView&, StorageView&) const { THROW_MPS(TopK) }
+
+// Rotary: handled in rotary_mps.mm
+// Conv1D: handled in conv1d_mps.mm - stub removed to avoid ODR conflict
+
+template <Device D, typename T>
+void AlibiAdd::compute(const StorageView&, const StorageView&, dim_t, StorageView&) const { THROW_MPS(AlibiAdd) }
+#define INST_ALIBI(T) template void AlibiAdd::compute<Device::MPS, T>(const StorageView&, const StorageView&, dim_t, StorageView&) const;
+INST_ALIBI(float)
+INST_ALIBI(float16_t)
+INST_ALIBI(bfloat16_t)
+
+template <Device D, typename T>
+void MedianFilter::compute(const StorageView&, dim_t, StorageView&) const { THROW_MPS(MedianFilter) }
+#define INST_MEDIAN(T) template void MedianFilter::compute<Device::MPS, T>(const StorageView&, dim_t, StorageView&) const;
+INST_MEDIAN(float)
+INST_MEDIAN(float16_t)
+INST_MEDIAN(bfloat16_t)
+
+template <Device D, typename T>
+void GumbelMax::add_gumbel_noise(const StorageView&, StorageView&) const { THROW_MPS(GumbelMax) }
+#define INST_GUMBEL(T) template void GumbelMax::add_gumbel_noise<Device::MPS, T>(const StorageView&, StorageView&) const;
+INST_GUMBEL(float)
+INST_GUMBEL(float16_t)
+INST_GUMBEL(bfloat16_t)
+
+// Mean: handled in mean_mps.mm
+template <Device D, typename T>
+void Mean::compute(const StorageView&, dim_t, dim_t, dim_t, bool, StorageView&) const { THROW_MPS(Mean) }
+
+// --- Flash Attention & AWQ ---
+template<> void FlashAttention::compute<Device::MPS>(StorageView&, StorageView&, StorageView&, StorageView&, StorageView*, StorageView*, StorageView*, bool, StorageView*, StorageView*, bool, StorageView*, dim_t) const { THROW_MPS(FlashAttention) }
+
+template<> void DequantizeAwq::dequantize<Device::MPS, int32_t, float16_t>(const StorageView&, const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(DequantizeAwq) }
+
+template<> void GemmAwq::compute<Device::MPS, float16_t, int32_t>(const StorageView&, const StorageView&, const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(GemmAwq) }
+template<> void GemvAwq::compute_gemv<Device::MPS, float16_t, int32_t>(const StorageView&, const StorageView&, const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(GemvAwq) }
+template<> void GemvAwq::compute_gemv2<Device::MPS, float16_t, int32_t>(const StorageView&, const StorageView&, const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(GemvAwq2) }
+
+// --- NCCL / Distributed ---
+template <Device D, typename T>
+void GatherAll::compute(const StorageView&, StorageView&) const { THROW_MPS(GatherAll) }
+#define INST_GATHERALL(T) template void GatherAll::compute<Device::MPS, T>(const StorageView&, StorageView&) const;
+INST_GATHERALL(float)
+INST_GATHERALL(float16_t)
+INST_GATHERALL(bfloat16_t)
+INST_GATHERALL(int8_t)
+INST_GATHERALL(int32_t)
+INST_GATHERALL(int16_t)
+
+template <Device D, typename T>
+void ReduceAll::compute(const StorageView&, StorageView&) const { THROW_MPS(ReduceAll) }
+#define INST_REDUCEALL(T) template void ReduceAll::compute<Device::MPS, T>(const StorageView&, StorageView&) const;
+INST_REDUCEALL(float)
+INST_REDUCEALL(float16_t)
+INST_REDUCEALL(bfloat16_t)
+INST_REDUCEALL(int8_t)
+INST_REDUCEALL(int32_t)
+INST_REDUCEALL(int16_t)
+
+template<>
+void TopPMask::compute<Device::MPS, float>(const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(TopPMask) }
+template<>
+void TopPMask::compute<Device::MPS, float16_t>(const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(TopPMask) }
+template<>
+void TopPMask::compute<Device::MPS, bfloat16_t>(const StorageView&, const StorageView&, StorageView&) const { THROW_MPS(TopPMask) }
+
+template<> dim_t TopPMask::max_num_classes<Device::MPS>() { return 0; }
+
+} // namespace ops
+} // namespace ctranslate2
+#endif

--- a/src/mps/ops_utils.h
+++ b/src/mps/ops_utils.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#ifdef __APPLE__
+#ifdef CT2_WITH_MPS
+
+#include <memory>
+
+#include "ctranslate2/storage_view.h"
+
+namespace ctranslate2 {
+  namespace mps {
+
+    inline StorageView to_cpu(const StorageView& view) {
+      return view.to(Device::CPU);
+    }
+
+    inline StorageView to_cpu_float32(const StorageView& view) {
+      StorageView cpu = to_cpu(view);
+      if (cpu.dtype() != DataType::FLOAT32)
+        cpu = cpu.to(DataType::FLOAT32);
+      return cpu;
+    }
+
+    inline std::unique_ptr<StorageView> optional_to_cpu(const StorageView* view) {
+      if (!view)
+        return nullptr;
+      return std::make_unique<StorageView>(to_cpu(*view));
+    }
+
+    inline std::unique_ptr<StorageView> optional_to_cpu_float32(const StorageView* view) {
+      if (!view)
+        return nullptr;
+      return std::make_unique<StorageView>(to_cpu_float32(*view));
+    }
+
+    inline StorageView cpu_float32_output_like(const StorageView& output) {
+      return StorageView(output.shape(), DataType::FLOAT32, Device::CPU);
+    }
+
+    inline void copy_cpu_float32_to_output(const StorageView& cpu_float32,
+                                           StorageView& output) {
+      StorageView converted = cpu_float32;
+      if (output.dtype() != DataType::FLOAT32)
+        converted = cpu_float32.to(output.dtype());
+      output.copy_from(converted);
+    }
+
+  }
+}
+
+#endif
+#endif

--- a/src/mps/primitives.mm
+++ b/src/mps/primitives.mm
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -402,6 +403,27 @@ namespace ctranslate2 {
                                                          dim_t batch_size,
                                                          dim_t length,
                                                          dim_t vocabulary_size) {
+    static const bool gpu_repetition_penalty_enabled = []() {
+      const char* value = std::getenv("CT2_MPS_USE_GPU_REPETITION_PENALTY");
+      return !value || value[0] == '\0' || value[0] != '0';
+    }();
+    if constexpr (is_mps_float_type_v<T>) {
+      if (!gpu_repetition_penalty_enabled) {
+        // Retain a diagnostic escape hatch for comparing with the synchronized
+        // reference implementation.
+      } else {
+        mps::penalize_previous_tokens(DataTypeToEnum<T>::value,
+                                      scores,
+                                      previous_scores,
+                                      previous_ids,
+                                      to_float(penalty),
+                                      batch_size,
+                                      length,
+                                      vocabulary_size);
+        return;
+      }
+    }
+
     mps::synchronize("host repetition penalty");
     const float p = to_float(penalty);
     for (dim_t i = 0; i < batch_size * length; ++i) {

--- a/src/mps/primitives.mm
+++ b/src/mps/primitives.mm
@@ -1,0 +1,999 @@
+// primitives_mps.mm - FIXED version with complete template instantiations
+// This eliminates undefined symbol errors by explicitly instantiating all templates
+
+#ifdef __APPLE__
+
+#import <Metal/Metal.h>
+#import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+#include "ctranslate2/primitives.h"
+#include "ctranslate2/types.h"
+#include "mps/kernels.h"
+#include "mps/utils.h"
+#include "type_dispatch.h"
+
+namespace ctranslate2 {
+
+  // -------------------------
+  // Small helpers (host/unified memory)
+  // -------------------------
+
+  template <typename T>
+  static constexpr bool is_mps_float_type_v =
+    std::is_same_v<T, float> || std::is_same_v<T, float16_t> || std::is_same_v<T, bfloat16_t>;
+
+  template <typename T>
+  static inline float to_float(T v) {
+    if constexpr (std::is_same_v<T, float>)
+      return v;
+    else
+      return static_cast<float>(v);
+  }
+
+  template <>
+  inline float to_float<float16_t>(float16_t v) {
+    return static_cast<float>(v);
+  }
+
+  template <>
+  inline float to_float<bfloat16_t>(bfloat16_t v) {
+    return static_cast<float>(v);
+  }
+
+  template <typename T>
+  static inline T from_float(float v) {
+    if constexpr (std::is_same_v<T, float>)
+      return v;
+    else
+      return static_cast<T>(v);
+  }
+
+  template <>
+  inline float16_t from_float<float16_t>(float v) {
+    return float16_t(v);
+  }
+
+  template <>
+  inline bfloat16_t from_float<bfloat16_t>(float v) {
+    return bfloat16_t(v);
+  }
+
+  template <typename T>
+  static inline T abs_val(T v) {
+    if constexpr (std::is_floating_point_v<T>)
+      return std::fabs(v);
+    else
+      return v < 0 ? -v : v;
+  }
+
+  template <>
+  inline float16_t abs_val<float16_t>(float16_t v) {
+    return float16_t(std::fabs((float)v));
+  }
+
+  template <>
+  inline bfloat16_t abs_val<bfloat16_t>(bfloat16_t v) {
+    return bfloat16_t(std::fabs((float)v));
+  }
+
+  template <typename T>
+  static inline T clamp_min(T x, T a) {
+    return x < a ? a : x;
+  }
+
+  template <typename T>
+  static inline T clamp_max(T x, T a) {
+    return x > a ? a : x;
+  }
+
+  // -------------------------
+  // Basic ops
+  // -------------------------
+
+  template<>
+  template <typename T>
+  T primitives<Device::MPS>::at(const T* x, dim_t index) {
+    mps::synchronize("host scalar read");
+    return x[index];
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::fill(T* x, T a, dim_t size) {
+    mps::fill(DataTypeToEnum<T>::value, &a, x, size);
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::strided_fill(T* x, T a, dim_t inc_x, dim_t size) {
+    mps::synchronize("host strided fill");
+    for (dim_t i = 0; i < size; ++i)
+      x[i * inc_x] = a;
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::indexed_fill(T* x, T a, const int32_t* indices, dim_t num_indices) {
+    mps::indexed_fill(DataTypeToEnum<T>::value, &a, x, indices, num_indices);
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::copy(const T* x, T* y, dim_t size) {
+    const size_t bytes = static_cast<size_t>(size) * sizeof(T);
+    if (bytes == 0 || x == y)
+      return;
+
+    size_t src_offset = 0;
+    size_t dst_offset = 0;
+    void* src_raw = mps::get_buffer(x, bytes, &src_offset);
+    void* dst_raw = mps::get_buffer(y, bytes, &dst_offset);
+
+    if (src_raw && dst_raw) {
+      const bool same_buffer = src_raw == dst_raw;
+      const bool overlaps = same_buffer
+                            && src_offset < dst_offset + bytes
+                            && dst_offset < src_offset + bytes;
+      if (overlaps) {
+        // Metal does not define memmove semantics for overlapping blits.
+        mps::synchronize("overlapping copy");
+        std::memmove(y, x, bytes);
+        mps::record_profile_event(mps::ProfileEvent::CpuFallback);
+        return;
+      }
+      // Cache growth and beam reordering create chains of small copies. A
+      // compute copy participates in the stream's explicit buffer barriers,
+      // unlike deferred blits that can observe a stale source in these chains.
+      mps::tile(DataTypeToEnum<T>::value, x, y, 1, size, 1);
+      mps::record_copy_bytes(bytes);
+      return;
+    }
+
+    mps::synchronize("unregistered copy");
+    std::memmove(y, x, bytes);
+    mps::record_profile_event(mps::ProfileEvent::CpuFallback);
+  }
+
+  template<>
+  template <typename U, typename V>
+  void primitives<Device::MPS>::convert(const U* x, V* y, dim_t size) {
+    mps::synchronize("host conversion");
+    for (dim_t i = 0; i < size; ++i)
+      y[i] = static_cast<V>(x[i]);
+  }
+
+  template void primitives<Device::MPS>::convert(const float*, float16_t*, dim_t);
+  template void primitives<Device::MPS>::convert(const float16_t*, float*, dim_t);
+  template void primitives<Device::MPS>::convert(const float*, bfloat16_t*, dim_t);
+  template void primitives<Device::MPS>::convert(const bfloat16_t*, float*, dim_t);
+  template void primitives<Device::MPS>::convert(const float16_t*, bfloat16_t*, dim_t);
+  template void primitives<Device::MPS>::convert(const bfloat16_t*, float16_t*, dim_t);
+
+  template<>
+  template <typename T>
+  T primitives<Device::MPS>::sum(const T* array, dim_t size) {
+    mps::synchronize("host sum reduction");
+    if constexpr (std::is_same_v<T, float> || std::is_same_v<T, float16_t> || std::is_same_v<T, bfloat16_t>) {
+      float acc = 0.f;
+      for (dim_t i = 0; i < size; ++i)
+        acc += to_float(array[i]);
+      return from_float<T>(acc);
+    } else {
+      long long acc = 0;
+      for (dim_t i = 0; i < size; ++i)
+        acc += static_cast<long long>(array[i]);
+      return static_cast<T>(acc);
+    }
+  }
+
+  template<>
+  template <typename T>
+  dim_t primitives<Device::MPS>::max_element(const T* array, dim_t size) {
+    mps::synchronize("host max index reduction");
+    if (size <= 0)
+      return 0;
+    dim_t best = 0;
+    for (dim_t i = 1; i < size; ++i) {
+      if (array[i] > array[best])
+        best = i;
+    }
+    return best;
+  }
+
+  template<>
+  template <typename T>
+  T primitives<Device::MPS>::max(const T* array, dim_t size) {
+    mps::synchronize("host max reduction");
+    if (size <= 0)
+      return T();
+    T best = array[0];
+    for (dim_t i = 1; i < size; ++i)
+      best = (array[i] > best ? array[i] : best);
+    return best;
+  }
+
+  template<>
+  template <typename T>
+  T primitives<Device::MPS>::amax(const T* array, dim_t size) {
+    mps::synchronize("host absolute max reduction");
+    if (size <= 0)
+      return T();
+    T best = abs_val(array[0]);
+    for (dim_t i = 1; i < size; ++i) {
+      T v = abs_val(array[i]);
+      best = (v > best ? v : best);
+    }
+    return best;
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::add(T a, const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::scalar(DataTypeToEnum<T>::value, mps::BinaryOp::ADD, to_float(a), x, y, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      y[i] = x[i] + a;
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::add(const T* a, const T* b, T* c, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::binary(DataTypeToEnum<T>::value, mps::BinaryOp::ADD, a, b, c, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      c[i] = a[i] + b[i];
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::add_batch_broadcast(const T* a, const T* b, T* c,
+                                                    dim_t a_size, dim_t b_size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::batch_broadcast(DataTypeToEnum<T>::value, mps::BinaryOp::ADD, a, b, c, a_size, b_size);
+      return;
+    }
+    for (dim_t i = 0; i < b_size; ++i)
+      c[i] = a[i % a_size] + b[i];
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::add_depth_broadcast(const T* a, const T* b, T* c,
+                                                    dim_t a_size, dim_t b_size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::depth_broadcast(DataTypeToEnum<T>::value, mps::BinaryOp::ADD, a, b, c, a_size, b_size);
+      return;
+    }
+    const dim_t depth = (a_size == 0 ? 0 : b_size / a_size);
+    for (dim_t i = 0; i < b_size; ++i) {
+      const dim_t j = (depth == 0 ? 0 : (i / depth));
+      c[i] = a[j] + b[i];
+    }
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::add_block_broadcast(const T* a, const T* b, T* c,
+                                                    dim_t block, dim_t a_size, dim_t b_size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::block_broadcast(DataTypeToEnum<T>::value, mps::BinaryOp::ADD, a, b, c, block, a_size, b_size);
+      return;
+    }
+    if (block == 0 || a_size == 0)
+      return;
+
+    const dim_t iter_size = b_size / block;
+    for (dim_t i = 0; i < iter_size; ++i) {
+      const T a_i = a[i % a_size];
+      const dim_t offset = i * block;
+      for (dim_t j = 0; j < block; ++j)
+        c[offset + j] = a_i + b[offset + j];
+    }
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::sub(const T* a, const T* b, T* c, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::binary(DataTypeToEnum<T>::value, mps::BinaryOp::SUB, a, b, c, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      c[i] = a[i] - b[i];
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::max(T a, const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::scalar(DataTypeToEnum<T>::value, mps::BinaryOp::MAX, to_float(a), x, y, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      y[i] = (x[i] > a ? x[i] : a);
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::max(const T* a, const T* b, T* c, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::binary(DataTypeToEnum<T>::value, mps::BinaryOp::MAX, a, b, c, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      c[i] = (a[i] > b[i] ? a[i] : b[i]);
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::min(T a, const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::scalar(DataTypeToEnum<T>::value, mps::BinaryOp::MIN, to_float(a), x, y, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      y[i] = (x[i] < a ? x[i] : a);
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::min(const T* a, const T* b, T* c, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::binary(DataTypeToEnum<T>::value, mps::BinaryOp::MIN, a, b, c, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      c[i] = (a[i] < b[i] ? a[i] : b[i]);
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::mul(T a, const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::scalar(DataTypeToEnum<T>::value, mps::BinaryOp::MUL, to_float(a), x, y, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      y[i] = x[i] * a;
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::mul(const T* a, const T* b, T* c, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::binary(DataTypeToEnum<T>::value, mps::BinaryOp::MUL, a, b, c, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      c[i] = a[i] * b[i];
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::mul_batch_broadcast(const T* a, const T* b, T* c,
+                                                    dim_t a_size, dim_t b_size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::batch_broadcast(DataTypeToEnum<T>::value, mps::BinaryOp::MUL, a, b, c, a_size, b_size);
+      return;
+    }
+    for (dim_t i = 0; i < b_size; ++i)
+      c[i] = a[i % a_size] * b[i];
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::penalize_previous_tokens(T* scores,
+                                                         const T* previous_scores,
+                                                         const int32_t* previous_ids,
+                                                         T penalty,
+                                                         dim_t batch_size,
+                                                         dim_t length,
+                                                         dim_t vocabulary_size) {
+    mps::synchronize("host repetition penalty");
+    const float p = to_float(penalty);
+    for (dim_t i = 0; i < batch_size * length; ++i) {
+      const dim_t write_index = (i / length) * vocabulary_size + previous_ids[i];
+      const float s = to_float(previous_scores[i]);
+      const float out = (s < 0.f ? s * p : s / p);
+      scores[write_index] = from_float<T>(out);
+    }
+  }
+
+  template<>
+  void primitives<Device::MPS>::prepare_length_mask(const int32_t* lengths,
+                                                    dim_t batch_size,
+                                                    dim_t num_heads,
+                                                    dim_t num_queries,
+                                                    bool mask_future,
+                                                    bool multi_query,
+                                                    int32_t* mask) {
+    // This path is host-visible by design. The mask layout depends on whether
+    // queries or heads are the merged dimension, so keep the CPU reference
+    // mapping until every attention layout has a dedicated tested GPU kernel.
+    mps::synchronize("host attention mask");
+    for (dim_t b = 0; b < batch_size; ++b) {
+      const int32_t length = lengths[b];
+      int32_t* output = mask + b * num_heads * num_queries;
+      for (dim_t i = 0; i < num_heads * num_queries; ++i) {
+        if (mask_future) {
+          const int32_t query = multi_query
+                                ? static_cast<int32_t>(i / num_heads)
+                                : static_cast<int32_t>(i % num_queries);
+          output[i] = std::min<int32_t>(length, query + 1);
+        } else {
+          output[i] = length;
+        }
+      }
+    }
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::transpose_2d(const T* a, const dim_t* dims, T* b) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::transpose_2d(DataTypeToEnum<T>::value, a, dims[0], dims[1], b);
+      return;
+    }
+    const dim_t rows = dims[0];
+    const dim_t cols = dims[1];
+    for (dim_t i = 0; i < rows; ++i)
+      for (dim_t j = 0; j < cols; ++j)
+        b[j * rows + i] = a[i * cols + j];
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::transpose_3d(const T* a, const dim_t* dims,
+                                            const dim_t* perm, T* b) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::transpose_3d(DataTypeToEnum<T>::value, a, dims, perm, b);
+      return;
+    }
+    const dim_t d0 = dims[0], d1 = dims[1], d2 = dims[2];
+    const dim_t a_stride[3] = {d1 * d2, d2, 1};
+    const dim_t bd[3] = {dims[perm[0]], dims[perm[1]], dims[perm[2]]};
+    const dim_t b_stride[3] = {bd[1] * bd[2], bd[2], 1};
+
+    for (dim_t i0 = 0; i0 < bd[0]; ++i0) {
+      for (dim_t i1 = 0; i1 < bd[1]; ++i1) {
+        for (dim_t i2 = 0; i2 < bd[2]; ++i2) {
+          dim_t idx_b = i0 * b_stride[0] + i1 * b_stride[1] + i2;
+          dim_t src_idx[3] = {0, 0, 0};
+          src_idx[perm[0]] = i0;
+          src_idx[perm[1]] = i1;
+          src_idx[perm[2]] = i2;
+          dim_t idx_a = src_idx[0] * a_stride[0] + src_idx[1] * a_stride[1] + src_idx[2];
+          b[idx_b] = a[idx_a];
+        }
+      }
+    }
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::transpose_4d(const T* a, const dim_t* dims,
+                                            const dim_t* perm, T* b) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::transpose_4d(DataTypeToEnum<T>::value, a, dims, perm, b);
+      return;
+    }
+    const dim_t d0 = dims[0], d1 = dims[1], d2 = dims[2], d3 = dims[3];
+    const dim_t a_stride[4] = {d1 * d2 * d3, d2 * d3, d3, 1};
+
+    const dim_t bd[4] = {dims[perm[0]], dims[perm[1]], dims[perm[2]], dims[perm[3]]};
+    const dim_t b_stride[4] = {bd[1] * bd[2] * bd[3], bd[2] * bd[3], bd[3], 1};
+
+    for (dim_t i0 = 0; i0 < bd[0]; ++i0) {
+      for (dim_t i1 = 0; i1 < bd[1]; ++i1) {
+        for (dim_t i2 = 0; i2 < bd[2]; ++i2) {
+          for (dim_t i3 = 0; i3 < bd[3]; ++i3) {
+            dim_t idx_b = i0 * b_stride[0] + i1 * b_stride[1] + i2 * b_stride[2] + i3;
+            dim_t src_idx[4] = {0, 0, 0, 0};
+            src_idx[perm[0]] = i0;
+            src_idx[perm[1]] = i1;
+            src_idx[perm[2]] = i2;
+            src_idx[perm[3]] = i3;
+            dim_t idx_a = src_idx[0] * a_stride[0] + src_idx[1] * a_stride[1] +
+                          src_idx[2] * a_stride[2] + src_idx[3];
+            b[idx_b] = a[idx_a];
+          }
+        }
+      }
+    }
+  }
+
+  // -------------------------
+  // Float ops (CUDA-style: float/float16/bfloat16 supported)
+  // -------------------------
+
+  template<>
+  template <typename T>
+  float primitives<Device::MPS>::logsumexp(const T* x, dim_t size) {
+    mps::synchronize("host logsumexp reduction");
+    if (size <= 0)
+      return -std::numeric_limits<float>::infinity();
+    float maxv = -std::numeric_limits<float>::infinity();
+    for (dim_t i = 0; i < size; ++i)
+      maxv = std::max(maxv, to_float(x[i]));
+    float sum = 0.f;
+    for (dim_t i = 0; i < size; ++i)
+      sum += std::exp(to_float(x[i]) - maxv);
+    return std::log(sum) + maxv;
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::exp(const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::unary(DataTypeToEnum<T>::value, mps::UnaryOp::EXP, x, y, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      y[i] = from_float<T>(std::exp(to_float(x[i])));
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::log(const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::unary(DataTypeToEnum<T>::value, mps::UnaryOp::LOG, x, y, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      y[i] = from_float<T>(std::log(to_float(x[i])));
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::cos(const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::unary(DataTypeToEnum<T>::value, mps::UnaryOp::COS, x, y, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      y[i] = from_float<T>(std::cos(to_float(x[i])));
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::sin(const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::unary(DataTypeToEnum<T>::value, mps::UnaryOp::SIN, x, y, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      y[i] = from_float<T>(std::sin(to_float(x[i])));
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::tanh(const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::unary(DataTypeToEnum<T>::value, mps::UnaryOp::TANH, x, y, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i)
+      y[i] = from_float<T>(std::tanh(to_float(x[i])));
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::relu(const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::unary(DataTypeToEnum<T>::value, mps::UnaryOp::RELU, x, y, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i) {
+      const float v = to_float(x[i]);
+      y[i] = from_float<T>(v > 0.f ? v : 0.f);
+    }
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::gelu(const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::unary(DataTypeToEnum<T>::value, mps::UnaryOp::GELU, x, y, size);
+      return;
+    }
+    constexpr float inv_sqrt2 = 0.7071067811865475f;
+    for (dim_t i = 0; i < size; ++i) {
+      const float v = to_float(x[i]);
+      const float out = 0.5f * v * (1.f + std::erf(v * inv_sqrt2));
+      y[i] = from_float<T>(out);
+    }
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::gelu_tanh(const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::unary(DataTypeToEnum<T>::value, mps::UnaryOp::GELU_TANH, x, y, size);
+      return;
+    }
+    constexpr float sqrt_2_over_pi = 0.7978845608028654f;
+    constexpr float k = 0.044715f;
+    for (dim_t i = 0; i < size; ++i) {
+      const float v = to_float(x[i]);
+      const float u = sqrt_2_over_pi * (v + k * v * v * v);
+      const float out = 0.5f * v * (1.f + std::tanh(u));
+      y[i] = from_float<T>(out);
+    }
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::gelu_sigmoid(const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::unary(DataTypeToEnum<T>::value, mps::UnaryOp::GELU_SIGMOID, x, y, size);
+      return;
+    }
+    constexpr float k = 1.702f;
+    for (dim_t i = 0; i < size; ++i) {
+      const float v = to_float(x[i]);
+      const float s = 1.f / (1.f + std::exp(-k * v));
+      y[i] = from_float<T>(v * s);
+    }
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::sigmoid(const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::unary(DataTypeToEnum<T>::value, mps::UnaryOp::SIGMOID, x, y, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i) {
+      const float v = to_float(x[i]);
+      const float out = 1.f / (1.f + std::exp(-v));
+      y[i] = from_float<T>(out);
+    }
+  }
+
+  template<>
+  template <typename T>
+  void primitives<Device::MPS>::swish(const T* x, T* y, dim_t size) {
+    if constexpr (is_mps_float_type_v<T>) {
+      mps::unary(DataTypeToEnum<T>::value, mps::UnaryOp::SWISH, x, y, size);
+      return;
+    }
+    for (dim_t i = 0; i < size; ++i) {
+      const float v = to_float(x[i]);
+      const float s = 1.f / (1.f + std::exp(-v));
+      y[i] = from_float<T>(v * s);
+    }
+  }
+
+  // -------------------------
+  // Quant helper / packing
+  // -------------------------
+
+  template<>
+  void primitives<Device::MPS>::compute_u8_compensation(const int8_t* b,
+                                                        bool transpose_b,
+                                                        dim_t k,
+                                                        dim_t n,
+                                                        float alpha,
+                                                        int32_t* compensation) {
+    mps::synchronize("INT8 compensation");
+    for (dim_t j = 0; j < n; ++j) {
+      int32_t sum = 0;
+      for (dim_t i = 0; i < k; ++i) {
+        const int8_t v = transpose_b ? b[j * k + i] : b[i * n + j];
+        sum += static_cast<int32_t>(v);
+      }
+      compensation[j] = static_cast<int32_t>(alpha * static_cast<float>(sum));
+    }
+  }
+
+  template<>
+  template <typename T>
+  dim_t primitives<Device::MPS>::gemm_pack_b(const T*, const bool, const dim_t, const dim_t,
+                                            const float, T*) {
+    return 0;  // Not supported, return 0 like CUDA
+  }
+
+  // -------------------------
+  // GEMM on MPS
+  // -------------------------
+
+  static void mps_gemm_float(bool transpose_a,
+                            bool transpose_b,
+                            dim_t m, dim_t n, dim_t k,
+                            float alpha,
+                            const float* a, dim_t lda,
+                            const float* b, dim_t ldb,
+                            float beta,
+                            float* c, dim_t ldc) {
+    mps::gemm(DataType::FLOAT32,
+              transpose_a,
+              transpose_b,
+              m,
+              n,
+              k,
+              alpha,
+              a,
+              lda,
+              b,
+              ldb,
+              beta,
+              c,
+              ldc);
+  }
+
+  template<>
+  template<>
+  void primitives<Device::MPS>::gemm(bool /*a_is_packed*/, bool /*b_is_packed*/,
+                                     bool transpose_a, bool transpose_b,
+                                     dim_t m, dim_t n, dim_t k,
+                                     float alpha,
+                                     const float* a, dim_t lda,
+                                     const float* b, dim_t ldb,
+                                     float beta,
+                                     float* c, dim_t ldc,
+                                     const float* /*a_shift_compensation*/) {
+    mps_gemm_float(transpose_a, transpose_b, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+  }
+
+  template<>
+  template<>
+  void primitives<Device::MPS>::gemm(bool, bool,
+                                     bool transpose_a, bool transpose_b,
+                                     dim_t m, dim_t n, dim_t k,
+                                     float alpha,
+                                     const float16_t* a, dim_t lda,
+                                     const float16_t* b, dim_t ldb,
+                                     float beta,
+                                     float16_t* c, dim_t ldc,
+                                     const float16_t*) {
+    mps::gemm(DataType::FLOAT16,
+              transpose_a,
+              transpose_b,
+              m,
+              n,
+              k,
+              alpha,
+              a,
+              lda,
+              b,
+              ldb,
+              beta,
+              c,
+              ldc);
+  }
+
+  template<>
+  template<>
+  void primitives<Device::MPS>::gemm(bool, bool,
+                                     bool transpose_a, bool transpose_b,
+                                     dim_t m, dim_t n, dim_t k,
+                                     float alpha,
+                                     const bfloat16_t* a, dim_t lda,
+                                     const bfloat16_t* b, dim_t ldb,
+                                     float beta,
+                                     bfloat16_t* c, dim_t ldc,
+                                     const bfloat16_t*) {
+    (void)transpose_a;
+    (void)transpose_b;
+    (void)m;
+    (void)n;
+    (void)k;
+    (void)alpha;
+    (void)a;
+    (void)lda;
+    (void)b;
+    (void)ldb;
+    (void)beta;
+    (void)c;
+    (void)ldc;
+    throw std::invalid_argument(
+      "BF16 GEMM is not supported on MPS; load the model with compute_type=float16");
+  }
+
+  template<>
+  template<>
+  void primitives<Device::MPS>::gemm(bool, bool,
+                                     bool transpose_a, bool transpose_b,
+                                     dim_t m, dim_t n, dim_t k,
+                                     float alpha,
+                                     const int8_t* a, dim_t lda,
+                                     const int8_t* b, dim_t ldb,
+                                     float beta,
+                                     int32_t* c, dim_t ldc,
+                                     const int32_t* a_shift_compensation) {
+    (void)transpose_a;
+    (void)transpose_b;
+    (void)m;
+    (void)n;
+    (void)k;
+    (void)alpha;
+    (void)a;
+    (void)lda;
+    (void)b;
+    (void)ldb;
+    (void)beta;
+    (void)c;
+    (void)ldc;
+    (void)a_shift_compensation;
+    // TODO: implement fused weight-only INT8/INT4 dequantization + GEMV/GEMM.
+    throw std::invalid_argument(
+      "INT8 GEMM is not supported on MPS; use float16 MPS or route the model to CPU");
+  }
+
+  template<>
+  template <typename In, typename Out>
+  void primitives<Device::MPS>::gemm_batch_strided(bool transpose_a, bool transpose_b,
+                                                   dim_t m, dim_t n, dim_t k,
+                                                   float alpha,
+                                                   const In* a, dim_t lda, dim_t stridea,
+                                                   const In* b, dim_t ldb, dim_t strideb,
+                                                   float beta,
+                                                   Out* c, dim_t ldc, dim_t stridec,
+                                                   dim_t batch_size) {
+    if constexpr (std::is_same_v<In, Out> && std::is_same_v<In, float>) {
+      mps::gemm_batch_strided(DataType::FLOAT32,
+                              transpose_a,
+                              transpose_b,
+                              m,
+                              n,
+                              k,
+                              alpha,
+                              a,
+                              lda,
+                              stridea,
+                              b,
+                              ldb,
+                              strideb,
+                              beta,
+                              c,
+                              ldc,
+                              stridec,
+                              batch_size);
+      return;
+    }
+    if constexpr (std::is_same_v<In, Out> && std::is_same_v<In, float16_t>) {
+      mps::gemm_batch_strided(DataType::FLOAT16,
+                              transpose_a,
+                              transpose_b,
+                              m,
+                              n,
+                              k,
+                              alpha,
+                              a,
+                              lda,
+                              stridea,
+                              b,
+                              ldb,
+                              strideb,
+                              beta,
+                              c,
+                              ldc,
+                              stridec,
+                              batch_size);
+      return;
+    }
+    for (dim_t i = 0; i < batch_size; ++i) {
+      primitives<Device::MPS>::gemm(false, false,
+                                    transpose_a, transpose_b,
+                                    m, n, k,
+                                    alpha,
+                                    a + i * stridea, lda,
+                                    b + i * strideb, ldb,
+                                    beta,
+                                    c + i * stridec, ldc,
+                                    static_cast<const Out*>(nullptr));
+    }
+  }
+
+  // -------------------------
+  // Cross-device copies (unified memory => memcpy)
+  // -------------------------
+
+  template<>
+  template <typename T>
+  void cross_device_primitives<Device::CPU, Device::MPS>::copy(const T* x, T* y, dim_t size) {
+    const size_t bytes = static_cast<size_t>(size) * sizeof(T);
+    if (mps::buffer_in_use(y, bytes))
+      mps::synchronize("CPU to MPS copy", bytes);
+    std::memcpy(y, x, bytes);
+    mps::record_copy_bytes(bytes);
+  }
+
+  template<>
+  template <typename T>
+  void cross_device_primitives<Device::MPS, Device::CPU>::copy(const T* x, T* y, dim_t size) {
+    const size_t bytes = static_cast<size_t>(size) * sizeof(T);
+    if (mps::buffer_in_use(x, bytes))
+      mps::synchronize("MPS to CPU copy", bytes);
+    std::memcpy(y, x, bytes);
+    mps::record_copy_bytes(bytes);
+  }
+
+  // -------------------------
+  // Integer GEMM Stubs (not implemented on MPS)
+  // -------------------------
+
+  #define MPS_STUB_GEMM(T) \
+  template<> template<> \
+  void primitives<Device::MPS>::gemm(bool, bool, bool, bool, dim_t, dim_t, dim_t, \
+                                     float, const T*, dim_t, const T*, dim_t, \
+                                     float, T*, dim_t, const T*) { \
+    throw std::runtime_error("MPS integer GEMM <" #T "," #T "> not implemented"); \
+  }
+
+  MPS_STUB_GEMM(int8_t)
+  MPS_STUB_GEMM(int16_t)
+  MPS_STUB_GEMM(int32_t)
+
+  // =========================================================================
+  // EXPLICIT TEMPLATE INSTANTIATIONS (CRITICAL - avoids linker errors)
+  // =========================================================================
+
+#define MPS_DECLARE_IMPL(T) \
+  template T primitives<Device::MPS>::at(const T*, dim_t); \
+  template void primitives<Device::MPS>::fill(T*, T, dim_t); \
+  template void primitives<Device::MPS>::strided_fill(T*, T, dim_t, dim_t); \
+  template void primitives<Device::MPS>::indexed_fill(T*, T, const int32_t*, dim_t); \
+  template void primitives<Device::MPS>::copy(const T*, T*, dim_t); \
+  template T primitives<Device::MPS>::sum(const T*, dim_t); \
+  template dim_t primitives<Device::MPS>::max_element(const T*, dim_t); \
+  template T primitives<Device::MPS>::max(const T*, dim_t); \
+  template T primitives<Device::MPS>::amax(const T*, dim_t); \
+  template void primitives<Device::MPS>::add(T, const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::add(const T*, const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::add_batch_broadcast(const T*, const T*, T*, dim_t, dim_t); \
+  template void primitives<Device::MPS>::add_depth_broadcast(const T*, const T*, T*, dim_t, dim_t); \
+  template void primitives<Device::MPS>::add_block_broadcast(const T*, const T*, T*, dim_t, dim_t, dim_t); \
+  template void primitives<Device::MPS>::sub(const T*, const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::min(T, const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::min(const T*, const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::max(T, const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::max(const T*, const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::mul(T, const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::mul(const T*, const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::mul_batch_broadcast(const T*, const T*, T*, dim_t, dim_t); \
+  template void primitives<Device::MPS>::penalize_previous_tokens(T*, const T*, const int32_t*, T, dim_t, dim_t, dim_t); \
+  template void primitives<Device::MPS>::transpose_2d(const T*, const dim_t*, T*); \
+  template void primitives<Device::MPS>::transpose_3d(const T*, const dim_t*, const dim_t*, T*); \
+  template void primitives<Device::MPS>::transpose_4d(const T*, const dim_t*, const dim_t*, T*); \
+  template dim_t primitives<Device::MPS>::gemm_pack_b(const T*, bool, dim_t, dim_t, float, T*); \
+  template void primitives<Device::MPS>::gemm_batch_strided<T, T>(bool, bool, dim_t, dim_t, dim_t, float, const T*, dim_t, dim_t, const T*, dim_t, dim_t, float, T*, dim_t, dim_t, dim_t); \
+  template void cross_device_primitives<Device::CPU, Device::MPS>::copy<T>(const T*, T*, dim_t); \
+  template void cross_device_primitives<Device::MPS, Device::CPU>::copy<T>(const T*, T*, dim_t);
+
+  DECLARE_ALL_TYPES(MPS_DECLARE_IMPL)
+
+  // Float-math operations (float/float16/bfloat16 only)
+#define MPS_DECLARE_FLOAT_IMPL(T) \
+  template void primitives<Device::MPS>::relu(const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::gelu(const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::gelu_tanh(const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::gelu_sigmoid(const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::sigmoid(const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::swish(const T*, T*, dim_t); \
+  template float primitives<Device::MPS>::logsumexp(const T*, dim_t); \
+  template void primitives<Device::MPS>::sin(const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::cos(const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::tanh(const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::exp(const T*, T*, dim_t); \
+  template void primitives<Device::MPS>::log(const T*, T*, dim_t);
+
+  MPS_DECLARE_FLOAT_IMPL(float)
+  MPS_DECLARE_FLOAT_IMPL(float16_t)
+  MPS_DECLARE_FLOAT_IMPL(bfloat16_t)
+
+}  // namespace ctranslate2
+#endif  // __APPLE__

--- a/src/mps/primitives.mm
+++ b/src/mps/primitives.mm
@@ -786,26 +786,25 @@ namespace ctranslate2 {
                                      float beta,
                                      bfloat16_t* c, dim_t ldc,
                                      const bfloat16_t*) {
-    (void)transpose_a;
-    (void)transpose_b;
-    (void)m;
-    (void)n;
-    (void)k;
-    (void)alpha;
-    (void)a;
-    (void)lda;
-    (void)b;
-    (void)ldb;
-    (void)beta;
-    (void)c;
-    (void)ldc;
-    throw std::invalid_argument(
-      "BF16 GEMM is not supported on MPS; load the model with compute_type=float16");
+    mps::gemm(DataType::BFLOAT16,
+              transpose_a,
+              transpose_b,
+              m,
+              n,
+              k,
+              alpha,
+              a,
+              lda,
+              b,
+              ldb,
+              beta,
+              c,
+              ldc);
   }
 
   template<>
   template<>
-  void primitives<Device::MPS>::gemm(bool, bool,
+  void primitives<Device::MPS>::gemm(bool a_is_packed, bool b_is_packed,
                                      bool transpose_a, bool transpose_b,
                                      dim_t m, dim_t n, dim_t k,
                                      float alpha,
@@ -814,23 +813,13 @@ namespace ctranslate2 {
                                      float beta,
                                      int32_t* c, dim_t ldc,
                                      const int32_t* a_shift_compensation) {
-    (void)transpose_a;
-    (void)transpose_b;
-    (void)m;
-    (void)n;
-    (void)k;
-    (void)alpha;
-    (void)a;
-    (void)lda;
-    (void)b;
-    (void)ldb;
-    (void)beta;
-    (void)c;
-    (void)ldc;
-    (void)a_shift_compensation;
-    // TODO: implement fused weight-only INT8/INT4 dequantization + GEMV/GEMM.
-    throw std::invalid_argument(
-      "INT8 GEMM is not supported on MPS; use float16 MPS or route the model to CPU");
+    if (a_is_packed || b_is_packed)
+      throw std::invalid_argument("Packed INT8 GEMM is not supported on MPS");
+    if (a_shift_compensation)
+      throw std::invalid_argument("Shifted-u8 INT8 GEMM is not supported on MPS");
+    mps::gemm_int8(transpose_a, transpose_b,
+                   m, n, k, alpha,
+                   a, lda, b, ldb, beta, c, ldc);
   }
 
   template<>
@@ -885,6 +874,47 @@ namespace ctranslate2 {
                               batch_size);
       return;
     }
+    if constexpr (std::is_same_v<In, Out> && std::is_same_v<In, bfloat16_t>) {
+      mps::gemm_batch_strided(DataType::BFLOAT16,
+                              transpose_a,
+                              transpose_b,
+                              m,
+                              n,
+                              k,
+                              alpha,
+                              a,
+                              lda,
+                              stridea,
+                              b,
+                              ldb,
+                              strideb,
+                              beta,
+                              c,
+                              ldc,
+                              stridec,
+                              batch_size);
+      return;
+    }
+    if constexpr (std::is_same_v<In, int8_t> && std::is_same_v<Out, int32_t>) {
+      mps::gemm_int8_batch_strided(transpose_a,
+                                   transpose_b,
+                                   m,
+                                   n,
+                                   k,
+                                   alpha,
+                                   a,
+                                   lda,
+                                   stridea,
+                                   b,
+                                   ldb,
+                                   strideb,
+                                   beta,
+                                   c,
+                                   ldc,
+                                   stridec,
+                                   batch_size);
+      return;
+    }
     for (dim_t i = 0; i < batch_size; ++i) {
       primitives<Device::MPS>::gemm(false, false,
                                     transpose_a, transpose_b,
@@ -923,7 +953,8 @@ namespace ctranslate2 {
   }
 
   // -------------------------
-  // Integer GEMM Stubs (not implemented on MPS)
+  // Same-type integer GEMM outputs are unsupported. Quantized MPS inference
+  // uses the signed INT8 -> INT32 overload implemented above.
   // -------------------------
 
   #define MPS_STUB_GEMM(T) \
@@ -975,6 +1006,12 @@ namespace ctranslate2 {
   template void cross_device_primitives<Device::MPS, Device::CPU>::copy<T>(const T*, T*, dim_t);
 
   DECLARE_ALL_TYPES(MPS_DECLARE_IMPL)
+
+  template void primitives<Device::MPS>::gemm_batch_strided<int8_t, int32_t>(
+    bool, bool, dim_t, dim_t, dim_t, float,
+    const int8_t*, dim_t, dim_t,
+    const int8_t*, dim_t, dim_t,
+    float, int32_t*, dim_t, dim_t, dim_t);
 
   // Float-math operations (float/float16/bfloat16 only)
 #define MPS_DECLARE_FLOAT_IMPL(T) \

--- a/src/mps/primitives.mm
+++ b/src/mps/primitives.mm
@@ -442,24 +442,13 @@ namespace ctranslate2 {
                                                     bool mask_future,
                                                     bool multi_query,
                                                     int32_t* mask) {
-    // This path is host-visible by design. The mask layout depends on whether
-    // queries or heads are the merged dimension, so keep the CPU reference
-    // mapping until every attention layout has a dedicated tested GPU kernel.
-    mps::synchronize("host attention mask");
-    for (dim_t b = 0; b < batch_size; ++b) {
-      const int32_t length = lengths[b];
-      int32_t* output = mask + b * num_heads * num_queries;
-      for (dim_t i = 0; i < num_heads * num_queries; ++i) {
-        if (mask_future) {
-          const int32_t query = multi_query
-                                ? static_cast<int32_t>(i / num_heads)
-                                : static_cast<int32_t>(i % num_queries);
-          output[i] = std::min<int32_t>(length, query + 1);
-        } else {
-          output[i] = length;
-        }
-      }
-    }
+    mps::prepare_length_mask(lengths,
+                             batch_size,
+                             num_heads,
+                             num_queries,
+                             mask_future,
+                             multi_query,
+                             mask);
   }
 
   template<>

--- a/src/mps/utils.h
+++ b/src/mps/utils.h
@@ -21,6 +21,9 @@ namespace ctranslate2 {
     void* get_command_queue();
     void* get_device();
     void* get_buffer(const void* ptr, size_t size, size_t* offset);
+    // Atomically looks up and retains a registered Metal buffer for command
+    // encoding. This closes the lookup-to-retain race with asynchronous frees.
+    void* get_buffer_for_use(const void* ptr, size_t size, size_t* offset);
     void record_metal_buffer_use(void* metal_buffer);
     void record_metal_object_use(void* metal_object);
     bool buffer_in_use(const void* ptr, size_t size);

--- a/src/mps/utils.h
+++ b/src/mps/utils.h
@@ -33,7 +33,7 @@ namespace ctranslate2 {
     void end_compute_encoder();
     void end_blit_encoder();
     void end_active_encoder();
-    void record_compute_dispatch();
+    void record_compute_dispatch(const char* kernel_name = nullptr);
     void record_blit_operation();
     void record_copy_bytes(size_t bytes);
 

--- a/src/mps/utils.h
+++ b/src/mps/utils.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#ifdef __APPLE__
+
+#include <cstddef>
+#include <cstdint>
+
+namespace ctranslate2 {
+  namespace mps {
+
+    bool has_mps();
+    int get_device_count();
+    int get_device_index();
+    void set_device_index(int index);
+    void flush();
+    void synchronize(const char* reason = nullptr, size_t bytes = 0);
+
+    void* allocate_buffer(size_t size);
+    void free_buffer(void* ptr);
+
+    void* get_command_queue();
+    void* get_device();
+    void* get_buffer(const void* ptr, size_t size, size_t* offset);
+    void record_metal_buffer_use(void* metal_buffer);
+    void record_metal_object_use(void* metal_object);
+    bool buffer_in_use(const void* ptr, size_t size);
+
+    // Objective-C objects are intentionally exposed as opaque pointers so this
+    // header remains usable from regular C++ translation units.
+    void* command_buffer();
+    void* compute_encoder();
+    void* blit_encoder();
+    void end_compute_encoder();
+    void end_blit_encoder();
+    void end_active_encoder();
+    void record_compute_dispatch();
+    void record_blit_operation();
+    void record_copy_bytes(size_t bytes);
+
+    enum class ProfileEvent : uint8_t {
+      Gemm,
+      Gemv,
+      CpuFallback,
+      TopKGpu,
+      TopKCpu,
+    };
+
+    bool profile_enabled();
+    void record_profile_event(ProfileEvent event);
+
+  }
+}
+
+#endif  // __APPLE__

--- a/src/mps/utils.h
+++ b/src/mps/utils.h
@@ -50,6 +50,7 @@ namespace ctranslate2 {
 
     bool profile_enabled();
     void record_profile_event(ProfileEvent event);
+    void record_profile_detail(const char* detail);
 
   }
 }

--- a/src/mps/utils.mm
+++ b/src/mps/utils.mm
@@ -1,0 +1,605 @@
+#ifdef __APPLE__
+
+#import <Metal/Metal.h>
+#import <Foundation/Foundation.h>
+
+#include <atomic>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "mps/utils.h"
+#include "mps/kernels.h"
+#include "ctranslate2/utils.h"
+
+namespace ctranslate2 {
+  namespace mps {
+
+    static id<MTLDevice> g_device = nil;
+    static id<MTLCommandQueue> g_queue = nil;
+    static int g_device_index = 0;
+    static std::mutex g_buffers_mutex;
+    static std::mutex g_error_mutex;
+    static std::string g_last_command_error;
+
+    struct BufferInfo {
+      id<MTLBuffer> buffer;
+      size_t size;
+    };
+
+    static std::map<uintptr_t, BufferInfo> g_buffers;
+    static std::mutex& inflight_mutex() {
+      // Completion handlers can run during process teardown. Leak these small
+      // registries intentionally so they always outlive thread-local streams.
+      static std::mutex* mutex = new std::mutex;
+      return *mutex;
+    }
+
+    static std::unordered_map<void*, size_t>& inflight_buffers() {
+      static auto* buffers = new std::unordered_map<void*, size_t>;
+      return *buffers;
+    }
+
+    static std::unordered_set<void*>& pending_buffer_frees() {
+      static auto* buffers = new std::unordered_set<void*>;
+      return *buffers;
+    }
+
+    static void destroy_buffer(void* ptr);
+
+    static std::shared_ptr<std::vector<void*>> mark_inflight(
+        std::unordered_set<void*>& active_buffers) {
+      auto resources = std::make_shared<std::vector<void*>>(active_buffers.begin(),
+                                                            active_buffers.end());
+      active_buffers.clear();
+      std::lock_guard<std::mutex> lock(inflight_mutex());
+      for (void* buffer : *resources)
+        ++inflight_buffers()[buffer];
+      return resources;
+    }
+
+    static void unmark_inflight(const std::shared_ptr<std::vector<void*>>& resources) {
+      std::vector<void*> buffers_to_destroy;
+      {
+        std::lock_guard<std::mutex> lock(inflight_mutex());
+        for (void* buffer : *resources) {
+          auto& buffers = inflight_buffers();
+          const auto found = buffers.find(buffer);
+          if (found != buffers.end() && --found->second == 0) {
+            buffers.erase(found);
+            if (pending_buffer_frees().erase(buffer) != 0)
+              buffers_to_destroy.emplace_back(buffer);
+          }
+          CFRelease(static_cast<CFTypeRef>(buffer));
+        }
+      }
+      for (void* buffer : buffers_to_destroy)
+        destroy_buffer(buffer);
+    }
+
+    struct ProfileCounters {
+      std::atomic<uint64_t> command_buffers_created{0};
+      std::atomic<uint64_t> command_buffers_committed{0};
+      std::atomic<uint64_t> compute_dispatches{0};
+      std::atomic<uint64_t> blit_operations{0};
+      std::atomic<uint64_t> synchronizations{0};
+      std::atomic<uint64_t> gemms{0};
+      std::atomic<uint64_t> gemvs{0};
+      std::atomic<uint64_t> cpu_fallbacks{0};
+      std::atomic<uint64_t> topk_gpu_calls{0};
+      std::atomic<uint64_t> topk_cpu_calls{0};
+      std::atomic<uint64_t> buffer_lookups{0};
+      std::atomic<uint64_t> buffer_lookup_comparisons{0};
+      std::atomic<uint64_t> allocations{0};
+      std::atomic<uint64_t> allocated_bytes{0};
+      std::atomic<uint64_t> copied_bytes{0};
+      std::atomic<uint64_t> gpu_time_ns{0};
+    };
+
+    static ProfileCounters g_profile;
+
+    static bool env_enabled(const char* name) {
+      const char* value = std::getenv(name);
+      return value && value[0] != '\0' && std::string(value) != "0";
+    }
+
+    bool profile_enabled() {
+      static const bool enabled = env_enabled("CT2_MPS_PROFILE");
+      return enabled;
+    }
+
+    static uint64_t operation_limit(const char* specific_name, uint64_t default_value) {
+      const char* legacy = std::getenv("CT2_MPS_MAX_OPS");
+      const char* specific = std::getenv(specific_name);
+      const char* env = specific && specific[0] != '\0' ? specific : legacy;
+      if (!env || env[0] == '\0')
+        return default_value;
+      errno = 0;
+      char* end = nullptr;
+      const unsigned long long parsed = std::strtoull(env, &end, 10);
+      if (errno != 0 || end == env || *end != '\0')
+        return default_value;
+      return static_cast<uint64_t>(parsed);
+    }
+
+    static uint64_t max_compute_operations() {
+      static const uint64_t value = []() {
+        // The M1 Marian trace reaches useful overlap at 16 compute dispatches;
+        // copy-only sequences are cheaper to encode and use a separate limit.
+        return operation_limit("CT2_MPS_MAX_COMPUTE_OPS", 16);
+      }();
+      return value;
+    }
+
+    static uint64_t max_blit_operations() {
+      static const uint64_t value = []() {
+        return operation_limit("CT2_MPS_MAX_BLIT_OPS", 64);
+      }();
+      return value;
+    }
+
+    static void print_profile() {
+      if (!profile_enabled())
+        return;
+      std::fprintf(stderr,
+                   "CT2 MPS profile: command_buffers_created=%llu "
+                   "command_buffers_committed=%llu compute_dispatches=%llu "
+                   "blit_operations=%llu synchronizations=%llu gemms=%llu "
+                   "gemvs=%llu cpu_fallbacks=%llu topk_gpu_calls=%llu "
+                   "topk_cpu_calls=%llu buffer_lookups=%llu "
+                   "buffer_lookup_comparisons=%llu allocations=%llu "
+                   "allocated_bytes=%llu copied_bytes=%llu gpu_time_ms=%.3f\n",
+                   static_cast<unsigned long long>(g_profile.command_buffers_created.load()),
+                   static_cast<unsigned long long>(g_profile.command_buffers_committed.load()),
+                   static_cast<unsigned long long>(g_profile.compute_dispatches.load()),
+                   static_cast<unsigned long long>(g_profile.blit_operations.load()),
+                   static_cast<unsigned long long>(g_profile.synchronizations.load()),
+                   static_cast<unsigned long long>(g_profile.gemms.load()),
+                   static_cast<unsigned long long>(g_profile.gemvs.load()),
+                   static_cast<unsigned long long>(g_profile.cpu_fallbacks.load()),
+                   static_cast<unsigned long long>(g_profile.topk_gpu_calls.load()),
+                   static_cast<unsigned long long>(g_profile.topk_cpu_calls.load()),
+                   static_cast<unsigned long long>(g_profile.buffer_lookups.load()),
+                   static_cast<unsigned long long>(g_profile.buffer_lookup_comparisons.load()),
+                   static_cast<unsigned long long>(g_profile.allocations.load()),
+                   static_cast<unsigned long long>(g_profile.allocated_bytes.load()),
+                   static_cast<unsigned long long>(g_profile.copied_bytes.load()),
+                   static_cast<double>(g_profile.gpu_time_ns.load()) / 1.0e6);
+    }
+
+    static void record_command_buffer_error(id<MTLCommandBuffer> command_buffer) {
+      if (!command_buffer || [command_buffer status] != MTLCommandBufferStatusError)
+        return;
+
+      std::string message = "MPS command buffer failed";
+      if ([command_buffer label])
+        message += " (" + std::string([[command_buffer label] UTF8String]) + ")";
+      if ([command_buffer error] && [[command_buffer error] localizedDescription])
+        message += ": " + std::string([[[command_buffer error] localizedDescription] UTF8String]);
+
+      std::lock_guard<std::mutex> lock(g_error_mutex);
+      if (g_last_command_error.empty())
+        g_last_command_error = std::move(message);
+    }
+
+    static void throw_last_command_error() {
+      std::string error;
+      {
+        std::lock_guard<std::mutex> lock(g_error_mutex);
+        error.swap(g_last_command_error);
+      }
+      if (!error.empty())
+        throw std::runtime_error(error);
+    }
+
+    static void ensure_initialized() {
+      static std::once_flag once;
+      std::call_once(once, []() {
+        g_device = MTLCreateSystemDefaultDevice();
+        if (g_device) {
+          g_queue = [g_device newCommandQueue];
+          if (profile_enabled())
+            std::atexit(print_profile);
+        }
+      });
+    }
+
+    class MPSStream {
+    public:
+      ~MPSStream() {
+        // A worker thread can finish with pending asynchronous work. Wait here
+        // so completion handlers cannot outlive process-wide Metal state during
+        // thread or process teardown. This is not on the inference hot path.
+        try {
+          synchronize();
+        } catch (...) {
+        }
+        if (_last_submitted)
+          [_last_submitted release];
+      }
+
+      id<MTLCommandBuffer> command_buffer() {
+        throw_last_command_error();
+        if (!_command_buffer) {
+          ensure_initialized();
+          if (!g_queue)
+            throw std::runtime_error("MPS command queue not available");
+          _command_buffer = [[g_queue commandBuffer] retain];
+          if (!_command_buffer)
+            throw std::runtime_error("MPS command buffer creation failed");
+          if (profile_enabled())
+            ++g_profile.command_buffers_created;
+        }
+        return _command_buffer;
+      }
+
+      id<MTLComputeCommandEncoder> compute_encoder() {
+        if (_blit_encoder)
+          end_blit_encoder();
+        if (!_compute_encoder) {
+          _compute_encoder = [[command_buffer() computeCommandEncoder] retain];
+          if (!_compute_encoder)
+            throw std::runtime_error("MPS compute encoder creation failed");
+        }
+        return _compute_encoder;
+      }
+
+      id<MTLBlitCommandEncoder> blit_encoder() {
+        if (_compute_encoder)
+          end_compute_encoder();
+        if (!_blit_encoder) {
+          _blit_encoder = [[command_buffer() blitCommandEncoder] retain];
+          if (!_blit_encoder)
+            throw std::runtime_error("MPS blit encoder creation failed");
+        }
+        return _blit_encoder;
+      }
+
+      void end_compute_encoder() {
+        if (_compute_encoder) {
+          [_compute_encoder endEncoding];
+          [_compute_encoder release];
+          _compute_encoder = nil;
+        }
+      }
+
+      void end_blit_encoder() {
+        if (_blit_encoder) {
+          [_blit_encoder endEncoding];
+          [_blit_encoder release];
+          _blit_encoder = nil;
+        }
+      }
+
+      void end_active_encoder() {
+        end_compute_encoder();
+        end_blit_encoder();
+      }
+
+      void record_operation(bool compute) {
+        if (compute)
+          ++_compute_operations;
+        else
+          ++_blit_operations;
+        const uint64_t limit = compute ? max_compute_operations() : max_blit_operations();
+        const uint64_t count = compute ? _compute_operations : _blit_operations;
+        if (limit != 0 && count >= limit)
+          flush();
+      }
+
+      void record_buffer(void* buffer) {
+        if (buffer && _active_buffers.insert(buffer).second) {
+          // StorageView temporaries may be destroyed before this command
+          // buffer is committed. Metal command encoding alone does not give
+          // the registry ownership, so retain each resource until the GPU
+          // completion handler has run.
+          CFRetain(static_cast<CFTypeRef>(buffer));
+        }
+      }
+
+      bool has_active_buffer(void* buffer) const {
+        return _active_buffers.find(buffer) != _active_buffers.end();
+      }
+
+      void flush() {
+        end_active_encoder();
+        if (!_command_buffer)
+          return;
+        id<MTLCommandBuffer> submitted = _command_buffer;
+        _command_buffer = nil;
+        _compute_operations = 0;
+        _blit_operations = 0;
+        auto resources = mark_inflight(_active_buffers);
+        if (_last_submitted)
+          [_last_submitted release];
+        _last_submitted = submitted;
+        [submitted addCompletedHandler:^(id<MTLCommandBuffer> completed_buffer) {
+          record_command_buffer_error(completed_buffer);
+          if (profile_enabled()
+              && completed_buffer.GPUStartTime > 0
+              && completed_buffer.GPUEndTime >= completed_buffer.GPUStartTime) {
+            const double duration = completed_buffer.GPUEndTime - completed_buffer.GPUStartTime;
+            g_profile.gpu_time_ns.fetch_add(static_cast<uint64_t>(duration * 1.0e9));
+          }
+          unmark_inflight(resources);
+        }];
+        [submitted commit];
+        if (profile_enabled())
+          ++g_profile.command_buffers_committed;
+      }
+
+      void synchronize() {
+        end_active_encoder();
+        id<MTLCommandBuffer> submitted = _command_buffer;
+        std::shared_ptr<std::vector<void*>> resources;
+        if (submitted) {
+          _command_buffer = nil;
+          _compute_operations = 0;
+          _blit_operations = 0;
+          resources = mark_inflight(_active_buffers);
+          if (_last_submitted) {
+            [_last_submitted release];
+            _last_submitted = nil;
+          }
+          [submitted commit];
+          if (profile_enabled())
+            ++g_profile.command_buffers_committed;
+        } else {
+          submitted = _last_submitted;
+          _last_submitted = nil;
+        }
+        if (!submitted) {
+          throw_last_command_error();
+          return;
+        }
+        if (profile_enabled())
+          ++g_profile.synchronizations;
+        [submitted waitUntilCompleted];
+        if (resources)
+          unmark_inflight(resources);
+        record_command_buffer_error(submitted);
+        [submitted release];
+        throw_last_command_error();
+      }
+
+    private:
+      id<MTLCommandBuffer> _command_buffer = nil;
+      id<MTLCommandBuffer> _last_submitted = nil;
+      id<MTLComputeCommandEncoder> _compute_encoder = nil;
+      id<MTLBlitCommandEncoder> _blit_encoder = nil;
+      uint64_t _compute_operations = 0;
+      uint64_t _blit_operations = 0;
+      std::unordered_set<void*> _active_buffers;
+    };
+
+    static MPSStream& current_stream() {
+      static thread_local MPSStream stream;
+      return stream;
+    }
+
+    bool has_mps() {
+      ensure_initialized();
+      return g_device != nil;
+    }
+
+    int get_device_count() {
+      if (!has_mps())
+        return 0;
+      return 1;
+    }
+
+    int get_device_index() {
+      return g_device_index;
+    }
+
+    void set_device_index(int index) {
+      if (index != 0)
+        THROW_INVALID_ARGUMENT("MPS device index must be 0 (single device only)");
+      g_device_index = index;
+    }
+
+    void flush() {
+      if (!has_mps())
+        return;
+      current_stream().flush();
+    }
+
+    void synchronize(const char* reason, size_t bytes) {
+      if (!has_mps())
+        return;
+      if (env_enabled("CT2_MPS_LOG_SYNC"))
+        std::fprintf(stderr,
+                     "CT2 MPS synchronize reason=%s bytes=%zu\n",
+                     reason ? reason : "explicit",
+                     bytes);
+      current_stream().synchronize();
+    }
+
+    void* allocate_buffer(size_t size) {
+      if (!has_mps())
+        throw std::runtime_error("MPS device not available");
+      id<MTLBuffer> buf = [g_device newBufferWithLength:size
+                                               options:MTLResourceStorageModeShared];
+      if (!buf)
+        throw std::runtime_error("MPS buffer allocation failed");
+      if (profile_enabled()) {
+        ++g_profile.allocations;
+        g_profile.allocated_bytes.fetch_add(size);
+      }
+      {
+        std::lock_guard<std::mutex> lock(g_buffers_mutex);
+        g_buffers[reinterpret_cast<uintptr_t>([buf contents])] = BufferInfo{buf, size};
+      }
+      return (__bridge void*)buf;
+    }
+
+    static void destroy_buffer(void* ptr) {
+      id<MTLBuffer> buf = (__bridge id<MTLBuffer>)ptr;
+      invalidate_packed_weight_cache(ptr);
+      {
+        std::lock_guard<std::mutex> lock(g_buffers_mutex);
+        g_buffers.erase(reinterpret_cast<uintptr_t>([buf contents]));
+      }
+#if __has_feature(objc_arc)
+      (void)CFBridgingRelease(ptr);
+#else
+      [buf release];
+#endif
+      (void)buf;
+    }
+
+    void free_buffer(void* ptr) {
+      if (!ptr)
+        return;
+
+      const bool active = current_stream().has_active_buffer(ptr);
+      if (active)
+        current_stream().flush();
+      bool defer = active;
+      {
+        std::lock_guard<std::mutex> lock(inflight_mutex());
+        if (inflight_buffers().find(ptr) != inflight_buffers().end())
+          defer = true;
+        if (defer)
+          pending_buffer_frees().insert(ptr);
+      }
+      if (!defer)
+        destroy_buffer(ptr);
+    }
+
+    void* get_command_queue() {
+      if (!has_mps())
+        return nullptr;
+      return (__bridge void*)g_queue;
+    }
+
+    void* get_device() {
+      if (!has_mps())
+        return nullptr;
+      return (__bridge void*)g_device;
+    }
+
+    void* get_buffer(const void* ptr, size_t size, size_t* offset) {
+      if (!ptr)
+        return nullptr;
+
+      const auto address = reinterpret_cast<uintptr_t>(ptr);
+      if (size > std::numeric_limits<uintptr_t>::max() - address)
+        return nullptr;
+      const auto requested_end = address + size;
+      if (profile_enabled())
+        ++g_profile.buffer_lookups;
+      std::lock_guard<std::mutex> lock(g_buffers_mutex);
+      auto it = g_buffers.upper_bound(address);
+      if (it == g_buffers.begin())
+        return nullptr;
+      --it;
+      if (profile_enabled())
+        ++g_profile.buffer_lookup_comparisons;
+      const uintptr_t base = it->first;
+      if (it->second.size > std::numeric_limits<uintptr_t>::max() - base)
+        return nullptr;
+      const uintptr_t allocation_end = base + it->second.size;
+      if (address >= base && requested_end <= allocation_end) {
+        if (offset)
+          *offset = static_cast<size_t>(address - base);
+        return (__bridge void*)it->second.buffer;
+      }
+      return nullptr;
+    }
+
+    void record_metal_buffer_use(void* metal_buffer) {
+      current_stream().record_buffer(metal_buffer);
+    }
+
+    void record_metal_object_use(void* metal_object) {
+      current_stream().record_buffer(metal_object);
+    }
+
+    bool buffer_in_use(const void* ptr, size_t size) {
+      size_t offset = 0;
+      void* buffer = get_buffer(ptr, size, &offset);
+      if (!buffer)
+        return false;
+      if (current_stream().has_active_buffer(buffer))
+        return true;
+      std::lock_guard<std::mutex> lock(inflight_mutex());
+      const auto& buffers = inflight_buffers();
+      return buffers.find(buffer) != buffers.end();
+    }
+
+    void* command_buffer() {
+      return (__bridge void*)current_stream().command_buffer();
+    }
+
+    void* compute_encoder() {
+      return (__bridge void*)current_stream().compute_encoder();
+    }
+
+    void* blit_encoder() {
+      return (__bridge void*)current_stream().blit_encoder();
+    }
+
+    void end_compute_encoder() {
+      current_stream().end_compute_encoder();
+    }
+
+    void end_blit_encoder() {
+      current_stream().end_blit_encoder();
+    }
+
+    void end_active_encoder() {
+      current_stream().end_active_encoder();
+    }
+
+    void record_compute_dispatch() {
+      if (profile_enabled())
+        ++g_profile.compute_dispatches;
+      current_stream().record_operation(true);
+    }
+
+    void record_blit_operation() {
+      if (profile_enabled())
+        ++g_profile.blit_operations;
+      current_stream().record_operation(false);
+    }
+
+    void record_copy_bytes(size_t bytes) {
+      if (profile_enabled())
+        g_profile.copied_bytes.fetch_add(bytes);
+    }
+
+    void record_profile_event(ProfileEvent event) {
+      if (!profile_enabled())
+        return;
+      switch (event) {
+      case ProfileEvent::Gemm:
+        ++g_profile.gemms;
+        break;
+      case ProfileEvent::Gemv:
+        ++g_profile.gemvs;
+        break;
+      case ProfileEvent::CpuFallback:
+        ++g_profile.cpu_fallbacks;
+        break;
+      case ProfileEvent::TopKGpu:
+        ++g_profile.topk_gpu_calls;
+        break;
+      case ProfileEvent::TopKCpu:
+        ++g_profile.topk_cpu_calls;
+        break;
+      }
+    }
+
+  }
+}
+
+#endif  // __APPLE__

--- a/src/mps/utils.mm
+++ b/src/mps/utils.mm
@@ -49,6 +49,11 @@ namespace ctranslate2 {
       return *buffers;
     }
 
+    static std::unordered_map<void*, size_t>& globally_active_buffers() {
+      static auto* buffers = new std::unordered_map<void*, size_t>;
+      return *buffers;
+    }
+
     static std::unordered_set<void*>& pending_buffer_frees() {
       static auto* buffers = new std::unordered_set<void*>;
       return *buffers;
@@ -62,8 +67,15 @@ namespace ctranslate2 {
                                                             active_buffers.end());
       active_buffers.clear();
       std::lock_guard<std::mutex> lock(inflight_mutex());
-      for (void* buffer : *resources)
+      for (void* buffer : *resources) {
+        auto& active = globally_active_buffers();
+        const auto active_it = active.find(buffer);
+        if (active_it != active.end()) {
+          if (--active_it->second == 0)
+            active.erase(active_it);
+        }
         ++inflight_buffers()[buffer];
+      }
       return resources;
     }
 
@@ -76,12 +88,14 @@ namespace ctranslate2 {
           const auto found = buffers.find(buffer);
           if (found != buffers.end() && --found->second == 0) {
             buffers.erase(found);
-            if (pending_buffer_frees().erase(buffer) != 0)
+            if (globally_active_buffers().find(buffer) == globally_active_buffers().end()
+                && pending_buffer_frees().erase(buffer) != 0)
               buffers_to_destroy.emplace_back(buffer);
           }
-          CFRelease(static_cast<CFTypeRef>(buffer));
         }
       }
+      for (void* buffer : *resources)
+        CFRelease(static_cast<CFTypeRef>(buffer));
       for (void* buffer : buffers_to_destroy)
         destroy_buffer(buffer);
     }
@@ -119,10 +133,7 @@ namespace ctranslate2 {
       return enabled;
     }
 
-    static uint64_t operation_limit(const char* specific_name, uint64_t default_value) {
-      const char* legacy = std::getenv("CT2_MPS_MAX_OPS");
-      const char* specific = std::getenv(specific_name);
-      const char* env = specific && specific[0] != '\0' ? specific : legacy;
+    static uint64_t parse_operation_limit(const char* env, uint64_t default_value) {
       if (!env || env[0] == '\0')
         return default_value;
       errno = 0;
@@ -131,6 +142,13 @@ namespace ctranslate2 {
       if (errno != 0 || end == env || *end != '\0')
         return default_value;
       return static_cast<uint64_t>(parsed);
+    }
+
+    static uint64_t operation_limit(const char* specific_name, uint64_t default_value) {
+      const char* legacy = std::getenv("CT2_MPS_MAX_OPS");
+      const char* specific = std::getenv(specific_name);
+      const char* env = specific && specific[0] != '\0' ? specific : legacy;
+      return parse_operation_limit(env, default_value);
     }
 
     static uint64_t max_compute_operations() {
@@ -145,6 +163,24 @@ namespace ctranslate2 {
     static uint64_t max_blit_operations() {
       static const uint64_t value = []() {
         return operation_limit("CT2_MPS_MAX_BLIT_OPS", 64);
+      }();
+      return value;
+    }
+
+    static NSUInteger max_inflight_command_buffers() {
+      static const NSUInteger value = []() {
+        // An unbounded queue lets a fast CPU encoder submit thousands of tiny
+        // command buffers while the GPU is busy. Each submitted buffer keeps
+        // its temporary tensors alive until completion, which is especially
+        // dangerous on unified-memory systems. Eight preserves useful overlap
+        // while applying backpressure before memory pressure becomes extreme;
+        // higher values corrupted cold Whisper encoders on an 8 GB M1.
+        // CT2_MPS_MAX_OPS is intentionally not consulted here: that legacy
+        // variable controls dispatch batching, not the number of resident
+        // Metal command buffers.
+        const uint64_t configured = parse_operation_limit(
+          std::getenv("CT2_MPS_MAX_INFLIGHT_COMMAND_BUFFERS"), 8);
+        return static_cast<NSUInteger>(std::max<uint64_t>(1, configured));
       }();
       return value;
     }
@@ -221,7 +257,8 @@ namespace ctranslate2 {
       std::call_once(once, []() {
         g_device = MTLCreateSystemDefaultDevice();
         if (g_device) {
-          g_queue = [g_device newCommandQueue];
+          g_queue = [g_device
+            newCommandQueueWithMaxCommandBufferCount:max_inflight_command_buffers()];
           if (profile_enabled())
             std::atexit(print_profile);
         }
@@ -248,7 +285,15 @@ namespace ctranslate2 {
           ensure_initialized();
           if (!g_queue)
             throw std::runtime_error("MPS command queue not available");
-          _command_buffer = [[g_queue commandBuffer] retain];
+          // CTranslate2 workers are plain C++ threads and do not have Cocoa's
+          // run-loop autorelease pool. Retain the command buffer explicitly,
+          // then drain only the temporary factory ownership immediately. A
+          // pool spanning the whole inference kept thousands of completed
+          // command buffers alive until the first host read and could exhaust
+          // unified memory during a cold Whisper encoder.
+          @autoreleasepool {
+            _command_buffer = [[g_queue commandBuffer] retain];
+          }
           if (!_command_buffer)
             throw std::runtime_error("MPS command buffer creation failed");
           if (profile_enabled())
@@ -261,7 +306,9 @@ namespace ctranslate2 {
         if (_blit_encoder)
           end_blit_encoder();
         if (!_compute_encoder) {
-          _compute_encoder = [[command_buffer() computeCommandEncoder] retain];
+          @autoreleasepool {
+            _compute_encoder = [[command_buffer() computeCommandEncoder] retain];
+          }
           if (!_compute_encoder)
             throw std::runtime_error("MPS compute encoder creation failed");
         }
@@ -272,7 +319,9 @@ namespace ctranslate2 {
         if (_compute_encoder)
           end_compute_encoder();
         if (!_blit_encoder) {
-          _blit_encoder = [[command_buffer() blitCommandEncoder] retain];
+          @autoreleasepool {
+            _blit_encoder = [[command_buffer() blitCommandEncoder] retain];
+          }
           if (!_blit_encoder)
             throw std::runtime_error("MPS blit encoder creation failed");
         }
@@ -318,6 +367,8 @@ namespace ctranslate2 {
           // the registry ownership, so retain each resource until the GPU
           // completion handler has run.
           CFRetain(static_cast<CFTypeRef>(buffer));
+          std::lock_guard<std::mutex> lock(inflight_mutex());
+          ++globally_active_buffers()[buffer];
         }
       }
 
@@ -338,14 +389,16 @@ namespace ctranslate2 {
           [_last_submitted release];
         _last_submitted = submitted;
         [submitted addCompletedHandler:^(id<MTLCommandBuffer> completed_buffer) {
-          record_command_buffer_error(completed_buffer);
-          if (profile_enabled()
-              && completed_buffer.GPUStartTime > 0
-              && completed_buffer.GPUEndTime >= completed_buffer.GPUStartTime) {
-            const double duration = completed_buffer.GPUEndTime - completed_buffer.GPUStartTime;
-            g_profile.gpu_time_ns.fetch_add(static_cast<uint64_t>(duration * 1.0e9));
+          @autoreleasepool {
+            record_command_buffer_error(completed_buffer);
+            if (profile_enabled()
+                && completed_buffer.GPUStartTime > 0
+                && completed_buffer.GPUEndTime >= completed_buffer.GPUStartTime) {
+              const double duration = completed_buffer.GPUEndTime - completed_buffer.GPUStartTime;
+              g_profile.gpu_time_ns.fetch_add(static_cast<uint64_t>(duration * 1.0e9));
+            }
+            unmark_inflight(resources);
           }
-          unmark_inflight(resources);
         }];
         [submitted commit];
         if (profile_enabled())
@@ -477,17 +530,28 @@ namespace ctranslate2 {
       if (!ptr)
         return;
 
-      const bool active = current_stream().has_active_buffer(ptr);
-      if (active)
-        current_stream().flush();
-      bool defer = active;
+      const bool active_on_current_stream = current_stream().has_active_buffer(ptr);
+      bool defer = false;
       {
         std::lock_guard<std::mutex> lock(inflight_mutex());
-        if (inflight_buffers().find(ptr) != inflight_buffers().end())
-          defer = true;
+        // Register the pending free under the same mutex used by stream
+        // submission and completion. Previously this function flushed first;
+        // a fast command buffer could complete before the pending marker was
+        // inserted, leaking the MTLBuffer and its registry entry forever.
+        // The global active map also makes cross-thread StorageView destruction
+        // safe without forcing a command-buffer commit for every temporary.
+        defer = globally_active_buffers().find(ptr) != globally_active_buffers().end()
+                || inflight_buffers().find(ptr) != inflight_buffers().end();
         if (defer)
           pending_buffer_frees().insert(ptr);
       }
+      // Keep the conservative commit for a temporary owned by this stream.
+      // Some CTranslate2 paths directly reuse shared-memory views at lifetime
+      // boundaries, so merely retaining the MTLBuffer is insufficient. The
+      // pending marker is deliberately installed before this flush to prevent
+      // the lost-completion leak described above.
+      if (active_on_current_stream)
+        current_stream().flush();
       if (!defer)
         destroy_buffer(ptr);
     }
@@ -504,7 +568,10 @@ namespace ctranslate2 {
       return (__bridge void*)g_device;
     }
 
-    void* get_buffer(const void* ptr, size_t size, size_t* offset) {
+    static void* lookup_buffer(const void* ptr,
+                               size_t size,
+                               size_t* offset,
+                               bool record_use) {
       if (!ptr)
         return nullptr;
 
@@ -528,9 +595,20 @@ namespace ctranslate2 {
       if (address >= base && requested_end <= allocation_end) {
         if (offset)
           *offset = static_cast<size_t>(address - base);
-        return (__bridge void*)it->second.buffer;
+        void* buffer = (__bridge void*)it->second.buffer;
+        if (record_use)
+          current_stream().record_buffer(buffer);
+        return buffer;
       }
       return nullptr;
+    }
+
+    void* get_buffer(const void* ptr, size_t size, size_t* offset) {
+      return lookup_buffer(ptr, size, offset, false);
+    }
+
+    void* get_buffer_for_use(const void* ptr, size_t size, size_t* offset) {
+      return lookup_buffer(ptr, size, offset, true);
     }
 
     void record_metal_buffer_use(void* metal_buffer) {

--- a/src/mps/utils.mm
+++ b/src/mps/utils.mm
@@ -3,6 +3,7 @@
 #import <Metal/Metal.h>
 #import <Foundation/Foundation.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cerrno>
 #include <cstdio>
@@ -105,6 +106,8 @@ namespace ctranslate2 {
     };
 
     static ProfileCounters g_profile;
+    static std::mutex g_kernel_profile_mutex;
+    static std::unordered_map<std::string, uint64_t> g_kernel_dispatches;
 
     static bool env_enabled(const char* name) {
       const char* value = std::getenv(name);
@@ -173,6 +176,19 @@ namespace ctranslate2 {
                    static_cast<unsigned long long>(g_profile.allocated_bytes.load()),
                    static_cast<unsigned long long>(g_profile.copied_bytes.load()),
                    static_cast<double>(g_profile.gpu_time_ns.load()) / 1.0e6);
+      std::vector<std::pair<std::string, uint64_t>> kernels;
+      {
+        std::lock_guard<std::mutex> lock(g_kernel_profile_mutex);
+        kernels.assign(g_kernel_dispatches.begin(), g_kernel_dispatches.end());
+      }
+      std::sort(kernels.begin(), kernels.end(), [](const auto& left, const auto& right) {
+        return left.second > right.second;
+      });
+      for (const auto& kernel : kernels)
+        std::fprintf(stderr,
+                     "CT2 MPS kernel: name=%s dispatches=%llu\n",
+                     kernel.first.c_str(),
+                     static_cast<unsigned long long>(kernel.second));
     }
 
     static void record_command_buffer_error(id<MTLCommandBuffer> command_buffer) {
@@ -426,6 +442,7 @@ namespace ctranslate2 {
     void* allocate_buffer(size_t size) {
       if (!has_mps())
         throw std::runtime_error("MPS device not available");
+
       id<MTLBuffer> buf = [g_device newBufferWithLength:size
                                                options:MTLResourceStorageModeShared];
       if (!buf)
@@ -560,9 +577,12 @@ namespace ctranslate2 {
       current_stream().end_active_encoder();
     }
 
-    void record_compute_dispatch() {
-      if (profile_enabled())
+    void record_compute_dispatch(const char* kernel_name) {
+      if (profile_enabled()) {
         ++g_profile.compute_dispatches;
+        std::lock_guard<std::mutex> lock(g_kernel_profile_mutex);
+        ++g_kernel_dispatches[kernel_name ? kernel_name : "unknown"];
+      }
       current_stream().record_operation(true);
     }
 

--- a/src/mps/utils.mm
+++ b/src/mps/utils.mm
@@ -122,6 +122,7 @@ namespace ctranslate2 {
     static ProfileCounters g_profile;
     static std::mutex g_kernel_profile_mutex;
     static std::unordered_map<std::string, uint64_t> g_kernel_dispatches;
+    static std::unordered_map<std::string, uint64_t> g_profile_details;
 
     static bool env_enabled(const char* name) {
       const char* value = std::getenv(name);
@@ -225,6 +226,19 @@ namespace ctranslate2 {
                      "CT2 MPS kernel: name=%s dispatches=%llu\n",
                      kernel.first.c_str(),
                      static_cast<unsigned long long>(kernel.second));
+      std::vector<std::pair<std::string, uint64_t>> details;
+      {
+        std::lock_guard<std::mutex> lock(g_kernel_profile_mutex);
+        details.assign(g_profile_details.begin(), g_profile_details.end());
+      }
+      std::sort(details.begin(), details.end(), [](const auto& left, const auto& right) {
+        return left.second > right.second;
+      });
+      for (const auto& detail : details)
+        std::fprintf(stderr,
+                     "CT2 MPS detail: %s calls=%llu\n",
+                     detail.first.c_str(),
+                     static_cast<unsigned long long>(detail.second));
     }
 
     static void record_command_buffer_error(id<MTLCommandBuffer> command_buffer) {
@@ -545,11 +559,10 @@ namespace ctranslate2 {
         if (defer)
           pending_buffer_frees().insert(ptr);
       }
-      // Keep the conservative commit for a temporary owned by this stream.
-      // Some CTranslate2 paths directly reuse shared-memory views at lifetime
-      // boundaries, so merely retaining the MTLBuffer is insufficient. The
-      // pending marker is deliberately installed before this flush to prevent
-      // the lost-completion leak described above.
+      // Some CTranslate2 paths recycle shared-memory views at StorageView
+      // lifetime boundaries. Retaining the MTLBuffer prevents destruction but
+      // does not prevent a CPU-visible alias from being reused. Commit before
+      // releasing an active allocation so later work cannot race that reuse.
       if (active_on_current_stream)
         current_stream().flush();
       if (!defer)
@@ -695,6 +708,13 @@ namespace ctranslate2 {
         ++g_profile.topk_cpu_calls;
         break;
       }
+    }
+
+    void record_profile_detail(const char* detail) {
+      if (!profile_enabled() || !detail)
+        return;
+      std::lock_guard<std::mutex> lock(g_kernel_profile_mutex);
+      ++g_profile_details[detail];
     }
 
   }

--- a/src/ops/conv1d_mps.mm
+++ b/src/ops/conv1d_mps.mm
@@ -1,5 +1,7 @@
 #include "ctranslate2/ops/conv1d.h"
+#include "ctranslate2/ops/dequantize.h"
 #include "ctranslate2/ops/gemm.h"
+#include "ctranslate2/ops/quantize.h"
 #include "mps/kernels.h"
 #include "type_dispatch.h"
 
@@ -53,9 +55,6 @@ void Conv1D::compute(const StorageView& input,
                      const StorageView* bias,
                      StorageView& output,
                      const StorageView* qscale) const {
-  if (qscale)
-    throw std::runtime_error("Quantized Conv1D not supported on MPS");
-
   const dim_t batch_size = input.dim(0);
   const dim_t in_channels = input.dim(1);
   const dim_t input_length = input.dim(2);
@@ -73,7 +72,6 @@ void Conv1D::compute(const StorageView& input,
       Device::MPS);
 
   const T* x = input.data<T>();
-  const T* w = weight.data<T>();
   T* o = output.data<T>();
   T* col = col_buffer.data<T>();
 
@@ -98,6 +96,85 @@ void Conv1D::compute(const StorageView& input,
   const dim_t stridew = out_channels_per_group * k;
   const dim_t stridec = output_length * out_channels_per_group;
   const dim_t stridecol = output_length * k;
+
+  if (qscale) {
+    if (weight.dtype() != DataType::INT8)
+      throw std::invalid_argument("Quantized MPS Conv1D expects INT8 weights");
+    if (qscale->dtype() != DataType::FLOAT32)
+      throw std::invalid_argument("Quantized MPS Conv1D expects FLOAT32 scales");
+    if (!qscale->is_scalar() && qscale->size() != out_channels)
+      throw std::invalid_argument(
+          "Quantized MPS Conv1D expects one scale per output channel");
+
+    // Quantization scales loaded from a model are typically CPU-resident.  Keep a
+    // device copy alive for the duration of the asynchronously encoded kernels
+    // instead of presenting a host pointer as if it belonged to an MTLBuffer.
+    StorageView device_qscale;
+    if (qscale->device() != Device::MPS)
+      device_qscale = qscale->to(Device::MPS);
+    const StorageView& mps_qscale = device_qscale ? device_qscale : *qscale;
+
+    StorageView quantized_col(col_buffer.shape(), DataType::INT8, Device::MPS);
+    StorageView col_scale(DataType::FLOAT32, Device::MPS);
+    Quantize()(col_buffer, quantized_col, col_scale);
+    StorageView quantized_output(output.shape(), DataType::INT32, Device::MPS);
+
+    const int8_t* w = weight.data<int8_t>();
+    const int8_t* qcol = quantized_col.data<int8_t>();
+    int32_t* qout = quantized_output.data<int32_t>();
+
+    for (dim_t g = 0; g < _groups; ++g) {
+      primitives<Device::MPS>::gemm_batch_strided<int8_t, int32_t>(
+          false, true,
+          out_channels_per_group, output_length, k,
+          1.0f,
+          w + g * stridew, k, 0,
+          qcol + g * stridecol, k, _groups * stridecol,
+          0.0f,
+          qout + g * stridec, output_length, _groups * stridec,
+          batch_size);
+    }
+
+    const dim_t batch_output_stride = _groups * stridec;
+    const dim_t qscale_stride = mps_qscale.is_scalar()
+                                ? 0
+                                : mps_qscale.size() / _groups;
+    for (dim_t b = 0; b < batch_size; ++b) {
+      for (dim_t g = 0; g < _groups; ++g) {
+        StorageView c_view(DataType::INT32, Device::MPS);
+        c_view.view(qout + b * batch_output_stride + g * stridec,
+                    {out_channels_per_group, output_length});
+
+        StorageView weight_scale(DataType::FLOAT32, Device::MPS);
+        weight_scale.view(const_cast<float*>(mps_qscale.data<float>())
+                            + (qscale_stride == 0 ? 0 : g * qscale_stride),
+                          mps_qscale.is_scalar() ? Shape{} : Shape{out_channels_per_group});
+
+        StorageView input_scale(DataType::FLOAT32, Device::MPS);
+        input_scale.view(col_scale.data<float>()
+                           + (b * _groups + g) * output_length,
+                         {output_length});
+
+        StorageView output_view(input.dtype(), Device::MPS);
+        output_view.view(o + b * batch_output_stride + g * stridec,
+                         {out_channels_per_group, output_length});
+
+        Dequantize()(c_view,
+                     weight_scale,
+                     input_scale,
+                     false,
+                     true,
+                     output_view);
+      }
+    }
+
+    apply_bias_and_activation(output, bias, _activation_type,
+                              /*residual=*/nullptr,
+                              /*axis=*/-2);
+    return;
+  }
+
+  const T* w = weight.data<T>();
 
   for (dim_t g = 0; g < _groups; ++g) {
     primitives<Device::MPS>::gemm_batch_strided(

--- a/src/ops/conv1d_mps.mm
+++ b/src/ops/conv1d_mps.mm
@@ -1,0 +1,132 @@
+#include "ctranslate2/ops/conv1d.h"
+#include "ctranslate2/ops/gemm.h"
+#include "mps/kernels.h"
+#include "type_dispatch.h"
+
+namespace ctranslate2 {
+namespace ops {
+
+template <typename T>
+static void im2col_transposed_mps(const T* input,
+                                  T* output,
+                                  dim_t batch_size,
+                                  dim_t in_channels,
+                                  dim_t input_length,
+                                  dim_t kernel_size,
+                                  dim_t stride,
+                                  dim_t padding,
+                                  dim_t dilation,
+                                  dim_t groups,
+                                  dim_t output_length,
+                                  dim_t k,
+                                  dim_t in_batch_stride,
+                                  dim_t in_group_stride) {
+  for (dim_t b = 0; b < batch_size; ++b) {
+    for (dim_t g = 0; g < groups; ++g) {
+      for (dim_t t = 0; t < output_length; ++t) {
+        const dim_t base_t = t * stride - padding;
+        for (dim_t c = 0; c < k; ++c) {
+          const dim_t c_offset = c / kernel_size;
+          const dim_t k_offset = c % kernel_size;
+          const dim_t in_t = base_t + dilation * k_offset;
+
+          const dim_t input_idx =
+              b * in_batch_stride +
+              g * in_group_stride +
+              c_offset * input_length +
+              in_t;
+
+          const dim_t out_idx =
+              ((b * groups + g) * output_length + t) * k + c;
+
+          output[out_idx] =
+              (in_t >= 0 && in_t < input_length) ? input[input_idx] : T(0);
+        }
+      }
+    }
+  }
+}
+
+template <Device D, typename T>
+void Conv1D::compute(const StorageView& input,
+                     const StorageView& weight,
+                     const StorageView* bias,
+                     StorageView& output,
+                     const StorageView* qscale) const {
+  if (qscale)
+    throw std::runtime_error("Quantized Conv1D not supported on MPS");
+
+  const dim_t batch_size = input.dim(0);
+  const dim_t in_channels = input.dim(1);
+  const dim_t input_length = input.dim(2);
+  const dim_t out_channels = weight.dim(0);
+  const dim_t kernel_size = weight.dim(2);
+  const dim_t output_length = output.dim(2);
+
+  const dim_t in_channels_per_group = in_channels / _groups;
+  const dim_t out_channels_per_group = out_channels / _groups;
+  const dim_t k = in_channels_per_group * kernel_size;
+
+  StorageView col_buffer(
+      {batch_size, _groups, output_length, k},
+      input.dtype(),
+      Device::MPS);
+
+  const T* x = input.data<T>();
+  const T* w = weight.data<T>();
+  T* o = output.data<T>();
+  T* col = col_buffer.data<T>();
+
+  const dim_t in_batch_stride = in_channels * input_length;
+  const dim_t in_group_stride = in_batch_stride / _groups;
+
+  mps::im2col_conv1d(input.dtype(),
+                     x,
+                     col,
+                     batch_size,
+                     _groups,
+                     input_length,
+                     kernel_size,
+                     _stride,
+                     _padding,
+                     _dilation,
+                     output_length,
+                     k,
+                     in_batch_stride,
+                     in_group_stride);
+
+  const dim_t stridew = out_channels_per_group * k;
+  const dim_t stridec = output_length * out_channels_per_group;
+  const dim_t stridecol = output_length * k;
+
+  for (dim_t g = 0; g < _groups; ++g) {
+    primitives<Device::MPS>::gemm_batch_strided(
+        false, true,
+        out_channels_per_group, output_length, k,
+        1.0f,
+        w + g * stridew, k, 0,
+        col + g * stridecol, k, _groups * stridecol,
+        0.0f,
+        o + g * stridec, output_length, _groups * stridec,
+        batch_size);
+  }
+
+  apply_bias_and_activation(output, bias, _activation_type,
+                            /*residual=*/nullptr,
+                            /*axis=*/-2);
+}
+
+#define DECLARE_IMPL(T)                                             \
+template void                                                       \
+Conv1D::compute<Device::MPS, T>(const StorageView&,                \
+                                const StorageView&,                \
+                                const StorageView*,                \
+                                StorageView&,                      \
+                                const StorageView*) const;
+
+DECLARE_IMPL(float)
+DECLARE_IMPL(float16_t)
+DECLARE_IMPL(bfloat16_t)
+
+}  // namespace ops
+}  // namespace ctranslate2

--- a/src/ops/gemm.cc
+++ b/src/ops/gemm.cc
@@ -4,8 +4,36 @@
 
 #include "dispatch.h"
 
+#ifdef CT2_WITH_MPS
+#  include "mps/kernels.h"
+#endif
+
 namespace ctranslate2 {
   namespace ops {
+
+#ifdef CT2_WITH_MPS
+    static int mps_activation_code(const ActivationType* activation) {
+      if (!activation)
+        return -1;
+      switch (*activation) {
+      case ActivationType::ReLU:
+        return static_cast<int>(mps::UnaryOp::RELU);
+      case ActivationType::GELUTanh:
+        return static_cast<int>(mps::UnaryOp::GELU_TANH);
+      case ActivationType::Swish:
+        return static_cast<int>(mps::UnaryOp::SWISH);
+      case ActivationType::GELU:
+        return static_cast<int>(mps::UnaryOp::GELU);
+      case ActivationType::GELUSigmoid:
+        return static_cast<int>(mps::UnaryOp::GELU_SIGMOID);
+      case ActivationType::Tanh:
+        return static_cast<int>(mps::UnaryOp::TANH);
+      case ActivationType::Sigmoid:
+        return static_cast<int>(mps::UnaryOp::SIGMOID);
+      }
+      return -1;
+    }
+#endif
 
     // activation_type(x + bias + residual)
     void apply_bias_and_activation(StorageView& x,
@@ -32,13 +60,13 @@ namespace ctranslate2 {
                bool a_is_packed,
                bool b_is_packed,
                const ActivationType* activation_type)
-      : _alpha(alpha)
+      : _activation_type(activation_type)
+      , _alpha(alpha)
       , _beta(beta)
       , _trans_a(trans_a)
       , _trans_b(trans_b)
       , _a_is_packed(a_is_packed)
       , _b_is_packed(b_is_packed)
-      , _activation_type(activation_type)
     {
     }
 
@@ -49,6 +77,52 @@ namespace ctranslate2 {
                           const StorageView* bias,
                           const StorageView* residual) const {
       PROFILE("Gemm");
+
+#ifdef CT2_WITH_MPS
+      // Decode Dense layers immediately apply bias, optional residual, and
+      // optional activation to a single-row FP16 projection. Encode that
+      // epilogue in the output-major matvec so the intermediate output is not
+      // written and read by another kernel. The matvec rounds to FP16 before
+      // the epilogue to preserve the previous two-dispatch numerics.
+      if (a.device() == Device::MPS
+          && a.dtype() == DataType::FLOAT16
+          && _trans_b
+          && bias
+          && bias->dtype() == DataType::FLOAT16
+          && (!residual || residual->dtype() == DataType::FLOAT16)
+          && !a_shift_compensation) {
+        const dim_t k = a.dim(_trans_a ? -2 : -1);
+        const dim_t n = b.dim(_trans_b ? -2 : -1);
+        const dim_t m = a.size() / k;
+        if (m == 1 && bias->size() == n && (!residual || residual->size() == n)) {
+          Shape output_shape(a.shape());
+          output_shape[output_shape.size() - 2] = a.dim(_trans_a ? -1 : -2);
+          output_shape[output_shape.size() - 1] = n;
+          c.resize(std::move(output_shape));
+          mps::gemv_row(DataType::FLOAT16,
+                        _trans_a,
+                        _trans_b,
+                        n,
+                        k,
+                        _alpha,
+                        a.data<float16_t>(),
+                        _trans_a ? m : k,
+                        0,
+                        b.data<float16_t>(),
+                        _trans_b ? k : n,
+                        0,
+                        _beta,
+                        c.data<float16_t>(),
+                        n,
+                        0,
+                        1,
+                        bias->data<float16_t>(),
+                        residual ? residual->data<float16_t>() : nullptr,
+                        mps_activation_code(_activation_type));
+          return;
+        }
+      }
+#endif
 
       switch (a.dtype()) {
       case DataType::INT8:

--- a/src/ops/gemm.cc
+++ b/src/ops/gemm.cc
@@ -6,6 +6,7 @@
 
 #ifdef CT2_WITH_MPS
 #  include "mps/kernels.h"
+#  include "mps/utils.h"
 #endif
 
 namespace ctranslate2 {
@@ -33,6 +34,7 @@ namespace ctranslate2 {
       }
       return -1;
     }
+
 #endif
 
     // activation_type(x + bias + residual)
@@ -79,6 +81,57 @@ namespace ctranslate2 {
       PROFILE("Gemm");
 
 #ifdef CT2_WITH_MPS
+      if (a.device() == Device::MPS && mps::profile_enabled()) {
+        const dim_t profile_k = a.dim(_trans_a ? -2 : -1);
+        const dim_t profile_n = b.dim(_trans_b ? -2 : -1);
+        const dim_t profile_m = a.size() / profile_k;
+        const std::string detail =
+          "gemm_epilogue m=" + std::to_string(profile_m)
+          + " n=" + std::to_string(profile_n)
+          + " bias=" + std::to_string(bias != nullptr)
+          + " residual=" + std::to_string(residual != nullptr)
+          + " activation=" + std::to_string(mps_activation_code(_activation_type));
+        mps::record_profile_detail(detail.c_str());
+      }
+
+      // Medium and large FP16 Dense projections use the SIMD-group GEMM when
+      // enabled. Keep bias, residual, and activation in its store epilogue so
+      // the materialized output is not read by a second full-tensor dispatch.
+      if (a.device() == Device::MPS
+          && a.dtype() == DataType::FLOAT16
+          && (!bias || bias->dtype() == DataType::FLOAT16)
+          && (!residual || residual->dtype() == DataType::FLOAT16)
+          && !a_shift_compensation) {
+        const dim_t k = a.dim(_trans_a ? -2 : -1);
+        const dim_t n = b.dim(_trans_b ? -2 : -1);
+        const dim_t m = a.size() / k;
+        if ((!bias || bias->size() == n)
+            && (!residual || residual->size() == m * n)) {
+          Shape output_shape(a.shape());
+          output_shape[output_shape.size() - 2] = a.dim(_trans_a ? -1 : -2);
+          output_shape[output_shape.size() - 1] = n;
+          c.resize(std::move(output_shape));
+          if (mps::gemm_with_epilogue(DataType::FLOAT16,
+                                      _trans_a,
+                                      _trans_b,
+                                      m,
+                                      n,
+                                      k,
+                                      _alpha,
+                                      a.data<float16_t>(),
+                                      _trans_a ? m : k,
+                                      b.data<float16_t>(),
+                                      _trans_b ? k : n,
+                                      _beta,
+                                      c.data<float16_t>(),
+                                      n,
+                                      bias ? bias->data<float16_t>() : nullptr,
+                                      residual ? residual->data<float16_t>() : nullptr,
+                                      mps_activation_code(_activation_type)))
+            return;
+        }
+      }
+
       // Decode Dense layers immediately apply bias, optional residual, and
       // optional activation to a single-row FP16 projection. Encode that
       // epilogue in the output-major matvec so the intermediate output is not
@@ -122,6 +175,7 @@ namespace ctranslate2 {
           return;
         }
       }
+
 #endif
 
       switch (a.dtype()) {

--- a/src/ops/layer_norm_mps.mm
+++ b/src/ops/layer_norm_mps.mm
@@ -1,0 +1,107 @@
+#ifdef __APPLE__
+#ifdef CT2_WITH_MPS
+
+#include "ctranslate2/ops/layer_norm.h"
+#include "ctranslate2/primitives.h"
+#include "mps/kernels.h"
+
+#include <cstdlib>
+#include <algorithm>
+#include <cmath>
+#include <memory>
+
+namespace ctranslate2 {
+namespace ops {
+
+static bool use_reference_mps_norms() {
+  const char* all = std::getenv("CT2_MPS_REFERENCE_NORMS");
+  const char* layer_norm = std::getenv("CT2_MPS_REFERENCE_LAYER_NORM");
+  return (all && all[0] != '\0' && all[0] != '0')
+         || (layer_norm && layer_norm[0] != '\0' && layer_norm[0] != '0');
+}
+
+template <typename T>
+static void reference_layer_norm(const StorageView* beta,
+                                 const StorageView* gamma,
+                                 const StorageView& input,
+                                 dim_t axis,
+                                 dim_t outer_size,
+                                 dim_t axis_size,
+                                 dim_t inner_size,
+                                 StorageView& output,
+                                 float epsilon) {
+  StorageView input_cpu = input.to(Device::CPU);
+  std::unique_ptr<StorageView> beta_cpu;
+  std::unique_ptr<StorageView> gamma_cpu;
+  if (beta)
+    beta_cpu = std::make_unique<StorageView>(beta->to(Device::CPU));
+  if (gamma)
+    gamma_cpu = std::make_unique<StorageView>(gamma->to(Device::CPU));
+  StorageView output_cpu(output.shape(), output.dtype(), Device::CPU);
+  const T* x = input_cpu.data<T>();
+  const T* b = beta_cpu ? beta_cpu->data<T>() : nullptr;
+  const T* g = gamma_cpu ? gamma_cpu->data<T>() : nullptr;
+  T* y = output_cpu.data<T>();
+  for (dim_t outer = 0; outer < outer_size; ++outer) {
+    for (dim_t inner = 0; inner < inner_size; ++inner) {
+      const dim_t base = outer * axis_size * inner_size + inner;
+      float sum = 0;
+      float sumsq = 0;
+      for (dim_t k = 0; k < axis_size; ++k) {
+        const float value = static_cast<float>(x[base + k * inner_size]);
+        sum += value;
+        sumsq += value * value;
+      }
+      const float mean = sum / axis_size;
+      const float variance = std::max(sumsq / axis_size - mean * mean, 0.0f);
+      const float scale = 1.0f / std::sqrt(variance + epsilon);
+      for (dim_t k = 0; k < axis_size; ++k) {
+        float value = (static_cast<float>(x[base + k * inner_size]) - mean) * scale;
+        if (g)
+          value *= static_cast<float>(g[k]);
+        if (b)
+          value += static_cast<float>(b[k]);
+        y[base + k * inner_size] = static_cast<T>(value);
+      }
+    }
+  }
+  output.copy_from(output_cpu);
+}
+
+#define DECLARE_IMPL(T, DTYPE)                                                 \
+template <>                                                                    \
+void LayerNorm::compute<Device::MPS, T>(const StorageView* beta,               \
+                                        const StorageView* gamma,              \
+                                        const StorageView& input,              \
+                                        const dim_t axis,                      \
+                                        const dim_t outer_size,                \
+                                        const dim_t axis_size,                 \
+                                        const dim_t inner_size,                \
+                                        StorageView& output) const {           \
+  if (use_reference_mps_norms()) {                                             \
+    reference_layer_norm<T>(beta, gamma, input, axis, outer_size,              \
+                            axis_size, inner_size, output, _epsilon);           \
+    return;                                                                    \
+  }                                                                            \
+  mps::layer_norm(DTYPE,                                                       \
+                  input.data<T>(),                                             \
+                  gamma ? gamma->data<T>() : nullptr,                          \
+                  beta ? beta->data<T>() : nullptr,                            \
+                  output.data<T>(),                                            \
+                  outer_size,                                                  \
+                  axis_size,                                                   \
+                  inner_size,                                                  \
+                  _epsilon);                                                   \
+}
+
+DECLARE_IMPL(float, DataType::FLOAT32)
+DECLARE_IMPL(float16_t, DataType::FLOAT16)
+DECLARE_IMPL(bfloat16_t, DataType::BFLOAT16)
+
+#undef DECLARE_IMPL
+
+}  // namespace ops
+}  // namespace ctranslate2
+
+#endif
+#endif

--- a/src/ops/mean_mps.mm
+++ b/src/ops/mean_mps.mm
@@ -1,0 +1,38 @@
+#ifdef __APPLE__
+#ifdef CT2_WITH_MPS
+
+#include "ctranslate2/ops/mean.h"
+#include "ctranslate2/primitives.h"
+#include "mps/kernels.h"
+
+namespace ctranslate2 {
+namespace ops {
+
+#define DECLARE_IMPL(T, DTYPE)                                          \
+template <>                                                             \
+void Mean::compute<Device::MPS, T>(const StorageView& input,            \
+                                   const dim_t outer_size,              \
+                                   const dim_t axis_size,               \
+                                   const dim_t inner_size,              \
+                                   const bool get_sum,                  \
+                                   StorageView& output) const {         \
+  mps::mean(DTYPE,                                                       \
+            input.data<T>(),                                             \
+            output.data<T>(),                                            \
+            outer_size,                                                  \
+            axis_size,                                                   \
+            inner_size,                                                  \
+            get_sum);                                                    \
+}
+
+DECLARE_IMPL(float, DataType::FLOAT32)
+DECLARE_IMPL(float16_t, DataType::FLOAT16)
+DECLARE_IMPL(bfloat16_t, DataType::BFLOAT16)
+
+#undef DECLARE_IMPL
+
+}  // namespace ops
+}  // namespace ctranslate2
+
+#endif
+#endif

--- a/src/ops/rms_norm_mps.mm
+++ b/src/ops/rms_norm_mps.mm
@@ -1,0 +1,38 @@
+#ifdef __APPLE__
+#ifdef CT2_WITH_MPS
+
+#include "ctranslate2/ops/rms_norm.h"
+#include "ctranslate2/primitives.h"
+#include "mps/kernels.h"
+
+namespace ctranslate2 {
+namespace ops {
+
+#define DECLARE_IMPL(T, DTYPE)                                      \
+template <>                                                         \
+void RMSNorm::compute<Device::MPS, T>(const StorageView& gamma,     \
+                                      const StorageView& input,     \
+                                      StorageView& output) const {  \
+  const dim_t depth = input.dim(-1);                                \
+  const dim_t batch_size = input.size() / depth;                    \
+  mps::rms_norm(DTYPE,                                              \
+                input.data<T>(),                                    \
+                gamma.data<T>(),                                    \
+                output.data<T>(),                                   \
+                batch_size,                                         \
+                depth,                                              \
+                _epsilon,                                           \
+                _use_residual);                                     \
+}
+
+DECLARE_IMPL(float, DataType::FLOAT32)
+DECLARE_IMPL(float16_t, DataType::FLOAT16)
+DECLARE_IMPL(bfloat16_t, DataType::BFLOAT16)
+
+#undef DECLARE_IMPL
+
+}  // namespace ops
+}  // namespace ctranslate2
+
+#endif
+#endif

--- a/src/ops/rotary_mps.mm
+++ b/src/ops/rotary_mps.mm
@@ -1,0 +1,43 @@
+#ifdef __APPLE__
+#ifdef CT2_WITH_MPS
+
+#include "ctranslate2/ops/rotary.h"
+#include "mps/kernels.h"
+
+namespace ctranslate2 {
+namespace ops {
+
+#define DECLARE_IMPL(T, DTYPE)                                              \
+template <>                                                                 \
+void Rotary::compute<Device::MPS, T>(const StorageView& input,              \
+                                     const StorageView& sin,                \
+                                     const StorageView& cos,                \
+                                     StorageView& output,                   \
+                                     bool is_transposed) const {            \
+  const dim_t max_time = is_transposed ? input.dim(-2) : input.dim(-3);     \
+  const dim_t depth = input.dim(-1);                                        \
+  const dim_t batch_size = input.size() / (max_time * depth);               \
+  const dim_t ndims = _ndims == 0 ? depth : _ndims;                         \
+  mps::rotary(DTYPE,                                                        \
+              input.data<T>(),                                              \
+              sin.data<T>(),                                                \
+              cos.data<T>(),                                                \
+              output.data<T>(),                                             \
+              batch_size,                                                   \
+              max_time,                                                     \
+              ndims,                                                        \
+              depth,                                                        \
+              _interleave);                                                 \
+}
+
+DECLARE_IMPL(float, DataType::FLOAT32)
+DECLARE_IMPL(float16_t, DataType::FLOAT16)
+DECLARE_IMPL(bfloat16_t, DataType::BFLOAT16)
+
+#undef DECLARE_IMPL
+
+}  // namespace ops
+}  // namespace ctranslate2
+
+#endif
+#endif

--- a/src/ops/softmax_mps.cc
+++ b/src/ops/softmax_mps.cc
@@ -1,0 +1,90 @@
+#ifdef __APPLE__
+#ifdef CT2_WITH_MPS
+
+#include "ctranslate2/ops/softmax.h"
+#include "ctranslate2/primitives.h"
+#include "mps/kernels.h"
+
+#include <cstdlib>
+#include <cmath>
+#include <limits>
+#include <memory>
+
+namespace ctranslate2 {
+  namespace ops {
+
+    static bool use_reference_mps_softmax() {
+      const char* all = std::getenv("CT2_MPS_REFERENCE_NORMS");
+      const char* softmax = std::getenv("CT2_MPS_REFERENCE_SOFTMAX");
+      return (all && all[0] != '\0' && all[0] != '0')
+             || (softmax && softmax[0] != '\0' && softmax[0] != '0');
+    }
+
+    template <typename T>
+    static void reference_softmax(const StorageView& input,
+                                  const StorageView* lengths,
+                                  StorageView& output,
+                                  bool log_output) {
+      StorageView input_cpu = input.to(Device::CPU);
+      std::unique_ptr<StorageView> lengths_cpu;
+      if (lengths)
+        lengths_cpu = std::make_unique<StorageView>(lengths->to(Device::CPU));
+      StorageView output_cpu(output.shape(), output.dtype(), Device::CPU);
+      const dim_t depth = input_cpu.dim(-1);
+      const dim_t rows = input_cpu.size() / depth;
+      const T* x = input_cpu.data<T>();
+      const int32_t* row_lengths = lengths_cpu ? lengths_cpu->data<int32_t>() : nullptr;
+      T* y = output_cpu.data<T>();
+      for (dim_t row = 0; row < rows; ++row) {
+        const dim_t valid = row_lengths
+                            ? std::max<dim_t>(0, std::min<dim_t>(row_lengths[row], depth))
+                            : depth;
+        float maximum = -std::numeric_limits<float>::infinity();
+        for (dim_t i = 0; i < valid; ++i)
+          maximum = std::max(maximum, static_cast<float>(x[row * depth + i]));
+        float sum = 0;
+        for (dim_t i = 0; i < valid; ++i)
+          sum += std::exp(static_cast<float>(x[row * depth + i]) - maximum);
+        const float log_sum = std::log(sum);
+        for (dim_t i = 0; i < valid; ++i) {
+          const float value = static_cast<float>(x[row * depth + i]) - maximum;
+          y[row * depth + i] = static_cast<T>(log_output ? value - log_sum
+                                                         : std::exp(value - log_sum));
+        }
+        for (dim_t i = valid; i < depth; ++i)
+          y[row * depth + i] = T(0);
+      }
+      output.copy_from(output_cpu);
+    }
+
+#define DECLARE_IMPL(T, DTYPE)                                          \
+    template <>                                                         \
+    void SoftMax::compute<Device::MPS, T>(const StorageView& input,     \
+                                          const StorageView* lengths,   \
+                                          StorageView& output) const {  \
+      if (use_reference_mps_softmax()) {                                \
+        reference_softmax<T>(input, lengths, output, _log);             \
+        return;                                                         \
+      }                                                                 \
+      const dim_t depth = input.dim(-1);                                \
+      const dim_t batch_size = input.size() / depth;                    \
+      mps::softmax(DTYPE,                                               \
+                   input.data<T>(),                                     \
+                   lengths ? lengths->data<int32_t>() : nullptr,        \
+                   output.data<T>(),                                    \
+                   batch_size,                                          \
+                   depth,                                               \
+                   _log);                                               \
+    }
+
+    DECLARE_IMPL(float, DataType::FLOAT32)
+    DECLARE_IMPL(float16_t, DataType::FLOAT16)
+    DECLARE_IMPL(bfloat16_t, DataType::BFLOAT16)
+
+#undef DECLARE_IMPL
+
+  }
+}
+
+#endif
+#endif

--- a/src/ops/tile.cc
+++ b/src/ops/tile.cc
@@ -19,6 +19,16 @@ namespace ctranslate2 {
         throw std::out_of_range("Can't tile axis " + std::to_string(axis)
                                 + " for input with rank " + std::to_string(input.rank()));
 
+      // Tiling by one is an identity. This case is common in batched decoder
+      // state handling where the effective repeat count is computed at
+      // runtime. Avoid allocating a replacement tensor and launching a device
+      // copy when this overload is called in place.
+      if (_num_tiles == 1) {
+        if (&input != &output)
+          output.copy_from(input);
+        return;
+      }
+
       {
         Shape output_shape(input.shape());
         output_shape[axis] *= _num_tiles;
@@ -37,6 +47,13 @@ namespace ctranslate2 {
     }
 
     void Tile::operator()(StorageView& input) const {
+      if (_num_tiles == 1) {
+        const dim_t axis = _axis < 0 ? input.rank() + _axis : _axis;
+        if (axis >= input.rank())
+          throw std::out_of_range("Can't tile axis " + std::to_string(axis)
+                                  + " for input with rank " + std::to_string(input.rank()));
+        return;
+      }
       StorageView input_clone(std::move(input));
       operator()(input_clone, input);
     }

--- a/src/storage_view.cc
+++ b/src/storage_view.cc
@@ -410,15 +410,25 @@ namespace ctranslate2 {
     if (size != _size)
       THROW_INVALID_ARGUMENT("buffer to copy is of size " + std::to_string(size)
                              + " but current storage size is " + std::to_string(_size));
-#ifdef CT2_WITH_CUDA
     if (device != _device) {
+#ifdef CT2_WITH_CUDA
       if (device == Device::CUDA)
         cross_device_primitives<Device::CUDA, Device::CPU>::copy(data, this->data<T>(), size);
-      else
+      else if (_device == Device::CUDA)
         cross_device_primitives<Device::CPU, Device::CUDA>::copy(data, this->data<T>(), size);
-    } else
+      else
 #endif
-    {
+#ifdef CT2_WITH_MPS
+      if (device == Device::MPS)
+        cross_device_primitives<Device::MPS, Device::CPU>::copy(data, this->data<T>(), size);
+      else if (_device == Device::MPS)
+        cross_device_primitives<Device::CPU, Device::MPS>::copy(data, this->data<T>(), size);
+      else
+#endif
+        throw std::invalid_argument("cross-device copy not supported between "
+                                    + device_to_str(device) + " and "
+                                    + device_to_str(_device));
+    } else {
       DEVICE_DISPATCH(device, primitives<D>::copy(data, this->data<T>(), size));
     }
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -5,6 +5,9 @@
 #ifdef CT2_WITH_CUDA
 #  include "./cuda/utils.h"
 #endif
+#ifdef CT2_WITH_MPS
+#  include "mps/utils.h"
+#endif
 
 #include "cpu/backend.h"
 #include "env.h"
@@ -102,6 +105,15 @@ namespace ctranslate2 {
       return false;
 #endif
     }
+    case Device::MPS: {
+#ifdef CT2_WITH_MPS
+      (void)device_index;
+      return false;
+#else
+      (void)device_index;
+      return false;
+#endif
+    }
     default:
       return false;
     }
@@ -113,6 +125,15 @@ namespace ctranslate2 {
 #ifdef CT2_WITH_CUDA
       static const bool allow_float16 = read_bool_from_env("CT2_CUDA_ALLOW_FP16");
       return allow_float16 || cuda::gpu_has_fp16_tensor_cores(device_index);
+#else
+      (void)device_index;
+      return false;
+#endif
+    }
+    case Device::MPS: {
+#ifdef CT2_WITH_MPS
+      (void)device_index;
+      return mps::has_mps();
 #else
       (void)device_index;
       return false;
@@ -143,6 +164,14 @@ namespace ctranslate2 {
 #endif
     case Device::CPU:
       return cpu::has_gemm_backend(ComputeType::INT8);
+    case Device::MPS:
+#ifdef CT2_WITH_MPS
+      (void)device_index;
+      return false;
+#else
+      (void)device_index;
+      return false;
+#endif
     default:
       return false;
     }
@@ -192,7 +221,7 @@ namespace ctranslate2 {
         unsupported_compute_type("int16");
       if (device == Device::CPU && support_int8)
         return ComputeType::INT8_FLOAT32;
-      if (device == Device::CUDA && support_float16)
+      if ((device == Device::CUDA || device == Device::MPS) && support_float16)
         return ComputeType::FLOAT16;
       return ComputeType::FLOAT32;
     }
@@ -233,7 +262,7 @@ namespace ctranslate2 {
         unsupported_compute_type("int8_float32");
       if (device == Device::CPU && support_int16)
         return ComputeType::INT16;
-      if (device == Device::CUDA && support_float16)
+      if ((device == Device::CUDA || device == Device::MPS) && support_float16)
         return ComputeType::FLOAT16;
       return ComputeType::FLOAT32;
     }
@@ -265,14 +294,15 @@ namespace ctranslate2 {
     }
 
     case ComputeType::AUTO: {
-      if (device == Device::CUDA) {
+      if (device == Device::CUDA || device == Device::MPS) {
         if (support_int8 && support_float16)
           return ComputeType::INT8_FLOAT16;
         if (support_int8)
           return ComputeType::INT8_FLOAT32;
         if (support_float16)
           return ComputeType::FLOAT16;
-      } else {
+      }
+      if (device == Device::CPU) {
         if (support_int8)
           return ComputeType::INT8_FLOAT32;
         if (support_int16)
@@ -354,7 +384,15 @@ namespace ctranslate2 {
           && cuda::gpu_has_int8_tensor_cores(device_index))
         return 16;
     }
-#else
+#endif
+#ifdef CT2_WITH_MPS
+    if (device == Device::MPS && mps::has_mps()) {
+      (void)device_index;
+      if (compute_type == ComputeType::FLOAT16 || compute_type == ComputeType::BFLOAT16)
+        return 8;
+    }
+#endif
+#if !defined(CT2_WITH_CUDA) && !defined(CT2_WITH_MPS)
     (void)compute_type;
     (void)device;
     (void)device_index;

--- a/src/types.cc
+++ b/src/types.cc
@@ -108,7 +108,7 @@ namespace ctranslate2 {
     case Device::MPS: {
 #ifdef CT2_WITH_MPS
       (void)device_index;
-      return false;
+      return mps::has_mps();
 #else
       (void)device_index;
       return false;
@@ -167,7 +167,7 @@ namespace ctranslate2 {
     case Device::MPS:
 #ifdef CT2_WITH_MPS
       (void)device_index;
-      return false;
+      return mps::has_mps();
 #else
       (void)device_index;
       return false;
@@ -294,7 +294,16 @@ namespace ctranslate2 {
     }
 
     case ComputeType::AUTO: {
-      if (device == Device::CUDA || device == Device::MPS) {
+      // The custom INT8 path on Apple GPUs is useful for reduced model memory,
+      // but is not faster than FP16 for the common batch-1 decoder workload.
+      // Keep AUTO performance-oriented while still allowing explicit INT8 modes.
+      if (device == Device::MPS) {
+        if (support_float16)
+          return ComputeType::FLOAT16;
+        if (support_int8)
+          return ComputeType::INT8_FLOAT32;
+      }
+      if (device == Device::CUDA) {
         if (support_int8 && support_float16)
           return ComputeType::INT8_FLOAT16;
         if (support_int8)

--- a/src/types.cc
+++ b/src/types.cc
@@ -230,16 +230,24 @@ namespace ctranslate2 {
       const DataType float_type = compute_type_to_data_type(model_compute_type).second;
       ComputeType actual_compute_type = ComputeType::INT8_FLOAT32;
 
-      switch (float_type) {
-      case DataType::FLOAT16:
+      // Generic INT8 means the backend may select its most efficient floating
+      // activation type. Apple GPUs strongly prefer FP16 arithmetic; using the
+      // saved model's FP32 type here made compute_type="int8" substantially
+      // slower than the explicit int8_float16 mode on MPS.
+      if (device == Device::MPS && support_float16) {
         actual_compute_type = ComputeType::INT8_FLOAT16;
-        break;
-      case DataType::BFLOAT16:
-        actual_compute_type = ComputeType::INT8_BFLOAT16;
-        break;
-      default:
-        actual_compute_type = ComputeType::INT8_FLOAT32;
-        break;
+      } else {
+        switch (float_type) {
+        case DataType::FLOAT16:
+          actual_compute_type = ComputeType::INT8_FLOAT16;
+          break;
+        case DataType::BFLOAT16:
+          actual_compute_type = ComputeType::INT8_BFLOAT16;
+          break;
+        default:
+          actual_compute_type = ComputeType::INT8_FLOAT32;
+          break;
+        }
       }
 
       const ComputeType resolved_compute_type = resolve_compute_type(actual_compute_type,

--- a/src/types.cc
+++ b/src/types.cc
@@ -182,6 +182,16 @@ namespace ctranslate2 {
                                 "or backend do not support efficient " + name + " computation.");
   }
 
+#ifdef CT2_WITH_MPS
+  static bool use_native_mps_int8() {
+    // Native INT8 remains useful when model memory is the primary constraint,
+    // but it is slower than FP16 on current Apple GPUs and its activation
+    // quantization can change autoregressive decoding decisions.  Preserve the
+    // existing environment variable as the explicit opt-in for this path.
+    return !read_bool_from_env("CT2_MPS_CACHE_INT8_FP16", /*default_value=*/true);
+  }
+#endif
+
   ComputeType resolve_compute_type(const ComputeType requested_compute_type,
                                    const ComputeType model_compute_type,
                                    const Device device,
@@ -227,6 +237,14 @@ namespace ctranslate2 {
     }
 
     case ComputeType::INT8: {
+#ifdef CT2_WITH_MPS
+      // Generic INT8 is commonly carried over from CPU configurations.  Do not
+      // silently select a slower and numerically different MPS path.  Resolving
+      // to FLOAT16 converts saved INT8 weights once while loading the model and
+      // reports the compute type that is actually executed.
+      if (device == Device::MPS && support_float16 && !use_native_mps_int8())
+        return ComputeType::FLOAT16;
+#endif
       const DataType float_type = compute_type_to_data_type(model_compute_type).second;
       ComputeType actual_compute_type = ComputeType::INT8_FLOAT32;
 
@@ -276,6 +294,10 @@ namespace ctranslate2 {
     }
 
     case ComputeType::INT8_FLOAT16: {
+#ifdef CT2_WITH_MPS
+      if (device == Device::MPS && support_float16 && !use_native_mps_int8())
+        return ComputeType::FLOAT16;
+#endif
       if (support_int8 && support_float16)
         return ComputeType::INT8_FLOAT16;
       if (!enable_fallback)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,15 @@ if(NOT MSVC)
   target_compile_options(benchmark_ops PRIVATE -Wno-unused-result)
 endif()
 
+if(WITH_MPS)
+  add_executable(benchmark_mps
+    benchmark_mps.cc
+    )
+  target_link_libraries(benchmark_mps
+    ${PROJECT_NAME}
+    )
+endif()
+
 if(WITH_CUDA)
   target_link_libraries(benchmark_ops PRIVATE ${CUDA_LIBRARIES})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(ctranslate2_test
   attention_test.cc
   batching_test.cc
   decoding_test.cc
+  devices_test.cc
   layers_test.cc
   model_test.cc
   storage_view_test.cc

--- a/tests/benchmark_mps.cc
+++ b/tests/benchmark_mps.cc
@@ -52,6 +52,17 @@ void benchmark_decode_gemm() {
                samples);
 }
 
+void benchmark_vocab_gemm() {
+  const size_t samples = samples_from_env(50);
+  StorageView input({1, 512}, float16_t(0.01f), Device::MPS);
+  StorageView weight({64176, 512}, float16_t(0.01f), Device::MPS);
+  StorageView output(DataType::FLOAT16, Device::MPS);
+  const ops::Gemm gemm(1, 0, false, true);
+  print_result("fp16_vocab_gemm",
+               benchmark([&]() { gemm(input, weight, output); }, samples),
+               samples);
+}
+
 void benchmark_prefill_gemm() {
   const size_t samples = samples_from_env(30);
   StorageView input({128, 512}, float16_t(0.01f), Device::MPS);
@@ -97,6 +108,8 @@ int main(int argc, char* argv[]) {
   const std::string requested = argc > 1 ? argv[1] : "all";
   if (requested == "all" || requested == "decode")
     benchmark_decode_gemm();
+  if (requested == "all" || requested == "vocab")
+    benchmark_vocab_gemm();
   if (requested == "all" || requested == "prefill")
     benchmark_prefill_gemm();
   if (requested == "all" || requested == "topk")

--- a/tests/benchmark_mps.cc
+++ b/tests/benchmark_mps.cc
@@ -1,0 +1,107 @@
+#include <chrono>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "ctranslate2/devices.h"
+#include "ctranslate2/ops/ops.h"
+
+using namespace ctranslate2;
+
+namespace {
+
+size_t samples_from_env(size_t default_value) {
+  const char* value = std::getenv("CT2_MPS_BENCH_SAMPLES");
+  if (!value || value[0] == '\0')
+    return default_value;
+  return std::max<size_t>(1, std::strtoull(value, nullptr, 10));
+}
+
+template <typename Function>
+double benchmark(Function&& function, size_t samples) {
+  for (size_t i = 0; i < 5; ++i)
+    function();
+  synchronize_device(Device::MPS, 0);
+
+  const auto start = std::chrono::steady_clock::now();
+  for (size_t i = 0; i < samples; ++i)
+    function();
+  synchronize_device(Device::MPS, 0);
+  const auto end = std::chrono::steady_clock::now();
+  const auto microseconds =
+    std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+  return static_cast<double>(microseconds) / static_cast<double>(samples) / 1000.0;
+}
+
+void print_result(const std::string& name, double milliseconds, size_t samples) {
+  std::cout << std::left << std::setw(24) << name
+            << " avg_ms=" << std::fixed << std::setprecision(6) << milliseconds
+            << " samples=" << samples << '\n';
+}
+
+void benchmark_decode_gemm() {
+  const size_t samples = samples_from_env(200);
+  StorageView input({1, 512}, float16_t(0.01f), Device::MPS);
+  StorageView weight({2048, 512}, float16_t(0.01f), Device::MPS);
+  StorageView output(DataType::FLOAT16, Device::MPS);
+  const ops::Gemm gemm(1, 0, false, true);
+  print_result("fp16_decode_gemm",
+               benchmark([&]() { gemm(input, weight, output); }, samples),
+               samples);
+}
+
+void benchmark_prefill_gemm() {
+  const size_t samples = samples_from_env(30);
+  StorageView input({128, 512}, float16_t(0.01f), Device::MPS);
+  StorageView weight({2048, 512}, float16_t(0.01f), Device::MPS);
+  StorageView output(DataType::FLOAT16, Device::MPS);
+  const ops::Gemm gemm(1, 0, false, true);
+  print_result("fp16_prefill_gemm",
+               benchmark([&]() { gemm(input, weight, output); }, samples),
+               samples);
+}
+
+void benchmark_topk() {
+  const size_t samples = samples_from_env(300);
+  StorageView input({1, 51865}, float16_t(0.01f), Device::MPS);
+  StorageView values(DataType::FLOAT16, Device::MPS);
+  StorageView indices(DataType::INT32, Device::MPS);
+  const ops::TopK topk(1);
+  print_result("fp16_argmax",
+               benchmark([&]() { topk(input, values, indices); }, samples),
+               samples);
+}
+
+void benchmark_concat() {
+  const size_t samples = samples_from_env(500);
+  std::vector<StorageView> storage;
+  std::vector<const StorageView*> inputs;
+  storage.reserve(8);
+  inputs.reserve(8);
+  for (size_t i = 0; i < 8; ++i) {
+    storage.emplace_back(Shape{4, 128}, float16_t(i), Device::MPS);
+    inputs.push_back(&storage.back());
+  }
+  StorageView output(DataType::FLOAT16, Device::MPS);
+  const ops::Concat concat(0);
+  print_result("fp16_concat_8way",
+               benchmark([&]() { concat(inputs, output); }, samples),
+               samples);
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  const std::string requested = argc > 1 ? argv[1] : "all";
+  if (requested == "all" || requested == "decode")
+    benchmark_decode_gemm();
+  if (requested == "all" || requested == "prefill")
+    benchmark_prefill_gemm();
+  if (requested == "all" || requested == "topk")
+    benchmark_topk();
+  if (requested == "all" || requested == "concat")
+    benchmark_concat();
+  return 0;
+}

--- a/tests/benchmark_mps.cc
+++ b/tests/benchmark_mps.cc
@@ -63,6 +63,20 @@ void benchmark_vocab_gemm() {
                samples);
 }
 
+void benchmark_whisper_decode_gemms() {
+  const size_t samples = samples_from_env(100);
+  constexpr dim_t k = 1024;
+  for (const dim_t n : {dim_t(1024), dim_t(3072), dim_t(4096), dim_t(51865)}) {
+    StorageView input({1, k}, float16_t(0.01f), Device::MPS);
+    StorageView weight({n, k}, float16_t(0.01f), Device::MPS);
+    StorageView output(DataType::FLOAT16, Device::MPS);
+    const ops::Gemm gemm(1, 0, false, true);
+    print_result("whisper_gemv_1x" + std::to_string(n),
+                 benchmark([&]() { gemm(input, weight, output); }, samples),
+                 samples);
+  }
+}
+
 void benchmark_prefill_gemm() {
   const size_t samples = samples_from_env(30);
   StorageView input({128, 512}, float16_t(0.01f), Device::MPS);
@@ -74,6 +88,35 @@ void benchmark_prefill_gemm() {
                samples);
 }
 
+void benchmark_marian_batch_gemms() {
+  const size_t samples = samples_from_env(50);
+  const std::vector<dim_t> output_sizes = {512, 1536, 2048, 58104};
+  for (const dim_t m : {dim_t(4), dim_t(128)}) {
+    for (const dim_t n : output_sizes) {
+      StorageView input({m, 512}, float16_t(0.01f), Device::MPS);
+      StorageView weight({n, 512}, float16_t(0.01f), Device::MPS);
+      StorageView output(DataType::FLOAT16, Device::MPS);
+      const ops::Gemm gemm(1, 0, false, true);
+      print_result("fp16_gemm_" + std::to_string(m) + "x" + std::to_string(n),
+                   benchmark([&]() { gemm(input, weight, output); }, samples),
+                   samples);
+    }
+  }
+
+  const ops::ActivationType swish = ops::ActivationType::Swish;
+  for (const dim_t n : {dim_t(512), dim_t(1536), dim_t(2048)}) {
+    StorageView input({128, 512}, float16_t(0.01f), Device::MPS);
+    StorageView weight({n, 512}, float16_t(0.01f), Device::MPS);
+    StorageView bias({n}, float16_t(0.01f), Device::MPS);
+    StorageView output(DataType::FLOAT16, Device::MPS);
+    const ops::Gemm gemm(1, 0, false, true, false, false,
+                         n == 2048 ? &swish : nullptr);
+    print_result("fp16_epilogue_128x" + std::to_string(n),
+                 benchmark([&]() { gemm(input, weight, output, nullptr, &bias); }, samples),
+                 samples);
+  }
+}
+
 void benchmark_topk() {
   const size_t samples = samples_from_env(300);
   StorageView input({1, 51865}, float16_t(0.01f), Device::MPS);
@@ -82,6 +125,44 @@ void benchmark_topk() {
   const ops::TopK topk(1);
   print_result("fp16_argmax",
                benchmark([&]() { topk(input, values, indices); }, samples),
+               samples);
+}
+
+void benchmark_beam_topk() {
+  const size_t samples = samples_from_env(50);
+  constexpr dim_t batch_size = 32;
+  constexpr dim_t beam_size = 4;
+  constexpr dim_t vocabulary_size = 58104;
+  constexpr dim_t candidates = 8;
+  StorageView input({batch_size, beam_size * vocabulary_size},
+                    float16_t(0.01f),
+                    Device::MPS);
+  StorageView values(DataType::FLOAT16, Device::MPS);
+  StorageView indices(DataType::INT32, Device::MPS);
+  const ops::TopK topk(candidates);
+  print_result("fp16_beam_topk_b32",
+               benchmark([&]() { topk(input, values, indices); }, samples),
+               samples);
+}
+
+void benchmark_beam_logsoftmax() {
+  const size_t samples = samples_from_env(50);
+  constexpr dim_t rows = 128;
+  constexpr dim_t vocabulary_size = 58104;
+  StorageView input({rows, vocabulary_size}, float16_t(0.01f), Device::MPS);
+  print_result("fp16_logsoftmax_128x58k",
+               benchmark([&]() { ops::LogSoftMax()(input); }, samples),
+               samples);
+}
+
+void benchmark_batched_vocab_gemm() {
+  const size_t samples = samples_from_env(20);
+  StorageView input({128, 512}, float16_t(0.01f), Device::MPS);
+  StorageView weight({58104, 512}, float16_t(0.01f), Device::MPS);
+  StorageView output(DataType::FLOAT16, Device::MPS);
+  const ops::Gemm gemm(1, 0, false, true);
+  print_result("fp16_vocab_gemm_m128",
+               benchmark([&]() { gemm(input, weight, output); }, samples),
                samples);
 }
 
@@ -110,10 +191,19 @@ int main(int argc, char* argv[]) {
     benchmark_decode_gemm();
   if (requested == "all" || requested == "vocab")
     benchmark_vocab_gemm();
+  if (requested == "all" || requested == "whisper-decode")
+    benchmark_whisper_decode_gemms();
   if (requested == "all" || requested == "prefill")
     benchmark_prefill_gemm();
+  if (requested == "all" || requested == "marian-batch")
+    benchmark_marian_batch_gemms();
   if (requested == "all" || requested == "topk")
     benchmark_topk();
+  if (requested == "all" || requested == "beam") {
+    benchmark_batched_vocab_gemm();
+    benchmark_beam_logsoftmax();
+    benchmark_beam_topk();
+  }
   if (requested == "all" || requested == "concat")
     benchmark_concat();
   return 0;

--- a/tests/devices_test.cc
+++ b/tests/devices_test.cc
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+
+#include "ctranslate2/devices.h"
+
+using namespace ctranslate2;
+
+TEST(DevicesTest, ExplicitCPU) {
+  EXPECT_EQ(str_to_device("cpu"), Device::CPU);
+  EXPECT_EQ(str_to_device("CPU"), Device::CPU);
+}
+
+#ifdef CT2_WITH_MPS
+TEST(DevicesTest, MPSIsExplicitOptIn) {
+  EXPECT_EQ(str_to_device("auto"), Device::CPU);
+  EXPECT_EQ(str_to_device("AUTO"), Device::CPU);
+  EXPECT_EQ(str_to_device("mps"), Device::MPS);
+  EXPECT_EQ(str_to_device("MPS"), Device::MPS);
+}
+#endif

--- a/tests/layers_test.cc
+++ b/tests/layers_test.cc
@@ -268,3 +268,10 @@ INSTANTIATE_TEST_SUITE_P(CUDA, LayerDeviceFPTest,
                                            FloatType{Device::CUDA, DataType::BFLOAT16, 1e-2}),
                          fp_test_name);
 #endif
+#ifdef CT2_WITH_MPS
+INSTANTIATE_TEST_SUITE_P(MPS, LayerDeviceFPTest,
+                         ::testing::Values(FloatType{Device::MPS, DataType::FLOAT32, 1e-5},
+                                           FloatType{Device::MPS, DataType::FLOAT16, 1e-2},
+                                           FloatType{Device::MPS, DataType::BFLOAT16, 1e-2}),
+                         fp_test_name);
+#endif

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -1572,6 +1572,102 @@ TEST(MPSBackendTest, DecodeGemmFloat16NonTransposedWeight) {
   expect_storage_eq(output.to_float32(), expected, 3e-2f);
 }
 
+TEST(MPSBackendTest, DecodeGemmFloat16FeedsDependentDispatches) {
+  constexpr dim_t k = 64;
+  constexpr dim_t n = 96;
+  std::vector<float> a_values(k);
+  std::vector<float> b_values(n * k);
+  for (dim_t i = 0; i < k; ++i)
+    a_values[i] = std::sin(static_cast<float>(i) * 0.13f) * 0.2f;
+  for (dim_t i = 0; i < n * k; ++i)
+    b_values[i] = std::cos(static_cast<float>(i) * 0.07f) * 0.15f;
+
+  const StorageView a_cpu({1, k}, a_values);
+  const StorageView b_cpu({n, k}, b_values);
+  StorageView expected;
+  ops::Gemm(1, 0, false, true)(a_cpu, b_cpu, expected);
+  primitives<Device::CPU>::add(0.125f,
+                               expected.data<float>(),
+                               expected.data<float>(),
+                               expected.size());
+  primitives<Device::CPU>::mul(0.75f,
+                               expected.data<float>(),
+                               expected.data<float>(),
+                               expected.size());
+  primitives<Device::CPU>::add(-0.05f,
+                               expected.data<float>(),
+                               expected.data<float>(),
+                               expected.size());
+
+  const StorageView a_mps = a_cpu.to_float16().to(Device::MPS);
+  const StorageView b_mps = b_cpu.to_float16().to(Device::MPS);
+  StorageView output(DataType::FLOAT16, Device::MPS);
+  ops::Gemm(1, 0, false, true)(a_mps, b_mps, output);
+  primitives<Device::MPS>::add(float16_t(0.125f),
+                               output.data<float16_t>(),
+                               output.data<float16_t>(),
+                               output.size());
+  primitives<Device::MPS>::mul(float16_t(0.75f),
+                               output.data<float16_t>(),
+                               output.data<float16_t>(),
+                               output.size());
+  primitives<Device::MPS>::add(float16_t(-0.05f),
+                               output.data<float16_t>(),
+                               output.data<float16_t>(),
+                               output.size());
+
+  expect_storage_eq(output.to_float32(), expected, 3e-2f);
+}
+
+TEST(MPSBackendTest, ColdDecodeGemmChainMatchesCPU) {
+  constexpr dim_t input_size = 512;
+  constexpr dim_t hidden_size = 2048;
+  constexpr dim_t output_size = 512;
+  std::vector<float> input_values(input_size);
+  std::vector<float> first_weight_values(hidden_size * input_size);
+  std::vector<float> first_bias_values(hidden_size);
+  std::vector<float> second_weight_values(output_size * hidden_size);
+  std::vector<float> second_bias_values(output_size);
+  for (dim_t i = 0; i < input_size; ++i)
+    input_values[i] = std::sin(static_cast<float>(i) * 0.013f) * 0.1f;
+  for (dim_t i = 0; i < hidden_size * input_size; ++i)
+    first_weight_values[i] = std::cos(static_cast<float>(i) * 0.003f) * 0.02f;
+  for (dim_t i = 0; i < hidden_size; ++i)
+    first_bias_values[i] = std::sin(static_cast<float>(i) * 0.017f) * 0.01f;
+  for (dim_t i = 0; i < output_size * hidden_size; ++i)
+    second_weight_values[i] = std::sin(static_cast<float>(i) * 0.002f) * 0.015f;
+  for (dim_t i = 0; i < output_size; ++i)
+    second_bias_values[i] = std::cos(static_cast<float>(i) * 0.019f) * 0.01f;
+
+  const StorageView input_cpu({1, input_size}, input_values);
+  const StorageView first_weight_cpu({hidden_size, input_size}, first_weight_values);
+  const StorageView first_bias_cpu({hidden_size}, first_bias_values);
+  const StorageView second_weight_cpu({output_size, hidden_size}, second_weight_values);
+  const StorageView second_bias_cpu({output_size}, second_bias_values);
+  const ops::ActivationType activation = ops::ActivationType::GELU;
+
+  StorageView hidden_cpu;
+  StorageView expected;
+  ops::Gemm(1, 0, false, true, false, false, &activation)(
+    input_cpu, first_weight_cpu, hidden_cpu, nullptr, &first_bias_cpu);
+  ops::Gemm(1, 0, false, true)(
+    hidden_cpu, second_weight_cpu, expected, nullptr, &second_bias_cpu);
+
+  const StorageView input_mps = input_cpu.to_float16().to(Device::MPS);
+  const StorageView first_weight_mps = first_weight_cpu.to_float16().to(Device::MPS);
+  const StorageView first_bias_mps = first_bias_cpu.to_float16().to(Device::MPS);
+  const StorageView second_weight_mps = second_weight_cpu.to_float16().to(Device::MPS);
+  const StorageView second_bias_mps = second_bias_cpu.to_float16().to(Device::MPS);
+  StorageView hidden_mps(DataType::FLOAT16, Device::MPS);
+  StorageView output_mps(DataType::FLOAT16, Device::MPS);
+  ops::Gemm(1, 0, false, true, false, false, &activation)(
+    input_mps, first_weight_mps, hidden_mps, nullptr, &first_bias_mps);
+  ops::Gemm(1, 0, false, true)(
+    hidden_mps, second_weight_mps, output_mps, nullptr, &second_bias_mps);
+
+  expect_storage_eq(output_mps.to_float32(), expected, 6e-2f);
+}
+
 TEST(MPSBackendTest, TopKFloat16TieUsesFirstIndex) {
   const StorageView input = StorageView({1, 7},
                                         std::vector<float>{1, 4, 2, 4, 3, 0, -1})

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -128,6 +128,10 @@ class OpDeviceFPTest : public ::testing::TestWithParam<FloatType> {
 
 TEST_P(OpDeviceFPTest, MedianFilter) {
   Device device = GetParam().device;
+#ifdef CT2_WITH_MPS
+  if (device == Device::MPS)
+    GTEST_SKIP() << "MedianFilter is not implemented for MPS.";
+#endif
   const DataType dtype = GetParam().dtype;
   const float error = GetParam().error;
   StorageView x({2, 8}, std::vector<float>{
@@ -152,6 +156,10 @@ TEST_P(OpDeviceFPTest, MedianFilterShortAxis) {
   // produced by Whisper align() when num_frames < 2) must pass the input
   // through instead of crashing on an integer division by zero.
   const Device device = GetParam().device;
+#ifdef CT2_WITH_MPS
+  if (device == Device::MPS)
+    GTEST_SKIP() << "MedianFilter is not implemented for MPS.";
+#endif
   const DataType dtype = GetParam().dtype;
   const float error = GetParam().error;
   {
@@ -772,6 +780,10 @@ TEST_P(OpDeviceTest, TopKChangeK) {
 
 TEST_P(OpDeviceFPTest, TopPMask) {
   const Device device = GetParam().device;
+#ifdef CT2_WITH_MPS
+  if (device == Device::MPS)
+    GTEST_SKIP() << "TopPMask is not implemented for MPS.";
+#endif
   const DataType dtype = GetParam().dtype;
   const float error = GetParam().error;
   constexpr float inf = std::numeric_limits<float>::infinity();
@@ -936,6 +948,10 @@ TEST_P(OpDeviceFPTest, RMSNorm) {
 
 TEST_P(OpDeviceTest, QuantizeINT8) {
   Device device = GetParam();
+#ifdef CT2_WITH_MPS
+  if (device == Device::MPS)
+    GTEST_SKIP() << "INT8 quantization is not implemented for MPS.";
+#endif
   StorageView a({2, 4}, std::vector<float>{-10, -3, 5, 2, 5, 21, -3, 0}, device);
   StorageView scale(DataType::FLOAT32, device);
   StorageView qa(DataType::INT8, device);
@@ -969,6 +985,10 @@ TEST_P(OpDeviceTest, QuantizeINT8) {
 
 TEST_P(OpDeviceTest, QuantizeINT8ZeroRow) {
   Device device = GetParam();
+#ifdef CT2_WITH_MPS
+  if (device == Device::MPS)
+    GTEST_SKIP() << "INT8 quantization is not implemented for MPS.";
+#endif
   StorageView a({2, 4}, std::vector<float>{-10, -3, 5, 2, 0, 0, 0, 0}, device);
   StorageView scale(DataType::FLOAT32, device);
   StorageView qa(DataType::INT8, device);
@@ -993,6 +1013,10 @@ TEST_P(OpDeviceTest, QuantizeINT8ZeroRow) {
 
 TEST_P(OpDeviceFPTest, Multinomial) {
   const Device device = GetParam().device;
+#ifdef CT2_WITH_MPS
+  if (device == Device::MPS)
+    GTEST_SKIP() << "Multinomial is not implemented for MPS.";
+#endif
   const DataType dtype = GetParam().dtype;
   StorageView input({2, 4}, std::vector<float>{0.2, 0.1, 0.6, 0.1, 0.7, 0.2, 0.0, 0.1}, device);
   StorageView output(DataType::INT32, device);
@@ -1349,6 +1373,8 @@ TEST_P(OpDeviceFPTest, Conv1DGroupNoBiasQuantized) {
     const Device device = GetParam().device;
     if (device != Device::CPU)
         GTEST_SKIP() << "Grouped quantized convolution is not implemented for GPU.";
+    if (!mayiuse_int8(device))
+        GTEST_SKIP() << "Grouped quantized convolution requires a CPU INT8 GEMM backend.";
     const DataType dtype = GetParam().dtype;
     const float error = std::max(GetParam().error, float(3e-3));
     const StorageView expected({2, 2, 2}, std::vector<float>{
@@ -1605,7 +1631,6 @@ INSTANTIATE_TEST_SUITE_P(CUDA, OpDeviceFPTest,
 INSTANTIATE_TEST_SUITE_P(MPS, OpDeviceTest, ::testing::Values(Device::MPS));
 INSTANTIATE_TEST_SUITE_P(MPS, OpDeviceFPTest,
                          ::testing::Values(FloatType{Device::MPS, DataType::FLOAT32, 1e-5},
-                                           FloatType{Device::MPS, DataType::FLOAT16, 1e-2},
-                                           FloatType{Device::MPS, DataType::BFLOAT16, 4e-2}),
+                                           FloatType{Device::MPS, DataType::FLOAT16, 1e-2}),
                          fp_test_name);
 #endif

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <set>
 #include "test_utils.h"
 #include "ctranslate2/layers/attention.h"
 #include "ctranslate2/ops/ops.h"
@@ -128,10 +129,6 @@ class OpDeviceFPTest : public ::testing::TestWithParam<FloatType> {
 
 TEST_P(OpDeviceFPTest, MedianFilter) {
   Device device = GetParam().device;
-#ifdef CT2_WITH_MPS
-  if (device == Device::MPS)
-    GTEST_SKIP() << "MedianFilter is not implemented for MPS.";
-#endif
   const DataType dtype = GetParam().dtype;
   const float error = GetParam().error;
   StorageView x({2, 8}, std::vector<float>{
@@ -156,10 +153,6 @@ TEST_P(OpDeviceFPTest, MedianFilterShortAxis) {
   // produced by Whisper align() when num_frames < 2) must pass the input
   // through instead of crashing on an integer division by zero.
   const Device device = GetParam().device;
-#ifdef CT2_WITH_MPS
-  if (device == Device::MPS)
-    GTEST_SKIP() << "MedianFilter is not implemented for MPS.";
-#endif
   const DataType dtype = GetParam().dtype;
   const float error = GetParam().error;
   {
@@ -780,10 +773,6 @@ TEST_P(OpDeviceTest, TopKChangeK) {
 
 TEST_P(OpDeviceFPTest, TopPMask) {
   const Device device = GetParam().device;
-#ifdef CT2_WITH_MPS
-  if (device == Device::MPS)
-    GTEST_SKIP() << "TopPMask is not implemented for MPS.";
-#endif
   const DataType dtype = GetParam().dtype;
   const float error = GetParam().error;
   constexpr float inf = std::numeric_limits<float>::infinity();
@@ -946,12 +935,34 @@ TEST_P(OpDeviceFPTest, RMSNorm) {
   expect_storage_eq(y.to_float32(), expected, error);
 }
 
+TEST_P(OpDeviceFPTest, DequantizeGemmOutputBiasReLU) {
+  const Device device = GetParam().device;
+  const DataType dtype = GetParam().dtype;
+  const float error = std::max(GetParam().error, float(1e-3));
+  const StorageView input({2, 3},
+                          std::vector<int32_t>{20, -8, 16, -40, 24, 0},
+                          device);
+  const StorageView a_scale({2}, std::vector<float>{2, 4}, device);
+  const StorageView b_scale({3}, std::vector<float>{5, 2, 8}, device);
+  const StorageView bias = StorageView({3}, std::vector<float>{0.5f, -1, 2}, device)
+                             .to(dtype);
+  const StorageView expected({2, 3},
+                             std::vector<float>{2.5f, 0, 3, 0, 2, 2});
+  StorageView output(dtype, device);
+  const ops::ActivationType activation = ops::ActivationType::ReLU;
+  const ops::Dequantize dequantize(&activation);
+  dequantize(input,
+             a_scale,
+             b_scale,
+             /*transpose_a=*/false,
+             /*transpose_b=*/true,
+             output,
+             &bias);
+  expect_storage_eq(output.to_float32(), expected, error);
+}
+
 TEST_P(OpDeviceTest, QuantizeINT8) {
   Device device = GetParam();
-#ifdef CT2_WITH_MPS
-  if (device == Device::MPS)
-    GTEST_SKIP() << "INT8 quantization is not implemented for MPS.";
-#endif
   StorageView a({2, 4}, std::vector<float>{-10, -3, 5, 2, 5, 21, -3, 0}, device);
   StorageView scale(DataType::FLOAT32, device);
   StorageView qa(DataType::INT8, device);
@@ -985,10 +996,6 @@ TEST_P(OpDeviceTest, QuantizeINT8) {
 
 TEST_P(OpDeviceTest, QuantizeINT8ZeroRow) {
   Device device = GetParam();
-#ifdef CT2_WITH_MPS
-  if (device == Device::MPS)
-    GTEST_SKIP() << "INT8 quantization is not implemented for MPS.";
-#endif
   StorageView a({2, 4}, std::vector<float>{-10, -3, 5, 2, 0, 0, 0, 0}, device);
   StorageView scale(DataType::FLOAT32, device);
   StorageView qa(DataType::INT8, device);
@@ -1011,12 +1018,25 @@ TEST_P(OpDeviceTest, QuantizeINT8ZeroRow) {
   }
 }
 
+TEST_P(OpDeviceFPTest, QuantizeDequantizeINT8RoundTrip) {
+  const Device device = GetParam().device;
+  const DataType dtype = GetParam().dtype;
+  const StorageView input = StorageView(
+      {2, 5},
+      std::vector<float>{-10, -3, 5, 2, 0.25f, 5, 21, -3, 0, -7},
+      device).to(dtype);
+  StorageView quantized(DataType::INT8, device);
+  StorageView scale(DataType::FLOAT32, device);
+  StorageView output(dtype, device);
+
+  ops::Quantize()(input, quantized, scale);
+  ops::Dequantize()(quantized, scale, output);
+
+  expect_storage_eq(output.to_float32(), input.to_float32(), 0.1f);
+}
+
 TEST_P(OpDeviceFPTest, Multinomial) {
   const Device device = GetParam().device;
-#ifdef CT2_WITH_MPS
-  if (device == Device::MPS)
-    GTEST_SKIP() << "Multinomial is not implemented for MPS.";
-#endif
   const DataType dtype = GetParam().dtype;
   StorageView input({2, 4}, std::vector<float>{0.2, 0.1, 0.6, 0.1, 0.7, 0.2, 0.0, 0.1}, device);
   StorageView output(DataType::INT32, device);
@@ -1302,10 +1322,6 @@ TEST_P(OpDeviceFPTest, Conv1DDilation) {
   const Device device = GetParam().device;
   if (device == Device::CPU)
       GTEST_SKIP() << "Dilated convolution is not implemented for CPU.";
-#ifdef CT2_WITH_MPS
-  if (device == Device::MPS)
-      GTEST_SKIP() << "Dilated convolution is not implemented for MPS.";
-#endif
   const DataType dtype = GetParam().dtype;
   const float error = GetParam().error;
   const StorageView expected({2, 4, 1}, std::vector<float>{
@@ -1371,10 +1387,14 @@ TEST_P(OpDeviceFPTest, Conv1DGroupNoBiasQuantized) {
     GTEST_SKIP() << "Quantized convolution is not implemented for DNNL.";
 #endif
     const Device device = GetParam().device;
+#ifdef CT2_WITH_MPS
+    if (device != Device::CPU && device != Device::MPS)
+#else
     if (device != Device::CPU)
+#endif
         GTEST_SKIP() << "Grouped quantized convolution is not implemented for GPU.";
     if (!mayiuse_int8(device))
-        GTEST_SKIP() << "Grouped quantized convolution requires a CPU INT8 GEMM backend.";
+        GTEST_SKIP() << "Grouped quantized convolution requires an INT8 GEMM backend.";
     const DataType dtype = GetParam().dtype;
     const float error = std::max(GetParam().error, float(3e-3));
     const StorageView expected({2, 2, 2}, std::vector<float>{
@@ -1601,17 +1621,47 @@ TEST(MPSBackendTest, BatchedDecodeGemmBroadcastAndInteriorOffsets) {
   }
 }
 
-TEST(MPSBackendTest, RejectsUnsupportedBF16AndINT8Gemm) {
+TEST(MPSBackendTest, SupportsBF16AndINT8Gemm) {
   const StorageView fp32({1, 4}, std::vector<float>{1, 2, 3, 4});
   const StorageView bf16 = fp32.to(DataType::BFLOAT16).to(Device::MPS);
   StorageView bf16_output(DataType::BFLOAT16, Device::MPS);
-  EXPECT_THROW(ops::Gemm(1, 0, false, true)(bf16, bf16, bf16_output),
-               std::invalid_argument);
+  ops::Gemm(1, 0, false, true)(bf16, bf16, bf16_output);
+  expect_storage_eq(bf16_output.to_float32(), StorageView({1, 1}, std::vector<float>{30}), 0.1f);
 
   const StorageView int8_input({1, 4}, std::vector<int8_t>{1, 2, 3, 4}, Device::MPS);
   StorageView int8_output(DataType::INT32, Device::MPS);
-  EXPECT_THROW(ops::Gemm(1, 0, false, true)(int8_input, int8_input, int8_output),
-               std::invalid_argument);
+  ops::Gemm(1, 0, false, true)(int8_input, int8_input, int8_output);
+  expect_storage_eq(int8_output.to(Device::CPU),
+                    StorageView({1, 1}, std::vector<int32_t>{30}));
+}
+
+TEST(MPSBackendTest, AutoComputeTypePrefersFloat16) {
+  EXPECT_EQ(resolve_compute_type(ComputeType::AUTO,
+                                 ComputeType::FLOAT32,
+                                 Device::MPS,
+                                 0),
+            ComputeType::FLOAT16);
+}
+
+TEST(MPSBackendTest, GumbelMaxBF16ProducesValidUniqueIndices) {
+  const StorageView input = StorageView({2, 7}, 0.f)
+                              .to(DataType::BFLOAT16)
+                              .to(Device::MPS);
+  StorageView indices(DataType::INT32, Device::MPS);
+  ops::GumbelMax(3)(input, indices);
+
+  EXPECT_EQ(indices.shape(), Shape({2, 3}));
+  const std::vector<int32_t> result = indices.to_vector<int32_t>();
+  for (dim_t row = 0; row < 2; ++row) {
+    std::set<int32_t> unique;
+    for (dim_t sample = 0; sample < 3; ++sample) {
+      const int32_t index = result[row * 3 + sample];
+      EXPECT_GE(index, 0);
+      EXPECT_LT(index, 7);
+      unique.insert(index);
+    }
+    EXPECT_EQ(unique.size(), 3);
+  }
 }
 #endif
 
@@ -1631,6 +1681,7 @@ INSTANTIATE_TEST_SUITE_P(CUDA, OpDeviceFPTest,
 INSTANTIATE_TEST_SUITE_P(MPS, OpDeviceTest, ::testing::Values(Device::MPS));
 INSTANTIATE_TEST_SUITE_P(MPS, OpDeviceFPTest,
                          ::testing::Values(FloatType{Device::MPS, DataType::FLOAT32, 1e-5},
-                                           FloatType{Device::MPS, DataType::FLOAT16, 1e-2}),
+                                           FloatType{Device::MPS, DataType::FLOAT16, 1e-2},
+                                           FloatType{Device::MPS, DataType::BFLOAT16, 4e-2}),
                          fp_test_name);
 #endif

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -2,6 +2,7 @@
 #include "test_utils.h"
 #include "ctranslate2/layers/attention.h"
 #include "ctranslate2/ops/ops.h"
+#include "ctranslate2/primitives.h"
 
 TEST(OpTest, Transpose1D) {
   StorageView x({4}, std::vector<float>{1, 2, 3, 4});
@@ -949,8 +950,8 @@ TEST_P(OpDeviceTest, QuantizeINT8) {
   }
 
   // With rounding before cast and shift to uint8.
-  // Shift to uin8_t is not defined on CUDA
-  if (device != Device::CUDA) {
+  // Shift to uint8_t is not defined on CUDA or MPS.
+  if (device != Device::CUDA && device != Device::MPS) {
     StorageView expected_qa(a.shape(), std::vector<int8_t>{1, 90, -64, -103, -98, -1, 110, -128});
     ops::Quantize(ops::Quantize::ScaleType::GLOBAL, true, true)(a, qa, scale);
     expect_storage_eq(scale, expected_scale);
@@ -1277,6 +1278,10 @@ TEST_P(OpDeviceFPTest, Conv1DDilation) {
   const Device device = GetParam().device;
   if (device == Device::CPU)
       GTEST_SKIP() << "Dilated convolution is not implemented for CPU.";
+#ifdef CT2_WITH_MPS
+  if (device == Device::MPS)
+      GTEST_SKIP() << "Dilated convolution is not implemented for MPS.";
+#endif
   const DataType dtype = GetParam().dtype;
   const float error = GetParam().error;
   const StorageView expected({2, 4, 1}, std::vector<float>{
@@ -1343,7 +1348,7 @@ TEST_P(OpDeviceFPTest, Conv1DGroupNoBiasQuantized) {
 #endif
     const Device device = GetParam().device;
     if (device != Device::CPU)
-        GTEST_SKIP() << "Grouped quantized convolution is not implemented for CUDA.";
+        GTEST_SKIP() << "Grouped quantized convolution is not implemented for GPU.";
     const DataType dtype = GetParam().dtype;
     const float error = std::max(GetParam().error, float(3e-3));
     const StorageView expected({2, 2, 2}, std::vector<float>{
@@ -1431,6 +1436,159 @@ TEST_P(OpDeviceFPTest, BiasAddAxisGELU) {
     expect_storage_eq(output.to_float32(), expected, error);
 }
 
+#ifdef CT2_WITH_MPS
+TEST(MPSBackendTest, BatchesDependentComputeDispatches) {
+  StorageView x({4}, std::vector<float>{1, 2, 3, 4}, Device::MPS);
+  StorageView y({4}, DataType::FLOAT32, Device::MPS);
+  StorageView z({4}, DataType::FLOAT32, Device::MPS);
+  primitives<Device::MPS>::add(1.f, x.data<float>(), y.data<float>(), x.size());
+  primitives<Device::MPS>::mul(2.f, y.data<float>(), z.data<float>(), x.size());
+  primitives<Device::MPS>::add(x.data<float>(), z.data<float>(), y.data<float>(), x.size());
+  expect_storage_eq(y.to(Device::CPU),
+                    StorageView({4}, std::vector<float>{5, 8, 11, 14}));
+}
+
+TEST(MPSBackendTest, LayerNormParallelReductionIsStable) {
+  constexpr dim_t rows = 7;
+  constexpr dim_t width = 512;
+  std::vector<float> input_values(rows * width);
+  std::vector<float> gamma_values(width);
+  std::vector<float> beta_values(width);
+  for (dim_t i = 0; i < rows * width; ++i)
+    input_values[i] = std::sin(static_cast<float>(i) * 0.031f) * 2.0f
+                      + std::cos(static_cast<float>(i) * 0.013f);
+  for (dim_t i = 0; i < width; ++i) {
+    gamma_values[i] = 0.5f + std::sin(static_cast<float>(i) * 0.017f);
+    beta_values[i] = std::cos(static_cast<float>(i) * 0.023f) * 0.2f;
+  }
+
+  const StorageView input_cpu({rows, width}, input_values);
+  const StorageView gamma_cpu({width}, gamma_values);
+  const StorageView beta_cpu({width}, beta_values);
+  StorageView expected;
+  ops::LayerNorm()(beta_cpu, gamma_cpu, input_cpu, expected);
+
+  const StorageView input_mps = input_cpu.to(Device::MPS);
+  const StorageView gamma_mps = gamma_cpu.to(Device::MPS);
+  const StorageView beta_mps = beta_cpu.to(Device::MPS);
+  for (size_t iteration = 0; iteration < 20; ++iteration) {
+    StorageView output(DataType::FLOAT32, Device::MPS);
+    ops::LayerNorm()(beta_mps, gamma_mps, input_mps, output);
+    expect_storage_eq(output.to_float32(), expected, 2e-4f);
+  }
+}
+
+TEST(MPSBackendTest, DecodeGemmFloat16OddShapeAlphaBeta) {
+  constexpr dim_t k = 37;
+  constexpr dim_t n = 33;
+  std::vector<float> a_values(k);
+  std::vector<float> b_values(n * k);
+  std::vector<float> c_values(n);
+  for (dim_t i = 0; i < k; ++i)
+    a_values[i] = std::sin(static_cast<float>(i) * 0.17f);
+  for (dim_t i = 0; i < n * k; ++i)
+    b_values[i] = std::cos(static_cast<float>(i) * 0.11f) * 0.25f;
+  for (dim_t i = 0; i < n; ++i)
+    c_values[i] = static_cast<float>(i - 8) * 0.03f;
+
+  const StorageView a_cpu({1, k}, a_values);
+  const StorageView b_cpu({n, k}, b_values);
+  StorageView expected({1, n}, c_values);
+  ops::Gemm(/*alpha=*/0.75f, /*beta=*/0.25f, false, true)(a_cpu, b_cpu, expected);
+
+  const StorageView a_mps = a_cpu.to_float16().to(Device::MPS);
+  const StorageView b_mps = b_cpu.to_float16().to(Device::MPS);
+  StorageView output = StorageView({1, n}, c_values).to_float16().to(Device::MPS);
+  ops::Gemm(/*alpha=*/0.75f, /*beta=*/0.25f, false, true)(a_mps, b_mps, output);
+
+  expect_storage_eq(output.to_float32(), expected, 3e-2f);
+}
+
+TEST(MPSBackendTest, DecodeGemmFloat16NonTransposedWeight) {
+  constexpr dim_t k = 19;
+  constexpr dim_t n = 23;
+  std::vector<float> a_values(k);
+  std::vector<float> b_values(k * n);
+  for (dim_t i = 0; i < k; ++i)
+    a_values[i] = static_cast<float>(i - 5) * 0.02f;
+  for (dim_t i = 0; i < k * n; ++i)
+    b_values[i] = std::sin(static_cast<float>(i) * 0.07f);
+
+  const StorageView a_cpu({1, k}, a_values);
+  const StorageView b_cpu({k, n}, b_values);
+  StorageView expected;
+  ops::Gemm(1, 0, false, false)(a_cpu, b_cpu, expected);
+
+  StorageView output(DataType::FLOAT16, Device::MPS);
+  ops::Gemm(1, 0, false, false)(a_cpu.to_float16().to(Device::MPS),
+                                b_cpu.to_float16().to(Device::MPS),
+                                output);
+  expect_storage_eq(output.to_float32(), expected, 3e-2f);
+}
+
+TEST(MPSBackendTest, TopKFloat16TieUsesFirstIndex) {
+  const StorageView input = StorageView({1, 7},
+                                        std::vector<float>{1, 4, 2, 4, 3, 0, -1})
+                              .to_float16()
+                              .to(Device::MPS);
+  StorageView values(DataType::FLOAT16, Device::MPS);
+  StorageView indices(DataType::INT32, Device::MPS);
+  ops::TopK(1)(input, values, indices);
+  expect_storage_eq(indices, StorageView({1, 1}, std::vector<int32_t>{1}));
+}
+
+TEST(MPSBackendTest, BatchedDecodeGemmBroadcastAndInteriorOffsets) {
+  constexpr dim_t batch_size = 2;
+  constexpr dim_t k = 17;
+  constexpr dim_t n = 11;
+  std::vector<float> a_values(k + 1, 0);
+  std::vector<float> b_values(batch_size * n * k + 2, 0);
+  for (dim_t p = 0; p < k; ++p)
+    a_values[1 + p] = static_cast<float>(p - 4) * 0.04f;
+  for (dim_t i = 0; i < batch_size * n * k; ++i)
+    b_values[2 + i] = std::cos(static_cast<float>(i) * 0.09f);
+
+  const StorageView a = StorageView({k + 1}, a_values).to_float16().to(Device::MPS);
+  const StorageView b = StorageView({batch_size * n * k + 2}, b_values)
+                          .to_float16()
+                          .to(Device::MPS);
+  StorageView c({batch_size * n + 1}, float16_t(0), Device::MPS);
+
+  primitives<Device::MPS>::gemm_batch_strided<float16_t, float16_t>(
+    false, true,
+    1, n, k,
+    1,
+    a.data<float16_t>() + 1, k, 0,
+    b.data<float16_t>() + 2, k, n * k,
+    0,
+    c.data<float16_t>() + 1, n, n,
+    batch_size);
+
+  const std::vector<float> output = c.to_float32().to_vector<float>();
+  for (dim_t batch = 0; batch < batch_size; ++batch) {
+    for (dim_t column = 0; column < n; ++column) {
+      float expected = 0;
+      for (dim_t p = 0; p < k; ++p)
+        expected += a_values[1 + p] * b_values[2 + batch * n * k + column * k + p];
+      EXPECT_NEAR(output[1 + batch * n + column], expected, 3e-2f);
+    }
+  }
+}
+
+TEST(MPSBackendTest, RejectsUnsupportedBF16AndINT8Gemm) {
+  const StorageView fp32({1, 4}, std::vector<float>{1, 2, 3, 4});
+  const StorageView bf16 = fp32.to(DataType::BFLOAT16).to(Device::MPS);
+  StorageView bf16_output(DataType::BFLOAT16, Device::MPS);
+  EXPECT_THROW(ops::Gemm(1, 0, false, true)(bf16, bf16, bf16_output),
+               std::invalid_argument);
+
+  const StorageView int8_input({1, 4}, std::vector<int8_t>{1, 2, 3, 4}, Device::MPS);
+  StorageView int8_output(DataType::INT32, Device::MPS);
+  EXPECT_THROW(ops::Gemm(1, 0, false, true)(int8_input, int8_input, int8_output),
+               std::invalid_argument);
+}
+#endif
+
 INSTANTIATE_TEST_SUITE_P(CPU, OpDeviceTest, ::testing::Values(Device::CPU));
 INSTANTIATE_TEST_SUITE_P(CPU, OpDeviceFPTest,
                          ::testing::Values(FloatType{Device::CPU, DataType::FLOAT32, 1e-5}),
@@ -1441,5 +1599,13 @@ INSTANTIATE_TEST_SUITE_P(CUDA, OpDeviceFPTest,
                          ::testing::Values(FloatType{Device::CUDA, DataType::FLOAT32, 1e-5},
                                            FloatType{Device::CUDA, DataType::FLOAT16, 1e-2},
                                            FloatType{Device::CUDA, DataType::BFLOAT16, 4e-2}),
+                         fp_test_name);
+#endif
+#ifdef CT2_WITH_MPS
+INSTANTIATE_TEST_SUITE_P(MPS, OpDeviceTest, ::testing::Values(Device::MPS));
+INSTANTIATE_TEST_SUITE_P(MPS, OpDeviceFPTest,
+                         ::testing::Values(FloatType{Device::MPS, DataType::FLOAT32, 1e-5},
+                                           FloatType{Device::MPS, DataType::FLOAT16, 1e-2},
+                                           FloatType{Device::MPS, DataType::BFLOAT16, 4e-2}),
                          fp_test_name);
 #endif

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -4,6 +4,11 @@
 #include "ctranslate2/layers/attention.h"
 #include "ctranslate2/ops/ops.h"
 #include "ctranslate2/primitives.h"
+#ifdef CT2_WITH_MPS
+#  include "ctranslate2/allocator.h"
+#  include "ctranslate2/devices.h"
+#  include "mps/utils.h"
+#endif
 
 TEST(OpTest, Transpose1D) {
   StorageView x({4}, std::vector<float>{1, 2, 3, 4});
@@ -1483,6 +1488,28 @@ TEST_P(OpDeviceFPTest, BiasAddAxisGELU) {
 }
 
 #ifdef CT2_WITH_MPS
+TEST(MPSBackendTest, ActiveTemporaryFreesAreProcessedAfterCompletion) {
+  constexpr size_t iterations = 256;
+  constexpr dim_t elements = 16;
+  auto& allocator = get_allocator<Device::MPS>();
+  std::vector<void*> released;
+  released.reserve(iterations);
+
+  for (size_t iteration = 0; iteration < iterations; ++iteration) {
+    auto* buffer = static_cast<float*>(
+      allocator.allocate(static_cast<size_t>(elements) * sizeof(float), 0));
+    primitives<Device::MPS>::fill(buffer, static_cast<float>(iteration), elements);
+    released.emplace_back(buffer);
+    allocator.free(buffer, 0);
+  }
+
+  synchronize_stream(Device::MPS);
+  for (const void* address : released) {
+    size_t offset = 0;
+    EXPECT_EQ(mps::get_buffer(address, sizeof(float), &offset), nullptr);
+  }
+}
+
 TEST(MPSBackendTest, BatchesDependentComputeDispatches) {
   StorageView x({4}, std::vector<float>{1, 2, 3, 4}, Device::MPS);
   StorageView y({4}, DataType::FLOAT32, Device::MPS);
@@ -1522,6 +1549,43 @@ TEST(MPSBackendTest, LayerNormParallelReductionIsStable) {
     ops::LayerNorm()(beta_mps, gamma_mps, input_mps, output);
     expect_storage_eq(output.to_float32(), expected, 2e-4f);
   }
+}
+
+TEST(MPSBackendTest, WhisperSizedFloat16LayerNormFeedsDependentDispatch) {
+  constexpr dim_t rows = 1500;
+  constexpr dim_t width = 1024;
+  std::vector<float> input_values(rows * width);
+  std::vector<float> gamma_values(width);
+  std::vector<float> beta_values(width);
+  for (dim_t i = 0; i < rows * width; ++i)
+    input_values[i] = std::sin(static_cast<float>(i) * 0.0013f) * 1.5f
+                      + std::cos(static_cast<float>(i) * 0.0007f) * 0.5f;
+  for (dim_t i = 0; i < width; ++i) {
+    gamma_values[i] = 0.75f + std::sin(static_cast<float>(i) * 0.011f) * 0.2f;
+    beta_values[i] = std::cos(static_cast<float>(i) * 0.017f) * 0.1f;
+  }
+
+  const StorageView input_cpu({rows, width}, input_values);
+  const StorageView gamma_cpu({width}, gamma_values);
+  const StorageView beta_cpu({width}, beta_values);
+  StorageView expected;
+  ops::LayerNorm()(beta_cpu, gamma_cpu, input_cpu, expected);
+  primitives<Device::CPU>::add(0.125f,
+                               expected.data<float>(),
+                               expected.data<float>(),
+                               expected.size());
+
+  const StorageView input_mps = input_cpu.to_float16().to(Device::MPS);
+  const StorageView gamma_mps = gamma_cpu.to_float16().to(Device::MPS);
+  const StorageView beta_mps = beta_cpu.to_float16().to(Device::MPS);
+  StorageView output(DataType::FLOAT16, Device::MPS);
+  ops::LayerNorm()(beta_mps, gamma_mps, input_mps, output);
+  primitives<Device::MPS>::add(float16_t(0.125f),
+                               output.data<float16_t>(),
+                               output.data<float16_t>(),
+                               output.size());
+
+  expect_storage_eq(output.to_float32(), expected, 3e-2f);
 }
 
 TEST(MPSBackendTest, DecodeGemmFloat16OddShapeAlphaBeta) {

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -7,6 +7,7 @@
 #ifdef CT2_WITH_MPS
 #  include "ctranslate2/allocator.h"
 #  include "ctranslate2/devices.h"
+#  include "mps/kernels.h"
 #  include "mps/utils.h"
 #endif
 
@@ -251,6 +252,20 @@ TEST_P(OpDeviceTest, TileMiddleDim) {
   expect_storage_eq(output, expected_output);
 }
 
+TEST_P(OpDeviceTest, TileInPlaceIdentity) {
+  Device device = GetParam();
+  StorageView input({2, 3}, std::vector<float>{1, 2, 3, 4, 5, 6}, device);
+  void* original_buffer = input.buffer();
+
+  ops::Tile(1, 1)(input);
+
+  EXPECT_EQ(input.buffer(), original_buffer);
+  assert_vector_eq(input.shape(), {2, 3});
+  expect_storage_eq(
+    input,
+    StorageView({2, 3}, std::vector<float>{1, 2, 3, 4, 5, 6}, device));
+}
+
 TEST_P(OpDeviceTest, ConcatEmpty) {
   Device device = GetParam();
   StorageView a({2, 1, 2}, std::vector<float>{1, 2, 3, 4}, device);
@@ -434,6 +449,23 @@ TEST_P(OpDeviceTest, GatherData3D) {
   expect_storage_eq(output, expected);
 }
 
+TEST_P(OpDeviceTest, GatherVectorAlignedRows) {
+  Device device = GetParam();
+  std::vector<float> values(32);
+  std::iota(values.begin(), values.end(), 0.f);
+  StorageView data({4, 8}, values, device);
+  StorageView ids({3}, std::vector<int32_t>{3, 1, 2}, device);
+  StorageView expected(
+    {3, 8},
+    std::vector<float>{24, 25, 26, 27, 28, 29, 30, 31,
+                       8, 9, 10, 11, 12, 13, 14, 15,
+                       16, 17, 18, 19, 20, 21, 22, 23},
+    device);
+  StorageView output(device);
+  ops::Gather(0)(data, ids, output);
+  expect_storage_eq(output, expected);
+}
+
 TEST_P(OpDeviceTest, GatherData2DIndex2D) {
   Device device = GetParam();
   StorageView data({4, 2}, std::vector<float>{1, 1, 2, 2, 3, 3, 4, 4}, device);
@@ -518,6 +550,32 @@ TEST_P(OpDeviceTest, Transpose3DReverse) {
   StorageView y(x.dtype(), x.device());
   ops::Transpose()(x, y);
   expect_storage_eq(y, expected);
+}
+
+TEST_P(OpDeviceTest, Transpose4DSwapMiddleDimensions) {
+  Device device = GetParam();
+  const Shape input_shape{2, 3, 4, 8};
+  std::vector<float> input_values(2 * 3 * 4 * 8);
+  std::iota(input_values.begin(), input_values.end(), 0.f);
+  std::vector<float> expected_values(input_values.size());
+  for (dim_t i0 = 0; i0 < input_shape[0]; ++i0) {
+    for (dim_t i1 = 0; i1 < input_shape[1]; ++i1) {
+      for (dim_t i2 = 0; i2 < input_shape[2]; ++i2) {
+        for (dim_t i3 = 0; i3 < input_shape[3]; ++i3) {
+          const dim_t input_index = ((i0 * input_shape[1] + i1) * input_shape[2] + i2)
+                                    * input_shape[3] + i3;
+          const dim_t output_index = ((i0 * input_shape[2] + i2) * input_shape[1] + i1)
+                                     * input_shape[3] + i3;
+          expected_values[output_index] = input_values[input_index];
+        }
+      }
+    }
+  }
+  StorageView input(input_shape, input_values, device);
+  StorageView expected({2, 4, 3, 8}, expected_values, device);
+  StorageView output(device);
+  ops::Transpose({0, 2, 1, 3})(input, output);
+  expect_storage_eq(output, expected);
 }
 
 static const StorageView gemm_a({4, 5}, std::vector<float>{
@@ -1521,6 +1579,63 @@ TEST(MPSBackendTest, BatchesDependentComputeDispatches) {
                     StorageView({4}, std::vector<float>{5, 8, 11, 14}));
 }
 
+TEST(MPSBackendTest, WeightOnlyInt8DenseFloat16MatchesReference) {
+  constexpr dim_t m = 17;
+  constexpr dim_t n = 33;
+  constexpr dim_t k = 37;
+  std::vector<float> input_values(m * k);
+  std::vector<int8_t> weight_values(n * k);
+  std::vector<float> scale_values(n);
+  std::vector<float> bias_values(n);
+  std::vector<float> residual_values(m * n);
+  for (dim_t i = 0; i < m * k; ++i)
+    input_values[i] = std::sin(static_cast<float>(i) * 0.071f) * 1.3f;
+  for (dim_t i = 0; i < n * k; ++i)
+    weight_values[i] = static_cast<int8_t>((i * 41 + 13) % 251 - 125);
+  for (dim_t i = 0; i < n; ++i) {
+    scale_values[i] = 48.0f + static_cast<float>(i % 13);
+    bias_values[i] = std::cos(static_cast<float>(i) * 0.11f) * 0.1f;
+  }
+  for (dim_t i = 0; i < m * n; ++i)
+    residual_values[i] = std::sin(static_cast<float>(i) * 0.047f) * 0.2f;
+
+  std::vector<float> expected_values(m * n);
+  for (dim_t row = 0; row < m; ++row) {
+    for (dim_t column = 0; column < n; ++column) {
+      float sum = 0;
+      for (dim_t p = 0; p < k; ++p)
+        sum += static_cast<float>(float16_t(input_values[row * k + p]))
+               * static_cast<float>(weight_values[column * k + p]);
+      float value = sum / scale_values[column]
+                    + static_cast<float>(float16_t(bias_values[column]));
+      value = std::max(value, 0.0f);
+      value = static_cast<float>(float16_t(value));
+      value += static_cast<float>(float16_t(residual_values[row * n + column]));
+      expected_values[row * n + column] = static_cast<float>(float16_t(value));
+    }
+  }
+
+  const StorageView input = StorageView({m, k}, input_values).to_float16().to(Device::MPS);
+  const StorageView weight = StorageView({n, k}, weight_values).to(Device::MPS);
+  const StorageView scales = StorageView({n}, scale_values).to(Device::MPS);
+  const StorageView bias = StorageView({n}, bias_values).to_float16().to(Device::MPS);
+  const StorageView residual = StorageView({m, n}, residual_values).to_float16().to(Device::MPS);
+  StorageView output({m, n}, DataType::FLOAT16, Device::MPS);
+  ASSERT_TRUE(mps::gemm_weight_only_int8_with_epilogue(
+    input.data<float16_t>(),
+    weight.data<int8_t>(),
+    scales.data<float>(),
+    scales.size(),
+    bias.data<float16_t>(),
+    residual.data<float16_t>(),
+    output.data<float16_t>(),
+    m,
+    n,
+    k,
+    static_cast<int>(mps::UnaryOp::RELU)));
+  expect_storage_eq(output.to_float32(), StorageView({m, n}, expected_values), 2e-2f);
+}
+
 TEST(MPSBackendTest, LayerNormParallelReductionIsStable) {
   constexpr dim_t rows = 7;
   constexpr dim_t width = 512;
@@ -1588,6 +1703,50 @@ TEST(MPSBackendTest, WhisperSizedFloat16LayerNormFeedsDependentDispatch) {
   expect_storage_eq(output.to_float32(), expected, 3e-2f);
 }
 
+TEST(MPSBackendTest, FusedBiasResidualLayerNormMatchesMaterializedFloat16) {
+  constexpr dim_t rows = 7;
+  constexpr dim_t width = 513;
+  std::vector<float> input_values(rows * width);
+  std::vector<float> residual_values(rows * width);
+  std::vector<float> bias_values(width);
+  std::vector<float> gamma_values(width);
+  std::vector<float> beta_values(width);
+  for (dim_t i = 0; i < rows * width; ++i) {
+    input_values[i] = std::sin(static_cast<float>(i) * 0.013f) * 1.25f;
+    residual_values[i] = std::cos(static_cast<float>(i) * 0.021f) * 0.4f;
+  }
+  for (dim_t i = 0; i < width; ++i) {
+    bias_values[i] = std::sin(static_cast<float>(i) * 0.017f) * 0.15f;
+    gamma_values[i] = 0.8f + std::cos(static_cast<float>(i) * 0.011f) * 0.1f;
+    beta_values[i] = std::sin(static_cast<float>(i) * 0.023f) * 0.1f;
+  }
+
+  const StorageView input = StorageView({rows, width}, input_values).to_float16().to(Device::MPS);
+  const StorageView residual = StorageView({rows, width}, residual_values).to_float16().to(Device::MPS);
+  const StorageView bias = StorageView({width}, bias_values).to_float16().to(Device::MPS);
+  const StorageView gamma = StorageView({width}, gamma_values).to_float16().to(Device::MPS);
+  const StorageView beta = StorageView({width}, beta_values).to_float16().to(Device::MPS);
+
+  StorageView materialized(DataType::FLOAT16, Device::MPS);
+  ops::BiasAdd()(input, bias, materialized, &residual);
+  ops::LayerNorm()(beta, gamma, materialized, materialized);
+
+  StorageView fused({rows, width}, DataType::FLOAT16, Device::MPS);
+  ASSERT_TRUE(mps::fused_bias_residual_layer_norm(
+    DataType::FLOAT16,
+    input.data<float16_t>(),
+    bias.data<float16_t>(),
+    residual.data<float16_t>(),
+    gamma.data<float16_t>(),
+    beta.data<float16_t>(),
+    fused.data<float16_t>(),
+    rows,
+    width,
+    1e-5f));
+
+  expect_storage_eq(fused.to_float32(), materialized.to_float32(), 1e-3f);
+}
+
 TEST(MPSBackendTest, DecodeGemmFloat16OddShapeAlphaBeta) {
   constexpr dim_t k = 37;
   constexpr dim_t n = 33;
@@ -1612,6 +1771,70 @@ TEST(MPSBackendTest, DecodeGemmFloat16OddShapeAlphaBeta) {
   ops::Gemm(/*alpha=*/0.75f, /*beta=*/0.25f, false, true)(a_mps, b_mps, output);
 
   expect_storage_eq(output.to_float32(), expected, 3e-2f);
+}
+
+TEST(MPSBackendTest, Beam5GemmFloat16AlphaBetaAndTail) {
+  constexpr dim_t m = 5;
+  constexpr dim_t k = 68;
+  constexpr dim_t n = 37;
+  std::vector<float> a_values(m * k);
+  std::vector<float> b_values(n * k);
+  std::vector<float> c_values(m * n);
+  for (dim_t i = 0; i < m * k; ++i)
+    a_values[i] = std::sin(static_cast<float>(i) * 0.13f) * 0.3f;
+  for (dim_t i = 0; i < n * k; ++i)
+    b_values[i] = std::cos(static_cast<float>(i) * 0.07f) * 0.2f;
+  for (dim_t i = 0; i < m * n; ++i)
+    c_values[i] = static_cast<float>(i % 17 - 8) * 0.025f;
+
+  const StorageView a_cpu({m, k}, a_values);
+  const StorageView b_cpu({n, k}, b_values);
+  StorageView expected({m, n}, c_values);
+  ops::Gemm(/*alpha=*/0.75f, /*beta=*/0.25f, false, true)(a_cpu, b_cpu, expected);
+
+  const StorageView a_mps = a_cpu.to_float16().to(Device::MPS);
+  const StorageView b_mps = b_cpu.to_float16().to(Device::MPS);
+  StorageView actual = StorageView({m, n}, c_values).to_float16().to(Device::MPS);
+  ops::Gemm(/*alpha=*/0.75f, /*beta=*/0.25f, false, true)(a_mps, b_mps, actual);
+
+  expect_storage_eq(actual.to_float32(), expected, 3e-2f);
+}
+
+TEST(MPSBackendTest, Beam5GemmFloat16FusedEpilogue) {
+  constexpr dim_t m = 5;
+  constexpr dim_t k = 64;
+  constexpr dim_t n = 35;
+  std::vector<float> a_values(m * k);
+  std::vector<float> b_values(n * k);
+  std::vector<float> bias_values(n);
+  std::vector<float> residual_values(m * n);
+  for (dim_t i = 0; i < m * k; ++i)
+    a_values[i] = std::sin(static_cast<float>(i) * 0.09f) * 0.2f;
+  for (dim_t i = 0; i < n * k; ++i)
+    b_values[i] = std::cos(static_cast<float>(i) * 0.05f) * 0.15f;
+  for (dim_t i = 0; i < n; ++i)
+    bias_values[i] = static_cast<float>(i - 11) * 0.004f;
+  for (dim_t i = 0; i < m * n; ++i)
+    residual_values[i] = std::sin(static_cast<float>(i) * 0.03f) * 0.1f;
+
+  const StorageView a_cpu({m, k}, a_values);
+  const StorageView b_cpu({n, k}, b_values);
+  const StorageView bias_cpu({n}, bias_values);
+  const StorageView residual_cpu({m, n}, residual_values);
+  const ops::ActivationType activation = ops::ActivationType::GELU;
+  StorageView expected;
+  ops::Gemm(1, 0, false, true, false, false, &activation)(
+    a_cpu, b_cpu, expected, &residual_cpu, &bias_cpu);
+
+  const StorageView a_mps = a_cpu.to_float16().to(Device::MPS);
+  const StorageView b_mps = b_cpu.to_float16().to(Device::MPS);
+  const StorageView bias_mps = bias_cpu.to_float16().to(Device::MPS);
+  const StorageView residual_mps = residual_cpu.to_float16().to(Device::MPS);
+  StorageView actual(DataType::FLOAT16, Device::MPS);
+  ops::Gemm(1, 0, false, true, false, false, &activation)(
+    a_mps, b_mps, actual, &residual_mps, &bias_mps);
+
+  expect_storage_eq(actual.to_float32(), expected, 4e-2f);
 }
 
 TEST(MPSBackendTest, DecodeGemmFloat16NonTransposedWeight) {
@@ -1732,6 +1955,42 @@ TEST(MPSBackendTest, ColdDecodeGemmChainMatchesCPU) {
   expect_storage_eq(output_mps.to_float32(), expected, 6e-2f);
 }
 
+TEST(MPSBackendTest, DeferredTemporaryFeedsDependentGemm) {
+  constexpr dim_t rows = 8;
+  constexpr dim_t input_size = 64;
+  constexpr dim_t hidden_size = 128;
+  constexpr dim_t output_size = 32;
+  std::vector<float> input_values(rows * input_size);
+  std::vector<float> first_weight_values(hidden_size * input_size);
+  std::vector<float> second_weight_values(output_size * hidden_size);
+  for (dim_t i = 0; i < rows * input_size; ++i)
+    input_values[i] = std::sin(static_cast<float>(i) * 0.013f) * 0.1f;
+  for (dim_t i = 0; i < hidden_size * input_size; ++i)
+    first_weight_values[i] = std::cos(static_cast<float>(i) * 0.003f) * 0.02f;
+  for (dim_t i = 0; i < output_size * hidden_size; ++i)
+    second_weight_values[i] = std::sin(static_cast<float>(i) * 0.002f) * 0.015f;
+
+  const StorageView input_cpu({rows, input_size}, input_values);
+  const StorageView first_weight_cpu({hidden_size, input_size}, first_weight_values);
+  const StorageView second_weight_cpu({output_size, hidden_size}, second_weight_values);
+  StorageView hidden_cpu;
+  StorageView expected;
+  ops::Gemm(1, 0, false, true)(input_cpu, first_weight_cpu, hidden_cpu);
+  ops::Gemm(1, 0, false, true)(hidden_cpu, second_weight_cpu, expected);
+
+  const StorageView input_mps = input_cpu.to_float16().to(Device::MPS);
+  const StorageView first_weight_mps = first_weight_cpu.to_float16().to(Device::MPS);
+  const StorageView second_weight_mps = second_weight_cpu.to_float16().to(Device::MPS);
+  StorageView actual(DataType::FLOAT16, Device::MPS);
+  {
+    StorageView temporary(DataType::FLOAT16, Device::MPS);
+    ops::Gemm(1, 0, false, true)(input_mps, first_weight_mps, temporary);
+    ops::Gemm(1, 0, false, true)(temporary, second_weight_mps, actual);
+  }
+
+  expect_storage_eq(actual.to_float32(), expected, 3e-2f);
+}
+
 TEST(MPSBackendTest, TopKFloat16TieUsesFirstIndex) {
   const StorageView input = StorageView({1, 7},
                                         std::vector<float>{1, 4, 2, 4, 3, 0, -1})
@@ -1741,6 +2000,110 @@ TEST(MPSBackendTest, TopKFloat16TieUsesFirstIndex) {
   StorageView indices(DataType::INT32, Device::MPS);
   ops::TopK(1)(input, values, indices);
   expect_storage_eq(indices, StorageView({1, 1}, std::vector<int32_t>{1}));
+}
+
+TEST(MPSBackendTest, FusedBeamSearchTopKMatchesMaterializedFloat16) {
+  constexpr dim_t batch_size = 2;
+  constexpr dim_t beam_size = 4;
+  constexpr dim_t vocabulary_size = 513;
+  constexpr dim_t k = 8;
+  std::vector<float> logits_values(batch_size * beam_size * vocabulary_size);
+  std::vector<float> beam_score_values(batch_size * beam_size);
+  for (dim_t i = 0; i < static_cast<dim_t>(logits_values.size()); ++i)
+    logits_values[i] = std::sin(static_cast<float>(i) * 0.017f) * 3.0f
+                       + std::cos(static_cast<float>(i) * 0.007f);
+  for (dim_t i = 0; i < static_cast<dim_t>(beam_score_values.size()); ++i)
+    beam_score_values[i] = static_cast<float>(i % beam_size) * -0.37f;
+  // Exercise deterministic tie ordering across beams.
+  logits_values[17] = logits_values[vocabulary_size + 19] = 8.0f;
+
+  StorageView logits = StorageView({batch_size * beam_size, vocabulary_size}, logits_values)
+                         .to_float16()
+                         .to(Device::MPS);
+  const StorageView beam_scores = StorageView({batch_size * beam_size}, beam_score_values)
+                                    .to_float16()
+                                    .to(Device::MPS);
+  StorageView materialized(logits);
+  ops::LogSoftMax()(materialized);
+  primitives<Device::MPS>::add_depth_broadcast(
+    beam_scores.data<float16_t>(),
+    materialized.data<float16_t>(),
+    beam_scores.size(),
+    materialized.size());
+  materialized.reshape({batch_size, beam_size * vocabulary_size});
+  StorageView expected_values(DataType::FLOAT16, Device::MPS);
+  StorageView expected_indices(DataType::INT32, Device::MPS);
+  const ops::TopK topk(k);
+  topk(materialized, expected_values, expected_indices);
+
+  StorageView actual_values({batch_size, k}, DataType::FLOAT16, Device::MPS);
+  StorageView actual_indices({batch_size, k}, DataType::INT32, Device::MPS);
+  ASSERT_TRUE(mps::fused_beam_search_topk(
+    DataType::FLOAT16,
+    logits.data<float16_t>(),
+    beam_scores.data<float16_t>(),
+    actual_values.data<float16_t>(),
+    actual_indices.data<int32_t>(),
+    batch_size,
+    beam_size,
+    vocabulary_size,
+    k));
+
+  expect_storage_eq(actual_indices, expected_indices);
+  expect_storage_eq(actual_values.to_float32(), expected_values.to_float32(), 1e-3f);
+}
+
+TEST(MPSBackendTest, FusedBeamSearchTopKSupportsBeam5) {
+  constexpr dim_t batch_size = 2;
+  constexpr dim_t beam_size = 5;
+  constexpr dim_t vocabulary_size = 509;
+  constexpr dim_t k = 10;
+  std::vector<float> logits_values(batch_size * beam_size * vocabulary_size, -20.0f);
+  std::vector<float> beam_score_values(batch_size * beam_size);
+  for (dim_t row = 0; row < batch_size * beam_size; ++row) {
+    for (dim_t rank = 0; rank < 16; ++rank) {
+      const dim_t column = (row * 37 + rank * 19) % vocabulary_size;
+      logits_values[row * vocabulary_size + column]
+        = 8.0f - static_cast<float>(rank) * 0.4f
+          - static_cast<float>(row) * 0.031f;
+    }
+    beam_score_values[row] = static_cast<float>(row % beam_size) * -0.37f;
+  }
+
+  StorageView logits = StorageView({batch_size * beam_size, vocabulary_size}, logits_values)
+                         .to_float16()
+                         .to(Device::MPS);
+  const StorageView beam_scores = StorageView({batch_size * beam_size}, beam_score_values)
+                                    .to_float16()
+                                    .to(Device::MPS);
+  StorageView materialized(logits);
+  ops::LogSoftMax()(materialized);
+  primitives<Device::MPS>::add_depth_broadcast(
+    beam_scores.data<float16_t>(),
+    materialized.data<float16_t>(),
+    beam_scores.size(),
+    materialized.size());
+  materialized.reshape({batch_size, beam_size * vocabulary_size});
+  StorageView expected_values(DataType::FLOAT16, Device::MPS);
+  StorageView expected_indices(DataType::INT32, Device::MPS);
+  const ops::TopK topk(k);
+  topk(materialized, expected_values, expected_indices);
+
+  StorageView actual_values({batch_size, k}, DataType::FLOAT16, Device::MPS);
+  StorageView actual_indices({batch_size, k}, DataType::INT32, Device::MPS);
+  ASSERT_TRUE(mps::fused_beam_search_topk(
+    DataType::FLOAT16,
+    logits.data<float16_t>(),
+    beam_scores.data<float16_t>(),
+    actual_values.data<float16_t>(),
+    actual_indices.data<int32_t>(),
+    batch_size,
+    beam_size,
+    vocabulary_size,
+    k));
+
+  expect_storage_eq(actual_indices, expected_indices);
+  expect_storage_eq(actual_values.to_float32(), expected_values.to_float32(), 1e-3f);
 }
 
 TEST(MPSBackendTest, BatchedDecodeGemmBroadcastAndInteriorOffsets) {
@@ -1781,6 +2144,61 @@ TEST(MPSBackendTest, BatchedDecodeGemmBroadcastAndInteriorOffsets) {
   }
 }
 
+TEST(MPSBackendTest, FusedAttentionFloat16MatchesMaterializedPath) {
+  constexpr dim_t batch_size = 2;
+  constexpr dim_t query_length = 4;
+  constexpr dim_t key_length = 7;
+  constexpr dim_t depth = 12;
+
+  std::vector<float> query_values(batch_size * query_length * depth);
+  std::vector<float> key_values(batch_size * key_length * depth);
+  std::vector<float> value_values(batch_size * key_length * depth);
+  for (size_t i = 0; i < query_values.size(); ++i)
+    query_values[i] = std::sin(static_cast<float>(i) * 0.07f);
+  for (size_t i = 0; i < key_values.size(); ++i) {
+    key_values[i] = std::cos(static_cast<float>(i) * 0.05f);
+    value_values[i] = std::sin(static_cast<float>(i) * 0.11f);
+  }
+
+  const StorageView queries = StorageView({batch_size, query_length, depth}, query_values)
+                                .to_float16()
+                                .to(Device::MPS);
+  const StorageView keys = StorageView({batch_size, key_length, depth}, key_values)
+                             .to_float16()
+                             .to(Device::MPS);
+  const StorageView values = StorageView({batch_size, key_length, depth}, value_values)
+                               .to_float16()
+                               .to(Device::MPS);
+  const StorageView lengths({batch_size * query_length},
+                            std::vector<int32_t>{7, 6, 5, 4, 3, 7, 2, 1},
+                            Device::MPS);
+
+  constexpr float scale = 0.25f;
+  StorageView scores(DataType::FLOAT16, Device::MPS);
+  ops::MatMul(false, true, scale)(queries, keys, scores);
+  StorageView probabilities(DataType::FLOAT16, Device::MPS);
+  ops::SoftMax()(scores, lengths, probabilities);
+  StorageView expected(DataType::FLOAT16, Device::MPS);
+  ops::MatMul()(probabilities, values, expected);
+
+  StorageView actual({batch_size, query_length, depth},
+                     DataType::FLOAT16,
+                     Device::MPS);
+  ASSERT_TRUE(mps::fused_attention(DataType::FLOAT16,
+                                   queries.data<float16_t>(),
+                                   keys.data<float16_t>(),
+                                   values.data<float16_t>(),
+                                   lengths.data<int32_t>(),
+                                   actual.data<float16_t>(),
+                                   batch_size,
+                                   query_length,
+                                   key_length,
+                                   depth,
+                                   scale));
+
+  expect_storage_eq(actual.to_float32(), expected.to_float32(), 2e-2f);
+}
+
 TEST(MPSBackendTest, SupportsBF16AndINT8Gemm) {
   const StorageView fp32({1, 4}, std::vector<float>{1, 2, 3, 4});
   const StorageView bf16 = fp32.to(DataType::BFLOAT16).to(Device::MPS);
@@ -1801,6 +2219,14 @@ TEST(MPSBackendTest, AutoComputeTypePrefersFloat16) {
                                  Device::MPS,
                                  0),
             ComputeType::FLOAT16);
+}
+
+TEST(MPSBackendTest, GenericInt8ComputeTypeUsesFloat16Activations) {
+  EXPECT_EQ(resolve_compute_type(ComputeType::INT8,
+                                 ComputeType::FLOAT32,
+                                 Device::MPS,
+                                 0),
+            ComputeType::INT8_FLOAT16);
 }
 
 TEST(MPSBackendTest, GumbelMaxBF16ProducesValidUniqueIndices) {

--- a/tests/ops_test.cc
+++ b/tests/ops_test.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdlib>
 #include <set>
 #include "test_utils.h"
 #include "ctranslate2/layers/attention.h"
@@ -2221,12 +2222,48 @@ TEST(MPSBackendTest, AutoComputeTypePrefersFloat16) {
             ComputeType::FLOAT16);
 }
 
-TEST(MPSBackendTest, GenericInt8ComputeTypeUsesFloat16Activations) {
+TEST(MPSBackendTest, Int8ComputeTypesPreferFloat16Execution) {
+  const char* previous = std::getenv("CT2_MPS_CACHE_INT8_FP16");
+  const std::string previous_value = previous ? previous : "";
+  unsetenv("CT2_MPS_CACHE_INT8_FP16");
+
+  EXPECT_EQ(resolve_compute_type(ComputeType::INT8,
+                                 ComputeType::FLOAT32,
+                                 Device::MPS,
+                                 0),
+            ComputeType::FLOAT16);
+  EXPECT_EQ(resolve_compute_type(ComputeType::INT8_FLOAT16,
+                                 ComputeType::INT8_FLOAT16,
+                                 Device::MPS,
+                                 0),
+            ComputeType::FLOAT16);
+
+  if (previous)
+    setenv("CT2_MPS_CACHE_INT8_FP16", previous_value.c_str(), 1);
+  else
+    unsetenv("CT2_MPS_CACHE_INT8_FP16");
+}
+
+TEST(MPSBackendTest, NativeInt8RequiresExplicitOptIn) {
+  const char* previous = std::getenv("CT2_MPS_CACHE_INT8_FP16");
+  const std::string previous_value = previous ? previous : "";
+  setenv("CT2_MPS_CACHE_INT8_FP16", "0", 1);
+
   EXPECT_EQ(resolve_compute_type(ComputeType::INT8,
                                  ComputeType::FLOAT32,
                                  Device::MPS,
                                  0),
             ComputeType::INT8_FLOAT16);
+  EXPECT_EQ(resolve_compute_type(ComputeType::INT8_FLOAT16,
+                                 ComputeType::INT8_FLOAT16,
+                                 Device::MPS,
+                                 0),
+            ComputeType::INT8_FLOAT16);
+
+  if (previous)
+    setenv("CT2_MPS_CACHE_INT8_FP16", previous_value.c_str(), 1);
+  else
+    unsetenv("CT2_MPS_CACHE_INT8_FP16");
 }
 
 TEST(MPSBackendTest, GumbelMaxBF16ProducesValidUniqueIndices) {

--- a/tests/primitives_test.cc
+++ b/tests/primitives_test.cc
@@ -55,3 +55,6 @@ INSTANTIATE_TEST_SUITE_P(CPU, PrimitiveTest, ::testing::Values(Device::CPU));
 #ifdef CT2_WITH_CUDA
 INSTANTIATE_TEST_SUITE_P(CUDA, PrimitiveTest, ::testing::Values(Device::CUDA));
 #endif
+#ifdef CT2_WITH_MPS
+INSTANTIATE_TEST_SUITE_P(MPS, PrimitiveTest, ::testing::Values(Device::MPS));
+#endif

--- a/tests/primitives_test.cc
+++ b/tests/primitives_test.cc
@@ -51,6 +51,38 @@ TEST_P(PrimitiveTest, PenalizePreviousTokens) {
   expect_storage_eq(scores, expected);
 }
 
+#ifdef CT2_WITH_MPS
+TEST(MPSPrimitiveTest, PenalizePreviousTokensFloat16OddLength) {
+  const std::vector<float> score_values{
+    0.5f, 1.f, -1.5f, 2.f, -2.5f, 3.f, -3.5f,
+    -4.f, 4.5f, -5.f, 5.5f, -6.f, 6.5f, -7.f};
+  StorageView scores = StorageView({2, 7}, score_values).to_float16().to(Device::MPS);
+  const StorageView previous_ids(
+    {2, 3}, std::vector<int32_t>{0, 2, 6, 1, 4, 4}, Device::MPS);
+  const StorageView previous_scores =
+    StorageView({2, 3}, std::vector<float>{0.5f, -1.5f, -3.5f, 4.5f, -6.f, -6.f})
+      .to_float16()
+      .to(Device::MPS);
+
+  std::vector<float> expected_values = score_values;
+  expected_values[0] = 0.25f;
+  expected_values[2] = -3.f;
+  expected_values[6] = -7.f;
+  expected_values[8] = 2.25f;
+  expected_values[11] = -12.f;
+  const StorageView expected = StorageView({2, 7}, expected_values).to_float16();
+
+  primitives<Device::MPS>::penalize_previous_tokens(scores.data<float16_t>(),
+                                                     previous_scores.data<float16_t>(),
+                                                     previous_ids.data<int32_t>(),
+                                                     float16_t(2.f),
+                                                     scores.dim(0),
+                                                     previous_ids.dim(1),
+                                                     scores.dim(1));
+  expect_storage_eq(scores, expected);
+}
+#endif
+
 INSTANTIATE_TEST_SUITE_P(CPU, PrimitiveTest, ::testing::Values(Device::CPU));
 #ifdef CT2_WITH_CUDA
 INSTANTIATE_TEST_SUITE_P(CUDA, PrimitiveTest, ::testing::Values(Device::CUDA));

--- a/tests/storage_view_test.cc
+++ b/tests/storage_view_test.cc
@@ -78,3 +78,6 @@ INSTANTIATE_TEST_SUITE_P(CPU, StorageViewDeviceTest, ::testing::Values(Device::C
 #ifdef CT2_WITH_CUDA
 INSTANTIATE_TEST_SUITE_P(CUDA, StorageViewDeviceTest, ::testing::Values(Device::CUDA));
 #endif
+#ifdef CT2_WITH_MPS
+INSTANTIATE_TEST_SUITE_P(MPS, StorageViewDeviceTest, ::testing::Values(Device::MPS));
+#endif

--- a/tests/storage_view_test.cc
+++ b/tests/storage_view_test.cc
@@ -88,3 +88,6 @@ INSTANTIATE_TEST_SUITE_P(CPU, StorageViewDeviceTest, ::testing::Values(Device::C
 #ifdef CT2_WITH_CUDA
 INSTANTIATE_TEST_SUITE_P(CUDA, StorageViewDeviceTest, ::testing::Values(Device::CUDA));
 #endif
+#ifdef CT2_WITH_MPS
+INSTANTIATE_TEST_SUITE_P(MPS, StorageViewDeviceTest, ::testing::Values(Device::MPS));
+#endif

--- a/tests/translator_test.cc
+++ b/tests/translator_test.cc
@@ -103,6 +103,33 @@ static Translator default_translator(Device device = Device::CPU) {
   return Translator(default_model_dir(), device);
 }
 
+#ifdef CT2_WITH_MPS
+TEST(TranslatorTest, MPSFloat32GreedyMatchesCPU) {
+  const std::vector<std::string> input = {"آ", "ت", "ز", "م", "و", "ن"};
+  TranslationOptions options;
+  options.beam_size = 1;
+  options.max_decoding_length = 12;
+
+  Translator cpu(default_model_dir(), Device::CPU, ComputeType::FLOAT32);
+  Translator mps(default_model_dir(), Device::MPS, ComputeType::FLOAT32);
+  const auto expected = cpu.translate_batch({input}, options)[0].output();
+  const auto output = mps.translate_batch({input}, options)[0].output();
+  EXPECT_EQ(output, expected);
+}
+
+TEST(TranslatorTest, MPSFloat16GreedyMatchesCPU) {
+  const std::vector<std::string> input = {"آ", "ت", "ز", "م", "و", "ن"};
+  TranslationOptions options;
+  options.beam_size = 1;
+  options.max_decoding_length = 12;
+  Translator cpu(default_model_dir(), Device::CPU, ComputeType::FLOAT32);
+  Translator mps(default_model_dir(), Device::MPS, ComputeType::FLOAT16);
+  const auto expected = cpu.translate_batch({input}, options)[0].output();
+  const auto output = mps.translate_batch({input}, options)[0].output();
+  EXPECT_EQ(output, expected);
+}
+#endif
+
 TEST_P(SearchVariantTest, SetMaxDecodingLength) {
   Translator translator = default_translator();
   TranslationOptions options;

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -34,6 +34,12 @@ Note: the script focuses on raw decoding performance so the following steps are 
 * detokenization
 * model initialization (obtained by translating an empty file)
 
+### MPS quality benchmarks
+
+The Docker benchmark cannot expose Apple Metal. Use the host-native
+[quality benchmarks](quality/README.md) to compare Whisper WER and translation
+BLEU between CPU and MPS with identical models and decoding settings.
+
 ### Reproducing the benchmark numbers from the README
 
 We use the script `benchmark_all.py` to produce the benchmark numbers in the main [README](https://github.com/OpenNMT/CTranslate2#benchmarks). The script builds all Docker images defined in subdirectories and reports the results as a Markdown table. The execution can take up to 3 hours.

--- a/tools/benchmark/quality/README.md
+++ b/tools/benchmark/quality/README.md
@@ -1,0 +1,121 @@
+# MPS quality benchmarks
+
+These host-native benchmarks compare CPU and MPS with the same model, input,
+search settings, and sample order. Model loading and one warm-up inference are
+reported separately and are not included in inference time.
+
+Install the optional dependencies in the environment containing this
+CTranslate2 build:
+
+```bash
+python -m pip install -r tools/benchmark/quality/requirements.txt
+```
+
+## Whisper WER
+
+The Whisper benchmark follows the faster-whisper reference setup: the
+LibriSpeech `clean` validation split, English normalization, and corpus WER.
+The default model is `Systran/faster-whisper-small.en`, with beam size 5 on
+both devices. The spelling normalizer is pinned to faster-whisper commit
+`ed9a06cd89a93e47838f564998a6c09b655d7f43`, downloaded once, and verified by
+SHA-256 before use.
+
+Use a short run to verify the setup:
+
+```bash
+python tools/benchmark/quality/whisper_wer.py \
+  --max-samples 25 \
+  --output whisper-smoke.json
+```
+
+Omit `--max-samples` for the reportable 2,703-utterance result:
+
+```bash
+python tools/benchmark/quality/whisper_wer.py \
+  --model Systran/faster-whisper-small.en \
+  --beam-size 5 \
+  --cpu-compute-type float32 \
+  --mps-compute-type float16 \
+  --output whisper-librispeech-clean.json
+```
+
+The model and dataset are downloaded on first use and then read from the local
+Hugging Face cache. A subset is useful for correctness and estimating runtime,
+but its WER should not be published as the LibriSpeech validation result.
+
+## Translation BLEU
+
+This extends the existing CTranslate2 translation benchmark with a native MPS
+path. It uses SacreBLEU's WMT14 English-German files and the OPUS-MT model that
+is already represented under `tools/benchmark/opus_mt_ende`.
+
+Convert the model once without quantizing the stored weights:
+
+```bash
+ct2-transformers-converter \
+  --model Helsinki-NLP/opus-mt-en-de \
+  --output_dir opus-mt-en-de-ct2
+```
+
+Then run a smoke comparison:
+
+```bash
+python tools/benchmark/quality/translation_bleu.py \
+  --model opus-mt-en-de-ct2 \
+  --max-samples 64 \
+  --output translation-smoke.json
+```
+
+Omit `--max-samples` for the reportable full WMT14 result:
+
+```bash
+python tools/benchmark/quality/translation_bleu.py \
+  --model opus-mt-en-de-ct2 \
+  --beam-size 4 \
+  --batch-size 4 \
+  --length-penalty 0 \
+  --cpu-compute-type float32 \
+  --mps-compute-type float16 \
+  --output translation-wmt14-en-de.json
+```
+
+The default beam size (4), length penalty (0), and batch size (32) match the
+existing CTranslate2 WMT14 benchmark. The measured MPS result below uses batch
+size 4, which was selected before the full evaluation and is specified
+explicitly in the reproduction command. The JSON output records the model,
+compute types, settings, platform, timings, BLEU scores, output agreement, and
+individual hypotheses needed to investigate any CPU/MPS difference.
+
+## Measured Apple M1 results
+
+These full-dataset measurements were collected with CTranslate2 4.8.1 from a
+native arm64 Release build on a MacBook Air with an Apple M1 (7-core GPU), 8 GB
+unified memory, and macOS 26.5.2. Model loading and the warm-up inference are
+excluded from inference time. CPU and MPS used the same model, inputs, sample
+order, and decoding settings; the compute types are reported separately.
+
+### LibriSpeech clean validation
+
+Model: `Systran/faster-whisper-small.en`; 2,703 utterances; beam size 5.
+
+| Device | Compute type | WER | Inference time | Audio speed |
+|---|---:|---:|---:|---:|
+| CPU | FP32 | 2.9125% | 7,929.29 s | 2.45x realtime |
+| MPS | FP16 | 2.9089% | 4,114.88 s | 4.71x realtime |
+
+MPS was 1.93x faster, with a WER difference of -0.0036 percentage points and
+99.63% exact normalized transcript agreement.
+
+### WMT14 English-German
+
+Model: `Helsinki-NLP/opus-mt-en-de`; 2,737 sentences; beam size 4; batch size
+4; length penalty 0.
+
+| Device | Compute type | BLEU | Inference time | Output tokens/s |
+|---|---:|---:|---:|---:|
+| CPU | FP32 | 27.9152 | 665.24 s | 107.69 |
+| MPS | FP16 | 27.9332 | 312.97 s | 228.89 |
+
+MPS was 2.13x faster, with a BLEU difference of +0.0180 and 96.60% exact
+translation agreement. The SacreBLEU signature was
+`nrefs:1|case:mixed|eff:no|tok:13a|smooth:exp|version:2.6.0`.

--- a/tools/benchmark/quality/requirements.txt
+++ b/tools/benchmark/quality/requirements.txt
@@ -1,0 +1,6 @@
+datasets>=4.0
+faster-whisper>=1.2
+jiwer>=3.0
+sacrebleu>=2.4
+sentencepiece>=0.2
+transformers>=4.40,<5

--- a/tools/benchmark/quality/translation_bleu.py
+++ b/tools/benchmark/quality/translation_bleu.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Compare CTranslate2 translation quality and speed on CPU and MPS."""
+
+import argparse
+import gc
+import json
+import platform
+import time
+from pathlib import Path
+
+import ctranslate2
+import sacrebleu
+from tqdm import tqdm
+from transformers import AutoTokenizer
+
+
+def get_wmt14_files():
+    if not hasattr(sacrebleu, "get_source_file"):
+        raise RuntimeError(
+            "This benchmark requires the SacreBLEU compatibility dataset API"
+        )
+    source = sacrebleu.get_source_file("wmt14", langpair="en-de")
+    reference = sacrebleu.get_reference_files("wmt14", langpair="en-de")[0]
+    return Path(source), Path(reference)
+
+
+def read_lines(path, max_samples):
+    with path.open(encoding="utf-8") as stream:
+        lines = [line.rstrip("\n") for line in stream]
+    return lines if max_samples is None else lines[:max_samples]
+
+
+def encode_source(tokenizer, text):
+    token_ids = tokenizer.encode(text, add_special_tokens=True)
+    return tokenizer.convert_ids_to_tokens(token_ids)
+
+
+def decode_target(tokenizer, tokens):
+    token_ids = tokenizer.convert_tokens_to_ids(tokens)
+    return tokenizer.decode(
+        token_ids,
+        skip_special_tokens=True,
+        clean_up_tokenization_spaces=False,
+    )
+
+
+def benchmark_device(args, device, compute_type, source_tokens, tokenizer):
+    if device == "mps":
+        if not hasattr(ctranslate2, "get_mps_device_count"):
+            raise RuntimeError("CTranslate2 was not built with MPS support")
+        if ctranslate2.get_mps_device_count() < 1:
+            raise RuntimeError("No Apple MPS device is available")
+
+    load_start = time.perf_counter()
+    translator = ctranslate2.Translator(
+        str(args.model),
+        device=device,
+        compute_type=compute_type,
+        intra_threads=args.cpu_threads,
+    )
+    load_seconds = time.perf_counter() - load_start
+
+    translate_options = {
+        "beam_size": args.beam_size,
+        "length_penalty": args.length_penalty,
+    }
+    translator.translate_batch(source_tokens[:1], **translate_options)
+
+    hypotheses = []
+    output_tokens = 0
+    inference_start = time.perf_counter()
+    offsets = range(0, len(source_tokens), args.batch_size)
+    for offset in tqdm(
+        offsets,
+        desc=f"{device.upper()} BLEU",
+        unit="batch",
+    ):
+        batch = source_tokens[offset : offset + args.batch_size]
+        results = translator.translate_batch(batch, **translate_options)
+        for result in results:
+            tokens = result.hypotheses[0]
+            output_tokens += len(tokens)
+            hypotheses.append(decode_target(tokenizer, tokens))
+    inference_seconds = time.perf_counter() - inference_start
+
+    result = {
+        "device": device,
+        "compute_type": compute_type,
+        "model_load_seconds": load_seconds,
+        "inference_seconds": inference_seconds,
+        "sentences_per_second": len(hypotheses) / inference_seconds,
+        "output_tokens": output_tokens,
+        "output_tokens_per_second": output_tokens / inference_seconds,
+        "hypotheses": hypotheses,
+    }
+    del translator
+    gc.collect()
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument(
+        "--tokenizer",
+        default="Helsinki-NLP/opus-mt-en-de",
+        help="Tokenizer path or Hugging Face model name",
+    )
+    parser.add_argument("--source", type=Path)
+    parser.add_argument("--reference", type=Path)
+    parser.add_argument("--beam-size", type=int, default=4)
+    parser.add_argument("--length-penalty", type=float, default=0)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--cpu-compute-type", default="float32")
+    parser.add_argument("--mps-compute-type", default="float16")
+    parser.add_argument("--cpu-threads", type=int, default=4)
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=None,
+        help="Limit sentences for a smoke run; omit for publishable BLEU",
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    if (args.source is None) != (args.reference is None):
+        parser.error("--source and --reference must be specified together")
+    source_path, reference_path = (
+        (args.source, args.reference) if args.source is not None else get_wmt14_files()
+    )
+
+    sources = read_lines(source_path, args.max_samples)
+    references = read_lines(reference_path, args.max_samples)
+    if len(sources) != len(references):
+        raise RuntimeError("Source and reference files have different line counts")
+    if not sources:
+        raise RuntimeError("The selected translation dataset is empty")
+
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer)
+    source_tokens = [encode_source(tokenizer, source) for source in sources]
+    cpu = benchmark_device(args, "cpu", args.cpu_compute_type, source_tokens, tokenizer)
+    mps = benchmark_device(args, "mps", args.mps_compute_type, source_tokens, tokenizer)
+
+    bleu_metric = sacrebleu.metrics.BLEU(force=True)
+    cpu["bleu"] = bleu_metric.corpus_score(cpu["hypotheses"], [references]).score
+    mps["bleu"] = bleu_metric.corpus_score(mps["hypotheses"], [references]).score
+    agreement = sum(
+        cpu_hypothesis == mps_hypothesis
+        for cpu_hypothesis, mps_hypothesis in zip(cpu["hypotheses"], mps["hypotheses"])
+    )
+    summary = {
+        "benchmark": "WMT14 English-German BLEU",
+        "model": str(args.model),
+        "tokenizer": args.tokenizer,
+        "source": str(source_path),
+        "reference": str(reference_path),
+        "sentences": len(sources),
+        "max_samples": args.max_samples,
+        "beam_size": args.beam_size,
+        "length_penalty": args.length_penalty,
+        "batch_size": args.batch_size,
+        "ctranslate2_version": ctranslate2.__version__,
+        "sacrebleu_signature": str(bleu_metric.get_signature()),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "cpu": cpu,
+        "mps": mps,
+        "mps_inference_speedup": cpu["inference_seconds"] / mps["inference_seconds"],
+        "bleu_delta": mps["bleu"] - cpu["bleu"],
+        "exact_translation_agreement_percent": 100 * agreement / len(sources),
+    }
+
+    console_summary = json.loads(json.dumps(summary))
+    del console_summary["cpu"]["hypotheses"]
+    del console_summary["mps"]["hypotheses"]
+    print(json.dumps(console_summary, indent=2, sort_keys=True))
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmark/quality/whisper_wer.py
+++ b/tools/benchmark/quality/whisper_wer.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Compare Whisper quality and speed on CPU and MPS.
+
+This follows faster-whisper's WER benchmark setup: LibriSpeech clean
+validation, English text normalization, and corpus WER. Model loading and one
+warm-up utterance are reported separately from measured inference.
+"""
+
+import argparse
+import gc
+import hashlib
+import io
+import json
+import platform
+import time
+import urllib.request
+from pathlib import Path
+
+import ctranslate2
+from datasets import Audio, load_dataset
+from faster_whisper import WhisperModel, decode_audio
+from jiwer import wer
+from tqdm import tqdm
+from transformers.models.whisper.english_normalizer import EnglishTextNormalizer
+
+
+NORMALIZER_REVISION = "ed9a06cd89a93e47838f564998a6c09b655d7f43"
+NORMALIZER_SHA256 = "bf1c507dc8724ca9cf9903640dacfb69dae2f00edee4f21ceba106a7392f26dd"
+NORMALIZER_URL = (
+    "https://raw.githubusercontent.com/SYSTRAN/faster-whisper/"
+    f"{NORMALIZER_REVISION}/benchmark/normalizer.json"
+)
+
+
+def load_normalizer(path):
+    if path is None:
+        path = (
+            Path.home()
+            / ".cache"
+            / "ctranslate2"
+            / "benchmarks"
+            / f"faster-whisper-normalizer-{NORMALIZER_REVISION}.json"
+        )
+        if not path.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with urllib.request.urlopen(NORMALIZER_URL, timeout=60) as response:
+                data = response.read()
+            if hashlib.sha256(data).hexdigest() != NORMALIZER_SHA256:
+                raise RuntimeError("Downloaded normalizer has an unexpected checksum")
+            path.write_bytes(data)
+
+    data = path.read_bytes()
+    if hashlib.sha256(data).hexdigest() != NORMALIZER_SHA256:
+        raise RuntimeError(f"Normalizer checksum does not match: {path}")
+    return EnglishTextNormalizer(json.loads(data))
+
+
+def load_audio(sample):
+    encoded = sample["audio"]
+    if encoded.get("bytes") is not None:
+        source = io.BytesIO(encoded["bytes"])
+    elif encoded.get("path") is not None:
+        source = encoded["path"]
+    else:
+        raise RuntimeError("Dataset row contains neither audio bytes nor a path")
+    return decode_audio(source, sampling_rate=16000)
+
+
+def iter_dataset(args):
+    dataset = load_dataset(
+        args.dataset,
+        args.dataset_config,
+        split=args.split,
+        streaming=True,
+    )
+    # Let PyAV (already required by faster-whisper) decode the FLAC bytes. This
+    # avoids an additional TorchCodec dependency in recent datasets releases.
+    dataset = dataset.cast_column("audio", Audio(decode=False))
+    for index, sample in enumerate(dataset):
+        if args.max_samples is not None and index >= args.max_samples:
+            break
+        yield sample
+
+
+def transcribe(model, audio, beam_size):
+    segments, _ = model.transcribe(
+        audio,
+        language="en",
+        task="transcribe",
+        beam_size=beam_size,
+        temperature=0,
+        vad_filter=False,
+        word_timestamps=False,
+    )
+    return "".join(segment.text for segment in segments)
+
+
+def benchmark_device(args, device, compute_type, normalizer):
+    if device == "mps":
+        if not hasattr(ctranslate2, "get_mps_device_count"):
+            raise RuntimeError("CTranslate2 was not built with MPS support")
+        if ctranslate2.get_mps_device_count() < 1:
+            raise RuntimeError("No Apple MPS device is available")
+
+    load_start = time.perf_counter()
+    model = WhisperModel(
+        args.model,
+        device=device,
+        compute_type=compute_type,
+        cpu_threads=args.cpu_threads,
+    )
+    load_seconds = time.perf_counter() - load_start
+
+    warmup_sample = next(iter(iter_dataset(args)), None)
+    if warmup_sample is None:
+        raise RuntimeError("The selected dataset is empty")
+    transcribe(model, load_audio(warmup_sample), args.beam_size)
+
+    hypotheses = []
+    references = []
+    sample_ids = []
+    audio_seconds = 0.0
+    inference_seconds = 0.0
+    evaluation_start = time.perf_counter()
+    samples = tqdm(
+        iter_dataset(args),
+        total=args.max_samples,
+        desc=f"{device.upper()} WER",
+        unit="utterance",
+    )
+    for index, sample in enumerate(samples):
+        audio = load_audio(sample)
+        inference_start = time.perf_counter()
+        hypothesis = transcribe(model, audio, args.beam_size)
+        inference_seconds += time.perf_counter() - inference_start
+        hypotheses.append(normalizer(hypothesis))
+        references.append(normalizer(sample["text"]))
+        sample_ids.append(str(sample.get("id", index)))
+        audio_seconds += len(audio) / 16000
+    evaluation_wall_seconds = time.perf_counter() - evaluation_start
+
+    result = {
+        "device": device,
+        "compute_type": compute_type,
+        "model_load_seconds": load_seconds,
+        "inference_seconds": inference_seconds,
+        "evaluation_wall_seconds": evaluation_wall_seconds,
+        "audio_seconds": audio_seconds,
+        "real_time_factor": inference_seconds / audio_seconds,
+        "audio_speedup": audio_seconds / inference_seconds,
+        "samples": len(hypotheses),
+        "wer_percent": 100 * wer(reference=references, hypothesis=hypotheses),
+        "sample_ids": sample_ids,
+        "hypotheses": hypotheses,
+        "references": references,
+    }
+    del model
+    gc.collect()
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--model", default="Systran/faster-whisper-small.en")
+    parser.add_argument("--dataset", default="openslr/librispeech_asr")
+    parser.add_argument("--dataset-config", default="clean")
+    parser.add_argument("--split", default="validation")
+    parser.add_argument("--beam-size", type=int, default=5)
+    parser.add_argument("--cpu-compute-type", default="float32")
+    parser.add_argument("--mps-compute-type", default="float16")
+    parser.add_argument("--cpu-threads", type=int, default=4)
+    parser.add_argument(
+        "--normalizer-json",
+        type=Path,
+        help="Pinned faster-whisper normalizer; downloaded and verified by default",
+    )
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=None,
+        help="Limit rows for a smoke run; omit for publishable WER",
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    normalizer = load_normalizer(args.normalizer_json)
+    cpu = benchmark_device(args, "cpu", args.cpu_compute_type, normalizer)
+    mps = benchmark_device(args, "mps", args.mps_compute_type, normalizer)
+
+    if cpu["sample_ids"] != mps["sample_ids"]:
+        raise RuntimeError("CPU and MPS did not evaluate the same dataset rows")
+    if cpu["references"] != mps["references"]:
+        raise RuntimeError("CPU and MPS references differ")
+
+    agreement = sum(
+        cpu_hypothesis == mps_hypothesis
+        for cpu_hypothesis, mps_hypothesis in zip(cpu["hypotheses"], mps["hypotheses"])
+    )
+    summary = {
+        "benchmark": "Whisper LibriSpeech clean WER",
+        "model": args.model,
+        "dataset": args.dataset,
+        "dataset_config": args.dataset_config,
+        "split": args.split,
+        "beam_size": args.beam_size,
+        "normalizer_revision": NORMALIZER_REVISION,
+        "normalizer_sha256": NORMALIZER_SHA256,
+        "max_samples": args.max_samples,
+        "ctranslate2_version": ctranslate2.__version__,
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "cpu": cpu,
+        "mps": mps,
+        "mps_inference_speedup": cpu["inference_seconds"] / mps["inference_seconds"],
+        "wer_delta_points": mps["wer_percent"] - cpu["wer_percent"],
+        "exact_transcript_agreement_percent": 100 * agreement / cpu["samples"],
+    }
+
+    # The per-sample text is useful for investigating quality differences but
+    # makes console output unreadable, so it is only retained in the JSON file.
+    console_summary = json.loads(json.dumps(summary))
+    for device in ("cpu", "mps"):
+        del console_summary[device]["sample_ids"]
+        del console_summary[device]["hypotheses"]
+        del console_summary[device]["references"]
+    print(json.dumps(console_summary, indent=2, sort_keys=True))
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmark_mps_marian.py
+++ b/tools/benchmark_mps_marian.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Reproducible single-process Marian/M2M100 CTranslate2 benchmark.
+"""Reproducible single-process Marian CTranslate2 benchmark.
 
 Run CPU and MPS in separate invocations so model loading and allocator state do
 not influence the other device.  Kernel/profile output is written by the C++
@@ -13,7 +13,7 @@ import time
 from pathlib import Path
 
 import ctranslate2
-from transformers import M2M100Tokenizer
+from transformers import MarianTokenizer
 
 
 def percentile(values, fraction):
@@ -23,17 +23,23 @@ def percentile(values, fraction):
 
 
 def source_tokens(tokenizer, requested_length):
-    phrase = "Da yaw azmoina jumla da. Sta num sa de?"
-    ids = tokenizer(phrase, add_special_tokens=True)["input_ids"]
-    tokens = tokenizer.convert_ids_to_tokens(ids)
-    if len(tokens) >= requested_length:
-        return tokens[:requested_length]
+    phrase = (
+        "Paroon che za bazar ta talay wam, halta domra rush wo che pa motor ke "
+        "ma taqreeban yaw ghanta pa lar ke ter kro, kho bia hum zama tol zaroori "
+        "saman wakhisto."
+    )
+    tokens = tokenizer.convert_ids_to_tokens(
+        tokenizer.encode(phrase, add_special_tokens=True)
+    )
     content = [token for token in tokens if token not in tokenizer.all_special_tokens]
     if not content:
         raise RuntimeError("tokenizer produced no content tokens")
-    while len(tokens) < requested_length:
-        tokens.insert(-1 if tokens else 0, content[(len(tokens) - 1) % len(content)])
-    return tokens[:requested_length]
+    eos = tokenizer.eos_token
+    requested_content = max(0, requested_length - (1 if eos else 0))
+    generated = [content[index % len(content)] for index in range(requested_content)]
+    if eos:
+        generated.append(eos)
+    return generated
 
 
 def main():
@@ -43,20 +49,28 @@ def main():
     parser.add_argument("--device", choices=("cpu", "mps"), required=True)
     parser.add_argument("--compute-type", default=None)
     parser.add_argument("--beam-size", type=int, default=1)
-    parser.add_argument("--source-lengths", type=int, nargs="+", default=[8, 16, 32, 64, 128])
+    parser.add_argument(
+        "--source-lengths", type=int, nargs="+", default=[8, 16, 32, 64, 128]
+    )
     parser.add_argument("--warmups", type=int, default=5)
     parser.add_argument("--runs", type=int, default=30)
     parser.add_argument("--max-output-length", type=int, default=100)
-    parser.add_argument("--profile-only", action="store_true",
-                        help="run one warm inference for compact C++ profile capture")
+    parser.add_argument(
+        "--profile-only",
+        action="store_true",
+        help="run one warm inference for compact C++ profile capture",
+    )
     args = parser.parse_args()
 
-    compute_type = args.compute_type or ("float16" if args.device == "mps" else "default")
-    tokenizer = M2M100Tokenizer.from_pretrained(str(args.tokenizer), local_files_only=True)
-    tokenizer.src_lang = "ps"
-    target_prefix = [[tokenizer.convert_ids_to_tokens([tokenizer.get_lang_id("en")])[0]]]
+    compute_type = args.compute_type or (
+        "float16" if args.device == "mps" else "default"
+    )
+    tokenizer = MarianTokenizer.from_pretrained(
+        str(args.tokenizer), local_files_only=True
+    )
     translator = ctranslate2.Translator(
-        str(args.model), device=args.device, compute_type=compute_type)
+        str(args.model), device=args.device, compute_type=compute_type
+    )
 
     cases = []
     for length in args.source_lengths:
@@ -65,11 +79,11 @@ def main():
         def translate():
             return translator.translate_batch(
                 [tokens],
-                target_prefix=target_prefix,
                 beam_size=args.beam_size,
                 max_decoding_length=args.max_output_length,
                 length_penalty=1.0,
                 no_repeat_ngram_size=3,
+                return_scores=True,
             )[0]
 
         warmups = 1 if args.profile_only else args.warmups
@@ -79,34 +93,47 @@ def main():
 
         latencies = []
         output_lengths = []
+        hypotheses = []
         for _ in range(runs):
             start = time.perf_counter_ns()
             result = translate()
             elapsed = (time.perf_counter_ns() - start) / 1e6
             latencies.append(elapsed)
             output_lengths.append(len(result.hypotheses[0]))
+            hypotheses.append(list(result.hypotheses[0]))
 
         median_ms = statistics.median(latencies)
         mean_output = statistics.mean(output_lengths)
-        cases.append({
-            "source_length": length,
-            "output_tokens_mean": mean_output,
-            "latency_ms_median": median_ms,
-            "latency_ms_p90": percentile(latencies, 0.90),
-            "latency_ms_mean": statistics.mean(latencies),
-            "latency_ms_stdev": statistics.pstdev(latencies),
-            "output_tokens_per_second": mean_output / (median_ms / 1000.0),
-        })
+        cases.append(
+            {
+                "source_length": length,
+                "output_tokens_mean": mean_output,
+                "latency_ms_median": median_ms,
+                "latency_ms_p90": percentile(latencies, 0.90),
+                "latency_ms_mean": statistics.mean(latencies),
+                "latency_ms_stdev": statistics.pstdev(latencies),
+                "output_tokens_per_second": mean_output / (median_ms / 1000.0),
+                "outputs_consistent": len({tuple(output) for output in hypotheses})
+                == 1,
+                "hypothesis": hypotheses[0],
+            }
+        )
 
-    print(json.dumps({
-        "device": args.device,
-        "compute_type": compute_type,
-        "beam_size": args.beam_size,
-        "warmups": 1 if args.profile_only else args.warmups,
-        "runs": 1 if args.profile_only else args.runs,
-        "max_output_length": args.max_output_length,
-        "cases": cases,
-    }, indent=2, sort_keys=True))
+    print(
+        json.dumps(
+            {
+                "device": args.device,
+                "compute_type": compute_type,
+                "beam_size": args.beam_size,
+                "warmups": 1 if args.profile_only else args.warmups,
+                "runs": 1 if args.profile_only else args.runs,
+                "max_output_length": args.max_output_length,
+                "cases": cases,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/tools/benchmark_mps_marian.py
+++ b/tools/benchmark_mps_marian.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Reproducible single-process Marian/M2M100 CTranslate2 benchmark.
+
+Run CPU and MPS in separate invocations so model loading and allocator state do
+not influence the other device.  Kernel/profile output is written by the C++
+backend to stderr when CT2_MPS_PROFILE or CT2_MPS_LOG_GEMM is enabled.
+"""
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+
+import ctranslate2
+from transformers import M2M100Tokenizer
+
+
+def percentile(values, fraction):
+    ordered = sorted(values)
+    index = round((len(ordered) - 1) * fraction)
+    return ordered[index]
+
+
+def source_tokens(tokenizer, requested_length):
+    phrase = "Da yaw azmoina jumla da. Sta num sa de?"
+    ids = tokenizer(phrase, add_special_tokens=True)["input_ids"]
+    tokens = tokenizer.convert_ids_to_tokens(ids)
+    if len(tokens) >= requested_length:
+        return tokens[:requested_length]
+    content = [token for token in tokens if token not in tokenizer.all_special_tokens]
+    if not content:
+        raise RuntimeError("tokenizer produced no content tokens")
+    while len(tokens) < requested_length:
+        tokens.insert(-1 if tokens else 0, content[(len(tokens) - 1) % len(content)])
+    return tokens[:requested_length]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--tokenizer", type=Path, required=True)
+    parser.add_argument("--device", choices=("cpu", "mps"), required=True)
+    parser.add_argument("--compute-type", default=None)
+    parser.add_argument("--beam-size", type=int, default=1)
+    parser.add_argument("--source-lengths", type=int, nargs="+", default=[8, 16, 32, 64, 128])
+    parser.add_argument("--warmups", type=int, default=5)
+    parser.add_argument("--runs", type=int, default=30)
+    parser.add_argument("--max-output-length", type=int, default=100)
+    parser.add_argument("--profile-only", action="store_true",
+                        help="run one warm inference for compact C++ profile capture")
+    args = parser.parse_args()
+
+    compute_type = args.compute_type or ("float16" if args.device == "mps" else "default")
+    tokenizer = M2M100Tokenizer.from_pretrained(str(args.tokenizer), local_files_only=True)
+    tokenizer.src_lang = "ps"
+    target_prefix = [[tokenizer.convert_ids_to_tokens([tokenizer.get_lang_id("en")])[0]]]
+    translator = ctranslate2.Translator(
+        str(args.model), device=args.device, compute_type=compute_type)
+
+    cases = []
+    for length in args.source_lengths:
+        tokens = source_tokens(tokenizer, length)
+
+        def translate():
+            return translator.translate_batch(
+                [tokens],
+                target_prefix=target_prefix,
+                beam_size=args.beam_size,
+                max_decoding_length=args.max_output_length,
+                length_penalty=1.0,
+                no_repeat_ngram_size=3,
+            )[0]
+
+        warmups = 1 if args.profile_only else args.warmups
+        runs = 1 if args.profile_only else args.runs
+        for _ in range(warmups):
+            translate()
+
+        latencies = []
+        output_lengths = []
+        for _ in range(runs):
+            start = time.perf_counter_ns()
+            result = translate()
+            elapsed = (time.perf_counter_ns() - start) / 1e6
+            latencies.append(elapsed)
+            output_lengths.append(len(result.hypotheses[0]))
+
+        median_ms = statistics.median(latencies)
+        mean_output = statistics.mean(output_lengths)
+        cases.append({
+            "source_length": length,
+            "output_tokens_mean": mean_output,
+            "latency_ms_median": median_ms,
+            "latency_ms_p90": percentile(latencies, 0.90),
+            "latency_ms_mean": statistics.mean(latencies),
+            "latency_ms_stdev": statistics.pstdev(latencies),
+            "output_tokens_per_second": mean_output / (median_ms / 1000.0),
+        })
+
+    print(json.dumps({
+        "device": args.device,
+        "compute_type": compute_type,
+        "beam_size": args.beam_size,
+        "warmups": 1 if args.profile_only else args.warmups,
+        "runs": 1 if args.profile_only else args.runs,
+        "max_output_length": args.max_output_length,
+        "cases": cases,
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds an experimental native Metal/MPS backend for CTranslate2 on Apple Silicon. It is opt-in with `-DWITH_MPS=ON` and makes the existing C++ and Python APIs accept `device="mps"` without changing the default CPU, CUDA, or HIP behavior.

I started this port about six months ago because CTranslate2 could use Apple CPUs efficiently but had no path to the Apple GPU. The first versions could run a few operations, but real Marian and Whisper inference exposed missing operators, excessive synchronization, lifetime bugs, and poor batch-size-1 performance. I used those end-to-end workloads—not only large synthetic GEMMs—to guide the implementation in this PR.

## What is included

- `Device::MPS` support in device parsing, dispatch, storage, synchronization, the CLI, and Python bindings
- `ctranslate2.get_mps_device_count()` and `get_supported_compute_types("mps")`
- Source builds on Apple Silicon with Metal, Metal Performance Shaders, and Foundation
- FP32, FP16, BF16, and signed INT8 execution; `compute_type="auto"` selects FP16
- A thread-local persistent Metal execution stream that batches commands, reuses compute/blit encoders, supports several command buffers in flight, and only waits at host-visible synchronization points
- Shared-memory Metal allocation with an ordered interior-pointer lookup and GPU-lifetime tracking for buffers and Objective-C objects
- Cached Metal pipelines, MPS matrix multiplication objects, TopK objects, and persistent output-major decode weights
- A specialized FP16 `M == 1` GEMV path for autoregressive projections, including a fused bias/residual/activation epilogue
- MPSMatrix and custom GEMM paths for prefill, transposed inputs, batched GEMM, broadcast strides, odd dimensions, and tails
- GPU argmax and small TopK (`k <= 8`), with MPSMatrix TopK used for supported larger values
- Metal implementations for the common elementwise, reduction, normalization, rotary, copy/layout, gather, concat/split/tile, and Conv1D paths needed by Transformer, Marian, and Whisper inference
- BF16 storage with FP32 accumulation where required, plus INT8 quantize/GEMM/dequantize support
- Optional MPS profiling, GEMM-path logging, synchronization logging, and command-buffer tuning environment variables
- MPS correctness tests and standalone primitive/Marian benchmark tools

The dispatch changes also preserve non-MPS builds. In particular, FP16/BF16 dispatch is restricted to enabled GPU backends so MSVC does not instantiate unsupported CPU half-precision symbols in CUDA wheel builds.

## Build and use

```bash
cmake -S . -B build-mps \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
  -DWITH_MPS=ON \
  -DWITH_ACCELERATE=ON \
  -DWITH_MKL=OFF \
  -DWITH_RUY=ON \
  -DOPENMP_RUNTIME=NONE
cmake --build build-mps -j
```

```python
import ctranslate2

translator = ctranslate2.Translator(
    "model",
    device="mps",
    compute_type="float16",
)
```

The minimum deployment target is macOS 11. MPS is not enabled in prebuilt wheels by this PR and currently has to be built from source.

## Correctness and CI validation

Local validation and the reportable benchmarks were run on a MacBook Air with an Apple M1 (7-core GPU, 8 GB unified memory), arm64, macOS 26.5.2, using Release builds.

The CI configuration includes a dedicated real Apple Silicon MPS GPU job. It builds with `-DWITH_MPS=ON`, runs the MPS runtime suite, and then runs the normal CPU/shared suite from the same MPS-enabled build. It also builds the Python bindings, tests explicit `device="mps"` inference, and verifies that `device="auto"` remains on CPU so the experimental backend is opt-in.

The equivalent workflow passed on the self-hosted Apple M1 runner: 192 MPS C++ tests passed, 198 CPU/shared C++ tests passed with one existing CPU-only skip, and both Python MPS integration tests passed.

https://github.com/TBO22/CTranslate2/actions/runs/32951573494/job/98123905546

The upstream `macos-15-xlarge` job could not be scheduled because larger-runner billing is not enabled for the repository. No test process started in that failed job; this was a runner availability/billing issue rather than a test failure. The upstream workflow retains `macos-15-xlarge`, so the merged CI configuration does not depend on contributor-owned hardware.

MPS coverage includes FP32/FP16/BF16, INT8, odd sizes, tails, broadcast and nonzero batch strides, transposed GEMM, alpha/beta, interior offsets, dependent asynchronous dispatches, TopK tie behavior, Gather, Conv1D, and translation output comparison. `git diff --check` also passes.

## Quality Validation

The reproducible evaluation scripts and methodology are under `tools/benchmark/quality/`. CPU used FP32 and MPS used FP16 with the same models, inputs, sample order, and decoding settings. Model loading and one warm-up inference were excluded from inference timing.

| Benchmark | CPU quality | MPS quality | Output agreement | MPS speedup |
| --- | ---: | ---: | ---: | ---: |
| LibriSpeech clean, 2,703 utterances, beam 5 | 2.9125% WER | 2.9089% WER | 99.63% normalized transcript agreement | 1.93× |
| WMT14 En→De, 2,737 sentences, beam 4, batch 4 | 27.9152 BLEU | 27.9332 BLEU | 96.60% exact translation agreement | 2.13× |

## Performance

Performance varies by model and sequence length, so this is not intended as a universal claim. One representative end-to-end result from the M1 test machine was a 12.52-second, batch-size-1 Whisper transcription/translation workload:

| Backend | Compute type | Latency | Output |
| --- | --- | ---: | --- |
| CPU | FP32 | 54.950 s | reference |
| MPS | FP16 | 15.531 s | exact text match |

This is a **3.54x** end-to-end speedup for that workload. The PR also includes `tools/benchmark_mps_marian.py`, which runs CPU and MPS in separate processes with warmups and repeated measurements across source lengths and beam sizes, and `tests/benchmark_mps.cc` for decode GEMM, vocabulary projection, prefill GEMM, TopK, and copy-heavy operations.

## Current limitations

- Apple Silicon and source builds only; no MPS-enabled release wheel in this PR
- `WITH_MPS` cannot currently be combined with CUDA or HIP in one build
- FlashAttention, AWQ INT4, INT16 GEMM, distributed collectives, and packed/shifted-u8 INT8 GEMM are not implemented on MPS
- Metal kernels are currently compiled from source once and cached at runtime; a precompiled metallib can be added separately
- INT8 is supported for compatibility and reduced weight memory, but FP16 is normally faster for batch-size-1 decoding and remains the automatic default

## AI-assisted development disclosure

I used Codex with GPT-5.6 as a pair-programming tool for repository navigation, repetitive implementation work, test scaffolding, diff review, and tracing build and lifetime failures. I did not treat generated suggestions as authoritative. I researched the execution model and kernel design myself, including how Apple MLX kernels differ from ggml/PyTorch and CUDA implementations and how Apple unified memory affects synchronization and ownership. I selected the design, ran the benchmarks, reproduced correctness failures, reviewed the changes, and remain responsible for the implementation and results in this PR.

I understand that this is a large, performance-sensitive change and am happy to respond to detailed review or split follow-up work where maintainers prefer a different boundary.
