### PR TITLE
Check for overflow in StorageView::reserve before allocation

### DIFF
--- a/src/storage_view.cc
+++ b/src/storage_view.cc
@@ -1,5 +1,7 @@
 #include "ctranslate2/storage_view.h"
 
+#include <limits>
+
 #include "ctranslate2/primitives.h"
 
 #include "dispatch.h"
@@ -159,11 +161,16 @@ namespace ctranslate2 {
   }
 
   StorageView& StorageView::reserve(dim_t size) {
+    if (size < 0)
+      THROW_RUNTIME_ERROR("tensor size must be non-negative");
     if (size <= _allocated_size)
       return *this;
+    const dim_t is = item_size();
+    if (is <= 0 || size > std::numeric_limits<dim_t>::max() / is)
+      THROW_RUNTIME_ERROR("tensor byte size overflows dim_t");
     release();
     _allocator = &get_allocator(_device);
-    _data = _allocator->allocate(size * item_size(), _device_index);
+    _data = _allocator->allocate(static_cast<size_t>(size * is), _device_index);
     if (_data == nullptr)
       THROW_RUNTIME_ERROR("failed to allocated memory");
     _allocated_size = size;

--- a/tests/storage_view_test.cc
+++ b/tests/storage_view_test.cc
@@ -1,3 +1,5 @@
+#include <limits>
+
 #include "test_utils.h"
 #include "ctranslate2/storage_view.h"
 
@@ -25,6 +27,61 @@ TEST(StorageViewTest, InvalidNegativeDim) {
 TEST(StorageViewTest, InvalidNegativeIndex) {
   StorageView storage({1}, std::vector<float>{0});
   EXPECT_THROW(storage.at<float>(-1), std::invalid_argument);
+}
+
+TEST(StorageViewTest, ReserveByteSizeOverflow) {
+  for (const DataType dtype : {DataType::FLOAT16, DataType::FLOAT32}) {
+    StorageView sv(dtype);
+    const dim_t max_elements = std::numeric_limits<dim_t>::max() / sv.item_size();
+    for (const dim_t size : {max_elements + 1, std::numeric_limits<dim_t>::max()}) {
+      try {
+        sv.reserve(size);
+        FAIL() << "Expected byte-size overflow rejection";
+      } catch (const std::runtime_error& e) {
+        EXPECT_NE(std::string(e.what()).find("tensor byte size overflows dim_t"),
+                  std::string::npos);
+      }
+    }
+  }
+}
+
+TEST(StorageViewTest, ReserveNegativeSize) {
+  StorageView sv(DataType::FLOAT32);
+  EXPECT_THROW(sv.reserve(-1), std::runtime_error);
+  EXPECT_THROW(sv.reserve(std::numeric_limits<dim_t>::min()), std::runtime_error);
+}
+
+TEST(StorageViewTest, InvalidReservePreservesStorage) {
+  StorageView sv({2}, std::vector<float>{1, 2});
+  const auto* data = sv.data<float>();
+  const auto reserved_memory = sv.reserved_memory();
+  EXPECT_THROW(sv.reserve(-1), std::runtime_error);
+  EXPECT_THROW(sv.reserve(std::numeric_limits<dim_t>::max()), std::runtime_error);
+  EXPECT_EQ(sv.data<float>(), data);
+  EXPECT_EQ(sv.reserved_memory(), reserved_memory);
+  EXPECT_TRUE(sv.owns_data());
+  EXPECT_EQ(sv.size(), 2);
+  ASSERT_EQ(sv.shape(), Shape({2}));
+  EXPECT_EQ(sv.at<float>(0), 1);
+  EXPECT_EQ(sv.at<float>(1), 2);
+}
+
+TEST(StorageViewTest, ReserveWithinCapacity) {
+  StorageView empty(DataType::FLOAT32);
+  EXPECT_NO_THROW(empty.reserve(0));
+  EXPECT_EQ(empty.reserved_memory(), 0);
+
+  StorageView sv({2}, std::vector<float>{1, 2});
+  const auto* data = sv.data<float>();
+  const auto reserved_memory = sv.reserved_memory();
+  EXPECT_NO_THROW(sv.reserve(0));
+  EXPECT_NO_THROW(sv.reserve(1));
+  EXPECT_NO_THROW(sv.reserve(2));
+  EXPECT_EQ(sv.data<float>(), data);
+  EXPECT_EQ(sv.reserved_memory(), reserved_memory);
+  ASSERT_EQ(sv.shape(), Shape({2}));
+  EXPECT_EQ(sv.at<float>(0), 1);
+  EXPECT_EQ(sv.at<float>(1), 2);
 }
 
 TEST(StorageViewTest, BoolOperator) {


### PR DESCRIPTION
## Summary

- Reject negative `reserve` requests before the existing capacity fast path.
- Check the element-count-to-byte-count multiplication before allocation, using division to avoid signed overflow.
- Validate before releasing the current buffer, so a rejected request preserves its contents and shape.
- Exercise FLOAT16/FLOAT32 byte-count boundaries, negative sizes, preservation after rejection, and zero/smaller/equal-capacity no-ops.


## Validation

Built and tested on macOS arm64, AppleClang 21, Debug, Ruy backend, two build jobs:

```sh
cmake -S . -B build -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
  -DCMAKE_BUILD_TYPE=Debug -DWITH_MKL=OFF -DWITH_ACCELERATE=OFF \
  -DWITH_RUY=ON -DOPENMP_RUNTIME=NONE -DBUILD_TESTS=ON \
  -DBUILD_CLI=OFF -DBUILD_SHARED_LIBS=ON
cmake --build build --target ctranslate2_test --parallel 2
build/tests/ctranslate2_test tests/data \
  '--gtest_filter=StorageViewTest.*:CPU/StorageViewDeviceTest.*'
build/tests/ctranslate2_test tests/data --gtest_brief=1
```

- Targeted storage tests: **11/11 passed**.
- Before the follow-up correction, the same tests against the original #2092 implementation reproduced the negative-size and buffer-preservation failures (9 passed, 2 failed).
- Full local suite: **192 passed, 1 skipped, 3 failed** (196 total). The failures are `CPU/OpDeviceFPTest.Gemm/float32`, `GemmBias/float32`, and `GemmResidual/float32`. The same three numerical failures were present in the #2092 baseline before the follow-up correction.
- `git diff --check` passes. Linux/MKL, CUDA, and Windows have not been tested locally; upstream CI is still needed.

## AI assistance disclosure

OpenAI Codex assisted with preparing the follow-up correction and regression tests.
