### PR TITLE
remove runtime dependency on setuptools

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -103,7 +103,6 @@ setup(
     ext_modules=[ctranslate2_module],
     python_requires=">=3.9",
     install_requires=[
-        "setuptools",
         "numpy",
         "pyyaml>=5.3,<7",
     ],


### PR DESCRIPTION
I skimmed the repo and could not find setuptools actually being used at *runtime* yet users get setuptools when they install `ctranslate2`. Note that you don't need a runtime dependency on setuptools to build a package with setuptools, `pyproject.toml` already includes setuptools as a *build* time dependency

```console
❯ "ctranslate2" | uv pip compile -
Resolved 4 packages in 5ms
# This file was autogenerated by uv via the following command:
#    uv pip compile -
ctranslate2==4.8.1
numpy==2.5.2
    # via ctranslate2
pyyaml==6.0.3
    # via ctranslate2
setuptools==84.0.0
    # via ctranslate2
```