### PR TITLE
Check for overflow in StorageView::reserve byte size

### DIFF
--- a/src/storage_view.cc
+++ b/src/storage_view.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/storage_view.h"
 
+#include <limits>
+
 #include "ctranslate2/primitives.h"
 
 #include "dispatch.h"
@@ -163,7 +165,10 @@ namespace ctranslate2 {
       return *this;
     release();
     _allocator = &get_allocator(_device);
-    _data = _allocator->allocate(size * item_size(), _device_index);
+    const dim_t is = item_size();
+    if (size < 0 || is <= 0 || size > std::numeric_limits<dim_t>::max() / is)
+      THROW_RUNTIME_ERROR("tensor byte size overflows dim_t");
+    _data = _allocator->allocate(static_cast<size_t>(size * is), _device_index);
     if (_data == nullptr)
       THROW_RUNTIME_ERROR("failed to allocated memory");
     _allocated_size = size;

--- a/tests/storage_view_test.cc
+++ b/tests/storage_view_test.cc
@@ -1,3 +1,5 @@
+#include <limits>
+
 #include "test_utils.h"
 #include "ctranslate2/storage_view.h"
 
@@ -25,6 +27,16 @@ TEST(StorageViewTest, InvalidNegativeDim) {
 TEST(StorageViewTest, InvalidNegativeIndex) {
   StorageView storage({1}, std::vector<float>{0});
   EXPECT_THROW(storage.at<float>(-1), std::invalid_argument);
+}
+
+TEST(StorageViewTest, ReserveByteSizeOverflow) {
+  StorageView sv(DataType::FLOAT32);
+  EXPECT_THROW(sv.reserve(std::numeric_limits<dim_t>::max()), std::runtime_error);
+}
+
+TEST(StorageViewTest, ReserveNegativeSize) {
+  StorageView sv(DataType::FLOAT32);
+  EXPECT_THROW(sv.reserve(-1), std::runtime_error);
 }
 
 TEST(StorageViewTest, BoolOperator) {


### PR DESCRIPTION
Reject negative sizes and detect dim_t overflow when computing the allocation byte count in StorageView::reserve, preventing a malformed model from producing an undersized buffer. Adds regression tests.

Reported by Jitendra Prajapati (Infinityscroll).