### PR TITLE
Make flash_attention effective for the Whisper encoder

### DIFF
--- a/src/layers/flash_attention.cc
+++ b/src/layers/flash_attention.cc
@@ -110,7 +110,9 @@ namespace ctranslate2 {
 
       // init output
       StorageView context(dtype, device);
-      ops::FlashAttention fl_attn_ops(_queries_scale, _sliding_window);
+      // Causal masking only applies to decoder self-attention; encoder
+      // self-attention must attend bidirectionally.
+      ops::FlashAttention fl_attn_ops(_queries_scale, _sliding_window, /*is_causal=*/_is_decoder);
       fl_attn_ops(queries_proj, keys_proj, values_proj, context, cached_keys, cached_values, attention,
                   return_normalized_attention, rotary_cos, rotary_sin, rotary_interleaved, nullptr/*alibli*/, offset);
 

--- a/src/layers/whisper.cc
+++ b/src/layers/whisper.cc
@@ -17,7 +17,8 @@ namespace ctranslate2 {
                                                                  scope + "/layer",
                                                                  _num_heads,
                                                                  /*pre_norm=*/true,
-                                                                 ops::ActivationType::GELU))
+                                                                 ops::ActivationType::GELU,
+                                                                 model.use_flash_attention()))
       , _output_norm(model, scope + "/layer_norm")
     {
     }


### PR DESCRIPTION
## Problem

Setting `flash_attention=true` on a Whisper model has no effect today, for two independent reasons:

1. `WhisperEncoderLayer` constructs its `TransformerEncoderLayer` without forwarding `model.use_flash_attention()`, so the parameter always falls back to its default (`false`) and the encoder never takes the flash path (`src/layers/whisper.cc`).
2. `FlashMultiHeadAttention` constructs `ops::FlashAttention` without `is_causal`, which defaults to `true` (`src/layers/flash_attention.cc`). That is correct for decoder self-attention — currently the only in-tree user of the flash path — but wrong for any encoder, which must attend bidirectionally. This latent bug blocks enabling flash attention for every encoder, not just Whisper's.

## Fix

- Pass `is_causal = _is_decoder` when constructing `ops::FlashAttention`. Behavior-neutral for decoders; makes the flash path correct for encoder self-attention.
- Forward `model.use_flash_attention()` from `WhisperEncoderLayer` to its `TransformerEncoderLayer`.

The scope is deliberately limited to Whisper: `TransformerEncoder` (the generic one) also reads `model.use_flash_attention()` without forwarding it to its layers, but I only validated the Whisper encoder numerically, so I left the generic path unchanged. With the `is_causal` fix in place, wiring it up becomes a safe follow-up.

This does not touch wheel packaging — it only affects source builds with `-DWITH_FLASH_ATTN=ON`.

## Validation

Measured with a `WITH_FLASH_ATTN=ON` source build (based on a93c2bf) on one NVIDIA RTX PRO 6000 (Blackwell), Whisper large-v3-turbo, `float16`:

- Encoder forward pass: 358 ms → 116 ms (3.1×)
- Cosine similarity of encoder output vs. the non-flash encoder: 0.999667
- Pairwise WER on our internal test set: −0.026

Happy to share the comparison script if useful.
